### PR TITLE
Fix up small corner case bug

### DIFF
--- a/src/include/detail/ivf/qv.h
+++ b/src/include/detail/ivf/qv.h
@@ -980,7 +980,7 @@ auto nuv_query_heap_infinite_ram_reg_blocked(
                 /*
                  * Cleanup the last iteration(s) of k
                  */
-                for (size_t kp = kstop; kp < kstop; ++kp) {
+                for (size_t kp = kstop; kp < stop; ++kp) {
                   auto score_00 = L2(q_vec_0, shuffled_db[kp + 0]);
                   auto score_10 = L2(q_vec_1, shuffled_db[kp + 0]);
                   min_scores[n][j0].insert(score_00, shuffled_ids[kp + 0]);
@@ -1201,7 +1201,7 @@ auto nuv_query_heap_finite_ram_reg_blocked(
                   /*
                    * Cleanup the last iteration(s) of k
                    */
-                  for (size_t kp = kstop; kp < kstop; ++kp) {
+                  for (size_t kp = kstop; kp < stop; ++kp) {
                     auto score_00 = L2(q_vec_0, shuffled_db[kp + 0]);
                     auto score_10 = L2(q_vec_1, shuffled_db[kp + 0]);
                     min_scores[n][j0].insert(
@@ -1365,7 +1365,7 @@ auto apply_query(
       /*
        * Cleanup the last iteration(s) of k
        */
-      for (size_t kp = kstop; kp < kstop; ++kp) {
+      for (size_t kp = kstop; kp < stop; ++kp) {
         auto score_00 = L2(q_vec_0, shuffled_db[kp + 0]);
         auto score_10 = L2(q_vec_1, shuffled_db[kp + 0]);
         min_scores[j0].insert(score_00, ids[kp + 0]);


### PR DESCRIPTION
This is a very small fix for corner cases in the tiled `apply_query` functionality in ivf searches (one vector to be searched in a partition might be skipped).  It will not affect timing but may have a very small effect on accuracy.