### PR TITLE
Fix a number of warnings

### DIFF
--- a/src/include/defs.h
+++ b/src/include/defs.h
@@ -289,7 +289,7 @@ bool validate_top_k(TK& top_k, G& g) {
         return false;
       }
       std::cout << "Query " << qno << " is incorrect" << std::endl;
-      for (int i = 0; i < std::min(k, 10UL); ++i) {
+      for (size_t i = 0; i < std::min(k, 10UL); ++i) {
         std::cout << "  (" << top_k(i, qno) << " " << g(i, qno) << ")";
       }
       std::cout << std::endl;

--- a/src/include/detail/flat/qv.h
+++ b/src/include/detail/flat/qv.h
@@ -76,7 +76,7 @@ auto qv_query_nth(
         // @todo can we do this more efficiently?
         std::vector<float> scores(size_db);
 
-        for (int i = 0; i < size_db; ++i) {
+        for (size_t i = 0; i < size_db; ++i) {
           scores[i] = L2(q_vec, db[i]);
         }
         if (nth) {
@@ -129,7 +129,7 @@ auto qv_query_heap(const DB& db, const Q& q, size_t k, unsigned nthreads) {
               fixed_min_set<element> min_scores(k);
               size_t idx = 0;
 
-              for (int i = 0; i < size_db; ++i) {
+              for (size_t i = 0; i < size_db; ++i) {
                 auto score = L2(q[j], db[i]);
                 min_scores.insert(element{score, i});
               }
@@ -146,7 +146,7 @@ auto qv_query_heap(const DB& db, const Q& q, size_t k, unsigned nthreads) {
     }
   }
 
-  for (int n = 0; n < size(futs); ++n) {
+  for (size_t n = 0; n < size(futs); ++n) {
     futs[n].get();
   }
 

--- a/src/include/detail/flat/vq.h
+++ b/src/include/detail/flat/vq.h
@@ -73,7 +73,7 @@ auto vq_query_nth(const DB& db, const Q& q, int k, bool nth, int nthreads) {
           // For each database vector
           for (int i = db_start; i < db_stop; ++i) {
             // Compare with each query
-            for (int j = 0; j < size_q; ++j) {
+            for (size_t j = 0; j < size_q; ++j) {
               // scores[j][i] = L2(q[j], db[i]);
               scores(i, j) = L2(q[j], db[i]);
             }
@@ -126,19 +126,19 @@ auto vq_query_heap(DB& db, Q& q, int k, unsigned nthreads) {
         db,
         [&, size_q](auto&& db_vec, auto&& n = 0, auto&& i = 0) {
           if (block_db) {
-            for (int j = 0; j < size_q; ++j) {
+            for (size_t j = 0; j < size_q; ++j) {
               auto score = L2(q[j], db_vec);
               scores[n][j].insert(element{score, i + db.offset()});
             }
 
           } else if (block_q) {
-            for (int j = 0; j < size_q; ++j) {
+            for (size_t j = 0; j < size_q; ++j) {
               auto score = L2(q[j], db_vec);
               scores[n][j + q.offset()].insert(element{score, i});
             }
 
           } else {
-            for (int j = 0; j < size_q; ++j) {
+            for (size_t j = 0; j < size_q; ++j) {
               auto score = L2(q[j], db_vec);
               scores[n][j].insert(element{score, i});
             }
@@ -156,8 +156,8 @@ auto vq_query_heap(DB& db, Q& q, int k, unsigned nthreads) {
     }
   }
 
-  for (int j = 0; j < size(q); ++j) {
-    for (int n = 1; n < nthreads; ++n) {
+  for (size_t j = 0; j < size(q); ++j) {
+    for (unsigned n = 1; n < nthreads; ++n) {
       for (auto&& e : scores[n][j]) {
         scores[0][j].insert(e);
       }

--- a/src/include/test/unit_algorithm.cc
+++ b/src/include/test/unit_algorithm.cc
@@ -78,7 +78,7 @@ TEST_CASE("algorithm: for_each", "[algorithm]") {
   }
 
   SECTION("indexed parallel") {
-    auto nthreads = GENERATE(1, 2, 3, 4, 5, 5, 6, 7, 8, 9, 10, 63);
+    size_t nthreads = GENERATE(1, 2, 3, 4, 5, 5, 6, 7, 8, 9, 10, 63);
     std::vector<unsigned> indices(nthreads);
 
     stdx::for_each(

--- a/src/src/flat.cc
+++ b/src/src/flat.cc
@@ -209,6 +209,7 @@ int main(int argc, char* argv[]) {
         return detail::flat::gemm_query(db, q, k, nth, nthreads);
       }
     }*/
+    throw std::runtime_error("incorrect or unset order type: " + args["--order"].asString());
   }();
 
   if (!g_uri.empty() && validate) {


### PR DESCRIPTION
This will enable us to enable warnings as errors and have a cleaner build. Most warnings were about int vs size_t comparisons. Tested to compile without warnings on gcc 11.3