### PR TITLE
Handle tiledb.Config in load_as_matrix

### DIFF
--- a/apis/python/src/tiledb/vector_search/module.py
+++ b/apis/python/src/tiledb/vector_search/module.py
@@ -21,6 +21,10 @@ def load_as_matrix(path: str, nqueries: int = 0, ctx: "Ctx" = None, config: Opti
     ctx: Ctx
         TileDB context
     """
+    # If the user passes a tiledb python Config object convert to a dictionary
+    if isinstance(config, tiledb.Config):
+        config = dict(config)
+
     if ctx is None:
         ctx = Ctx(config)
 


### PR DESCRIPTION
If the user passes a tiledb.Config to load_as_matrix convert to a dictionary.