### PR TITLE
Support setting cmake options in python via env

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -2,6 +2,42 @@ from skbuild import setup  # This line replaces 'from setuptools import setup'
 
 import os
 
+def get_cmake_overrides():
+    import sys
+
+    conf = list()
+
+    key = "CMAKE_OSX_DEPLOYMENT_TARGET"
+    val = os.environ.get(key, default=None)
+    if val:
+        conf.append("-DCMAKE_OSX_DEPLOYMENT_TARGET={}".format(val))
+
+    key = "DOWNLOAD_TILEDB_PREBUILT"
+    val = os.environ.get(key, default=None)
+    if val:
+        conf.append("-DDOWNLOAD_TILEDB_PREBUILT={}".format(val))
+
+    key = "CMAKE_BUILD_TYPE"
+    val = os.environ.get(key, default=None)
+    if val:
+        conf.append("-DCMAKE_BUILD_TYPE={}".format(val))
+
+    key = "BUILD_TESTS"
+    val = os.environ.get(key, default=None)
+    if val:
+        conf.append("-DBUILD_TESTS={}".format(val))
+
+    key = "USE_MKL_CBLAS"
+    val = os.environ.get(key, default=None)
+    if val:
+        conf.append("-DUSE_MKL_CBLAS={}".format(val))
+
+    return conf
+
+cmake_args = ["-DTILEDB_VS_PYTHON=ON"]
+
+cmake_args += get_cmake_overrides()
+
 setup(
     name="tiledb-vector-search",
     description="Vector Search with TileDB",
@@ -10,7 +46,7 @@ setup(
     packages=["tiledb.vector_search"],
     package_dir={"": "src"},
     cmake_source_dir="../../src",
-    cmake_args=["-DTILEDB_VS_PYTHON=ON"],
+    cmake_args=cmake_args,
     cmake_install_target="install-libtiledbvectorsearch",
     cmake_install_dir="src/tiledb/vector_search",
 )


### PR DESCRIPTION
This adds support for the python setup.py to check and recognize environmental variables to toggle certain cmake options for the C++ library build.