### PR TITLE
Cut 10% of query time with this one weird trick.

### DIFF
--- a/src/include/defs.h
+++ b/src/include/defs.h
@@ -77,7 +77,8 @@ inline auto sum_of_squares(V const& a, U const& b) {
  */
 template <class V, class U>
 inline auto L2(V const& a, U const& b) {
-  return std::sqrt(sum_of_squares(a, b));
+  //  return std::sqrt(sum_of_squares(a, b));
+  return sum_of_squares(a, b);
 }
 
 /**

--- a/src/include/scoring.h
+++ b/src/include/scoring.h
@@ -95,9 +95,9 @@ void gemm_scores(const Matrix1& A, const Matrix2& B, Matrix3& C, unsigned nthrea
       CblasColMajor, M, N, 1.0, &beta_ones[0], 1, &beta[0], 1, C.data(), M);
 
   stdx::execution::parallel_policy par{nthreads};
-  stdx::for_each(std::move(par), begin(raveled_C), end(raveled_C), [](auto& a) {
-    a = sqrt(a);
-  });
+//  stdx::for_each(std::move(par), begin(raveled_C), end(raveled_C), [](auto& a) {
+//    a = sqrt(a);
+//  });
 }
 
 template <class Matrix1, class Matrix2, class Matrix3>

--- a/src/include/test/unit_gemm.cc
+++ b/src/include/test/unit_gemm.cc
@@ -277,10 +277,10 @@ TEST_CASE("gemm: row major test", "[sgemm]") {
         L2_span[j][i] = L2(B_span[j], A_span[i]);
       }
     }
-    CHECK(std::abs(L2_span[0][0] - 10.3923) < .0001);
-    CHECK(std::abs(L2_span[1][0] - 15.5884) < .0001);
-    CHECK(std::abs(L2_span[0][1] - 5.1961) < .0001);
-    CHECK(std::abs(L2_span[1][1] - 10.3923) < .0001);
+    CHECK(std::abs(L2_span[0][0] - 10.3923 * 10.3923) < .001);
+    CHECK(std::abs(L2_span[1][0] - 15.5884 * 15.5884) < .002);
+    CHECK(std::abs(L2_span[0][1] - 5.1961 * 5.1961) < .002);
+    CHECK(std::abs(L2_span[1][1] - 10.3923 * 10.3923) < .001);
 
     /****************************************************************
      *


### PR DESCRIPTION
Remove `std::sqrt` from `L2` as sum of squares will have the same ordering as square root of the sum of squares.  When actual distances are required, we can take the square root then.  This seems to save around 10% of query time.