### PR TITLE
Add pyproject dependency on scikit-learn

### DIFF
--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "tiledb-cloud>=0.10.5",
     "tiledb>=0.15.2",
-    "typing-extensions" # for tiledb-cloud indirect, x-ref https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/428
+    "typing-extensions", # for tiledb-cloud indirect, x-ref https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/428
     "scikit-learn",
 ]
 

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -21,11 +21,12 @@ classifiers = [
 dependencies = [
     "tiledb-cloud>=0.10.5",
     "tiledb>=0.15.2",
-    "typing-extensions" # for tiledb-cloud indirect
+    "typing-extensions" # for tiledb-cloud indirect, x-ref https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/428
+    "scikit-learn",
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "scikit-learn", "tiledb-cloud"]
+test = ["pytest"]
 
 
 [project.urls]

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tiledb-vector-search"
-version = "0.0.7"
+version = "0.0.8"
 #dynamic = ["version"]
 description = "TileDB Vector Search Python client"
 license = { text = "MIT" }

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -14,7 +14,7 @@ def ingest(
     config=None,
     namespace: Optional[str] = None,
     size: int = -1,
-    partitions: int = -1,
+    partitions: int = 1,
     copy_centroids_uri: str = None,
     training_sample_size: int = -1,
     workers: int = -1,


### PR DESCRIPTION
It is a de-facto requirement due to use in ingestion. We might relax it to optional again if we have better import guards with a clear message.