### PR TITLE
Small fixes to reduce g++ warnings

### DIFF
--- a/src/include/detail/ivf/qv.h
+++ b/src/include/detail/ivf/qv.h
@@ -378,7 +378,7 @@ auto qv_query_heap_infinite_ram(
     scoped_timer ___{tdb_func__ + std::string{"_top_k"}};
 
     // @todo get_top_k_from_heap
-    for (int j = 0; j < size(q); ++j) {
+    for (size_t j = 0; j < size(q); ++j) {
       sort_heap(min_scores[j].begin(), min_scores[j].end());
       std::transform(
           min_scores[j].begin(),
@@ -858,15 +858,15 @@ auto qv_query_heap_finite_ram(
       }
     }
 
-    for (int n = 0; n < size(futs); ++n) {
+    for (size_t n = 0; n < size(futs); ++n) {
       futs[n].get();
     }
     _i.stop();
   }
 
   _i.start();
-  for (int j = 0; j < num_queries; ++j) {
-    for (int n = 1; n < nthreads; ++n) {
+  for (size_t j = 0; j < num_queries; ++j) {
+    for (size_t n = 1; n < nthreads; ++n) {
       for (auto&& e : min_scores[n][j]) {
         min_scores[0][j].insert(std::get<0>(e), std::get<1>(e));
       }
@@ -881,7 +881,7 @@ auto qv_query_heap_finite_ram(
   // get_top_k_from_heap(min_scores, top_k);
 
   // @todo get_top_k_from_heap
-  for (int j = 0; j < num_queries; ++j) {
+  for (size_t j = 0; j < num_queries; ++j) {
     sort_heap(min_scores[0][j].begin(), min_scores[0][j].end());
     std::transform(
         min_scores[0][j].begin(),

--- a/src/include/test/unit_algorithm.cc
+++ b/src/include/test/unit_algorithm.cc
@@ -37,7 +37,7 @@ TEST_CASE("algorithm: test test", "[algorithm]") {
 }
 
 TEST_CASE("algorithm: for_each", "[algorithm]") {
-  auto length = GENERATE(
+  size_t length = GENERATE(
       0,
       1,
       2,


### PR DESCRIPTION
This is a small PR that includes a few fixes to code that was generating g++ warnings (mostly having to do with comparing signed to unsigned).  There are still a couple of warnings -- one in Catch2 and one in the unit tests (having to do with tmpnam).