### PR TITLE
Bump Catch2 version to 3.3.2 to fix GCC 13 build

### DIFF
--- a/src/cmake/Catch2.cmake
+++ b/src/cmake/Catch2.cmake
@@ -8,7 +8,7 @@ include(FetchContent)
 FetchContent_Declare(
   catch2
   GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
-  GIT_TAG        "v3.1.0"
+  GIT_TAG        "v3.3.2"
 )
 
 FetchContent_MakeAvailable(catch2)


### PR DESCRIPTION
Necessary for the UDF docker image.