### PR TITLE
Fix non-void return path warning

### DIFF
--- a/src/src/ivf_flat.cc
+++ b/src/src/ivf_flat.cc
@@ -288,6 +288,7 @@ int main(int argc, char* argv[]) {
           nthreads,
           num_nodes);
     }
+    throw std::runtime_error("incorrect or unset algorithm type: " + algorithm);
   }();
 
   debug_matrix(top_k, "top_k");


### PR DESCRIPTION
Eliminate warning by adding `throw` if method not found in if-else chain for algorithm choice.