### PR TITLE
Remove unused global variable global_region

### DIFF
--- a/apis/python/src/tiledb/vector_search/module.cc
+++ b/apis/python/src/tiledb/vector_search/module.cc
@@ -13,8 +13,6 @@ using Ctx = tiledb::Context;
 
 bool global_debug = true;
 double global_time_of_interest;
-//std::string global_region = "us-east-1";
-std::string global_region = "us-west-2";
 
 namespace {
 

--- a/src/include/linalg.h
+++ b/src/include/linalg.h
@@ -64,7 +64,6 @@ using namespace Kokkos::Experimental;
 
 extern bool global_verbose;
 extern bool global_debug;
-extern std::string global_region;
 
 template <class T>
 std::vector<T> read_vector(const tiledb::Context&, const std::string&);

--- a/src/include/tdb_partitioned_matrix.h
+++ b/src/include/tdb_partitioned_matrix.h
@@ -26,7 +26,6 @@ using namespace Kokkos::Experimental;
 
 extern bool global_verbose;
 extern bool global_debug;
-extern std::string global_region;
 
 template <class T, class LayoutPolicy = stdx::layout_right, class I = size_t>
 class tdbPartitionedMatrix : public Matrix<T, LayoutPolicy, I> {
@@ -56,7 +55,6 @@ class tdbPartitionedMatrix : public Matrix<T, LayoutPolicy, I> {
 
   // @todo: Make this configurable
   std::map<std::string, std::string> init_{};
-  // {"vfs.s3.region", global_region.c_str()}};
   tiledb::Config config_{init_};
   tiledb::Context ctx_{config_};
 

--- a/src/include/test/gen_partitioned.cc
+++ b/src/include/test/gen_partitioned.cc
@@ -37,7 +37,6 @@
 #include "linalg.h"
 
 bool global_debug = false;
-std::string global_region = "us-east-1";
 
 using namespace detail::flat;
 

--- a/src/include/test/gen_queries.cc
+++ b/src/include/test/gen_queries.cc
@@ -38,7 +38,6 @@
 #include "linalg.h"
 
 bool global_debug = false;
-std::string global_region = "us-east-1";
 
 TEST_CASE("gen db", "[queries]") {
   size_t dimension = 128;

--- a/src/include/test/time_l2.cc
+++ b/src/include/test/time_l2.cc
@@ -194,7 +194,6 @@ float l22_just_swap(const V& u, const U& v) {
 }
 
 bool global_debug = false;
-std::string global_region = "us-east-1";
 
 TEST_CASE("time queries", "[queries]") {
   size_t dimension = 128;

--- a/src/include/test/time_queries.cc
+++ b/src/include/test/time_queries.cc
@@ -44,7 +44,6 @@
 #include "linalg.h"
 
 bool global_debug = false;
-std::string global_region = "us-east-1";
 
 using namespace detail::flat;
 

--- a/src/include/test/unit_linalg.cc
+++ b/src/include/test/unit_linalg.cc
@@ -37,7 +37,6 @@
 #include "../linalg.h"
 
 bool global_debug = false;
-std::string global_region = "us-east-1";
 
 using TestTypes = std::tuple<float, double, int, char, size_t, uint32_t>;
 

--- a/src/include/test/unit_partitioned.cc
+++ b/src/include/test/unit_partitioned.cc
@@ -37,7 +37,6 @@
 #include "partitioned.h"
 
 bool global_debug = false;
-std::string global_region = "us-east-1";
 
 TEST_CASE("partitioned: test test", "[partitioned]") {
   REQUIRE(true);

--- a/src/src/flat.cc
+++ b/src/src/flat.cc
@@ -93,7 +93,6 @@
 bool verbose = false;
 bool debug = false;
 bool global_debug = false;
-std::string global_region{"us-east-1"};
 
 static constexpr const char USAGE[] =
     R"(flat: feature vector search with flat index.

--- a/src/src/index.cc
+++ b/src/src/index.cc
@@ -46,7 +46,6 @@
 
 bool global_verbose = false;
 bool global_debug = false;
-std::string global_region;
 
 using namespace detail::flat;
 

--- a/src/src/ingest.cc
+++ b/src/src/ingest.cc
@@ -5,7 +5,6 @@
 #include "linalg.h"
 
 bool global_debug{false};
-std::string global_region;
 
 static constexpr const char USAGE[] =
     R"(ingest: create TileDB array from input data


### PR DESCRIPTION
Minor cleanup by removing an unused and unneeded global.