### PR TITLE
Add storage format versions and store more metadata in group metadata

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -35,14 +35,15 @@ def get_cmake_overrides():
         conf.append("-DUSE_MKL_CBLAS={}".format(val))
 
     try:
-      # Make sure we use pybind11 from this python environment if available,
-      # required for windows wheels due to:
-      #   https://github.com/pybind/pybind11/issues/3445
-      import pybind11
-      pb11_path =  pybind11.get_cmake_dir()
-      conf.append(f"-Dpybind11_DIR={pb11_path}")
+        # Make sure we use pybind11 from this python environment if available,
+        # required for windows wheels due to:
+        #   https://github.com/pybind/pybind11/issues/3445
+        import pybind11
+
+        pb11_path = pybind11.get_cmake_dir()
+        conf.append(f"-Dpybind11_DIR={pb11_path}")
     except ImportError:
-      pass
+        pass
 
     return conf
 
@@ -62,5 +63,5 @@ setup(
     cmake_args=cmake_args,
     cmake_install_target="install-libtiledbvectorsearch",
     cmake_install_dir="src/tiledb/vector_search",
-    use_scm_version={"root": "../../", "relative_to":  __file__},
+    use_scm_version={"root": "../../", "relative_to": __file__},
 )

--- a/apis/python/src/tiledb/vector_search/__init__.py
+++ b/apis/python/src/tiledb/vector_search/__init__.py
@@ -1,6 +1,7 @@
 from . import utils
 from .index import FlatIndex, IVFFlatIndex
 from .ingestion import ingest
+from .storage_formats import storage_formats, STORAGE_VERSION
 from .module import load_as_array
 from .module import load_as_matrix
 from .module import (
@@ -34,5 +35,5 @@ __all__ = [
     "ivf_index_tdb",
     "array_to_matrix",
     "partition_ivf_index",
-    "utils"
+    "utils",
 ]

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -154,14 +154,14 @@ class IVFFlatIndex(Index):
 
         dtype = group.meta.get("dtype", None)
         if dtype is None:
-            schema = tiledb.ArraySchema.load(self.parts_db_uri)
+            schema = tiledb.ArraySchema.load(self.parts_db_uri, ctx=self.ctx)
             self.dtype = np.dtype(schema.attr("values").dtype)
         else:
             self.dtype = np.dtype(dtype)
 
         self.partitions = group.meta.get("partitions", -1)
         if self.partitions == -1:
-            schema = tiledb.ArraySchema.load(self.centroids_uri)
+            schema = tiledb.ArraySchema.load(self.centroids_uri, ctx=self.ctx)
             self.partitions = schema.domain.dim("cols").domain[1] + 1
 
     def query(

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -154,14 +154,14 @@ class IVFFlatIndex(Index):
 
         dtype = group.meta.get("dtype", None)
         if dtype is None:
-            schema = tiledb.ArraySchema.load(self.parts_db_uri, ctx=self.ctx)
+            schema = tiledb.ArraySchema.load(self.parts_db_uri, ctx=tiledb.Ctx(self.config))
             self.dtype = np.dtype(schema.attr("values").dtype)
         else:
             self.dtype = np.dtype(dtype)
 
         self.partitions = group.meta.get("partitions", -1)
         if self.partitions == -1:
-            schema = tiledb.ArraySchema.load(self.centroids_uri, ctx=self.ctx)
+            schema = tiledb.ArraySchema.load(self.centroids_uri, ctx=tiledb.Ctx(self.config))
             self.partitions = schema.domain.dim("cols").domain[1] + 1
 
     def query(

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -5,13 +5,9 @@ import logging
 
 import numpy as np
 from tiledb.vector_search.module import *
+from tiledb.vector_search.storage_formats import storage_formats
 from tiledb.cloud.dag import Mode
 from typing import Any, Mapping
-
-CENTROIDS_ARRAY_NAME = "centroids.tdb"
-INDEX_ARRAY_NAME = "index.tdb"
-IDS_ARRAY_NAME = "ids.tdb"
-PARTS_ARRAY_NAME = "parts.tdb"
 
 
 def submit_local(d, func, *args, **kwargs):
@@ -22,7 +18,7 @@ def submit_local(d, func, *args, **kwargs):
 
 
 class Index:
-    def query(self, targets: np.ndarray, k=10, nqueries=10, nthreads=8, nprobe=1):
+    def query(self, targets: np.ndarray, k):
         raise NotImplementedError
 
 
@@ -36,15 +32,11 @@ class FlatIndex(Index):
         URI of datataset
     dtype: numpy.dtype
         datatype float32 or uint8
-    parts_name: str
-        Optional name of partitions
     """
 
     def __init__(
         self,
         uri: str,
-        dtype: Optional[np.dtype] = None,
-        parts_name: str = "parts.tdb",
         config: Optional[Mapping[str, Any]] = None,
     ):
         # If the user passes a tiledb python Config object convert to a dictionary
@@ -52,24 +44,28 @@ class FlatIndex(Index):
             config = dict(config)
 
         self.uri = uri
-        self.dtype = dtype
         self._index = None
         self.ctx = Ctx(config)
         self.config = config
+        group = tiledb.Group(uri, ctx=tiledb.Ctx(config))
+        self.storage_version = group.meta.get("storage_version", "0.1")
+        self._db = load_as_matrix(
+            group[storage_formats[self.storage_version]["PARTS_ARRAY_NAME"]].uri,
+            ctx=self.ctx,
+            config=config,
+        )
 
-        self._db = load_as_matrix(os.path.join(uri, parts_name), ctx=self.ctx, config=config)
-
+        dtype = group.meta.get("dtype", None)
         if dtype is None:
             self.dtype = self._db.dtype
         else:
-            self.dtype = dtype
+            self.dtype = np.dtype(dtype)
 
     def query(
         self,
         targets: np.ndarray,
         k: int = 10,
         nthreads: int = 8,
-        nprobe: int = 1,
         query_type="heap",
     ):
         """
@@ -84,9 +80,7 @@ class FlatIndex(Index):
         nqueries: int
             Number of queries
         nthreads: int
-            Number of threads to use for queyr
-        nprobe: int
-            number of probes
+            Number of threads to use for query
         """
         # TODO:
         # - typecheck targets
@@ -123,7 +117,6 @@ class IVFFlatIndex(Index):
     def __init__(
         self,
         uri,
-        dtype: np.dtype = None,
         memory_budget: int = -1,
         config: Optional[Mapping[str, Any]] = None,
     ):
@@ -134,31 +127,48 @@ class IVFFlatIndex(Index):
         self.config = config
         self.ctx = Ctx(config)
         group = tiledb.Group(uri, ctx=tiledb.Ctx(config))
-        self.parts_db_uri = group[PARTS_ARRAY_NAME].uri
-        self.centroids_uri = group[CENTROIDS_ARRAY_NAME].uri
-        self.index_uri = group[INDEX_ARRAY_NAME].uri
-        self.ids_uri = group[IDS_ARRAY_NAME].uri
+        self.storage_version = group.meta.get("storage_version", "0.1")
+        self.parts_db_uri = group[
+            storage_formats[self.storage_version]["PARTS_ARRAY_NAME"]
+        ].uri
+        self.centroids_uri = group[
+            storage_formats[self.storage_version]["CENTROIDS_ARRAY_NAME"]
+        ].uri
+        self.index_uri = group[
+            storage_formats[self.storage_version]["INDEX_ARRAY_NAME"]
+        ].uri
+        self.ids_uri = group[
+            storage_formats[self.storage_version]["IDS_ARRAY_NAME"]
+        ].uri
         self.memory_budget = memory_budget
+
+        self._centroids = load_as_matrix(
+            self.centroids_uri, ctx=self.ctx, config=config
+        )
+        self._index = read_vector_u64(self.ctx, self.index_uri)
 
         # TODO pass in a context
         if self.memory_budget == -1:
             self._db = load_as_matrix(self.parts_db_uri, ctx=self.ctx, config=config)
             self._ids = read_vector_u64(self.ctx, self.ids_uri)
 
-        self._centroids = load_as_matrix(self.centroids_uri, ctx=self.ctx, config=config)
-
-        # TODO this should always be available
+        dtype = group.meta.get("dtype", None)
         if dtype is None:
-            self.dtype = self._centroids.dtype
+            schema = tiledb.ArraySchema.load(self.parts_db_uri)
+            self.dtype = np.dtype(schema.attr("values").dtype)
         else:
-            self.dtype = dtype
-        self._index = read_vector_u64(self.ctx, self.index_uri)
+            self.dtype = np.dtype(dtype)
+
+        self.partitions = group.meta.get("partitions", -1)
+        if self.partitions == -1:
+            schema = tiledb.ArraySchema.load(self.centroids_uri)
+            self.partitions = schema.domain.dim("cols").domain[1] + 1
 
     def query(
         self,
         queries: np.ndarray,
         k: int = 10,
-        nprobe: int = 10,
+        nprobe: int = 1,
         nthreads: int = -1,
         use_nuv_implementation: bool = False,
         mode: Mode = None,
@@ -198,6 +208,8 @@ class IVFFlatIndex(Index):
 
         if nthreads == -1:
             nthreads = multiprocessing.cpu_count()
+
+        nprobe = min(nprobe, self.partitions)
         if mode is None:
             queries_m = array_to_matrix(np.transpose(queries))
             if self.memory_budget == -1:
@@ -313,7 +325,7 @@ class IVFFlatIndex(Index):
                 active_queries=active_queries,
                 indices=indices,
                 k_nn=k_nn,
-                ctx=Ctx(config)
+                ctx=Ctx(config),
             )
             results = []
             for q in range(len(r)):
@@ -377,9 +389,7 @@ class IVFFlatIndex(Index):
                     ids_uri=self.ids_uri,
                     query_vectors=queries,
                     active_partitions=np.array(active_partitions)[part:part_end],
-                    active_queries=np.array(
-                        aq, dtype=object
-                    ),
+                    active_queries=np.array(aq, dtype=object),
                     indices=np.array(self._index),
                     k_nn=k,
                     config=config,
@@ -406,5 +416,5 @@ class IVFFlatIndex(Index):
             tmp = sorted(tmp_results, key=lambda t: t[0])[0:k]
             for j in range(len(tmp), k):
                 tmp.append((float(0.0), int(0)))
-            results_per_query.append(np.array(tmp, dtype=np.dtype('float,int'))['f1'])
+            results_per_query.append(np.array(tmp, dtype=np.dtype("float,int"))["f1"])
         return results_per_query

--- a/apis/python/src/tiledb/vector_search/module.py
+++ b/apis/python/src/tiledb/vector_search/module.py
@@ -8,7 +8,12 @@ from tiledb.vector_search._tiledbvspy import *
 from typing import Optional, Mapping, Any
 
 
-def load_as_matrix(path: str, nqueries: int = 0, ctx: "Ctx" = None, config: Optional[Mapping[str, Any]] = None):
+def load_as_matrix(
+    path: str,
+    nqueries: int = 0,
+    ctx: "Ctx" = None,
+    config: Optional[Mapping[str, Any]] = None,
+):
     """
     Load array as Matrix class
 
@@ -48,7 +53,12 @@ def load_as_matrix(path: str, nqueries: int = 0, ctx: "Ctx" = None, config: Opti
     return m
 
 
-def load_as_array(path, return_matrix: bool = False, ctx: "Ctx" = None, config: Optional[Mapping[str, Any]] = None):
+def load_as_array(
+    path,
+    return_matrix: bool = False,
+    ctx: "Ctx" = None,
+    config: Optional[Mapping[str, Any]] = None,
+):
     """
     Load array as array class
 

--- a/apis/python/src/tiledb/vector_search/storage_formats.py
+++ b/apis/python/src/tiledb/vector_search/storage_formats.py
@@ -11,7 +11,7 @@ storage_formats = {
         "INDEX_ARRAY_NAME": "partition_indexes",
         "IDS_ARRAY_NAME": "shuffled_vector_ids",
         "PARTS_ARRAY_NAME": "shuffled_vectors",
-        "PARTIAL_WRITE_ARRAY_DIR": "write_temp",
+        "PARTIAL_WRITE_ARRAY_DIR": "temp_data",
     },
 }
 

--- a/apis/python/src/tiledb/vector_search/storage_formats.py
+++ b/apis/python/src/tiledb/vector_search/storage_formats.py
@@ -1,0 +1,18 @@
+storage_formats = {
+    "0.1": {
+        "CENTROIDS_ARRAY_NAME": "centroids.tdb",
+        "INDEX_ARRAY_NAME": "index.tdb",
+        "IDS_ARRAY_NAME": "ids.tdb",
+        "PARTS_ARRAY_NAME": "parts.tdb",
+        "PARTIAL_WRITE_ARRAY_DIR": "write_temp",
+    },
+    "0.2": {
+        "CENTROIDS_ARRAY_NAME": "partition_centroids",
+        "INDEX_ARRAY_NAME": "partition_indexes",
+        "IDS_ARRAY_NAME": "shuffled_vector_ids",
+        "PARTS_ARRAY_NAME": "shuffled_vectors",
+        "PARTIAL_WRITE_ARRAY_DIR": "write_temp",
+    },
+}
+
+STORAGE_VERSION = "0.2"

--- a/apis/python/src/tiledb/vector_search/utils.py
+++ b/apis/python/src/tiledb/vector_search/utils.py
@@ -2,35 +2,39 @@ import tiledb
 import numpy as np
 import io
 
+
 def _load_vecs_t(uri, dtype, ctx_or_config=None):
-  with tiledb.scope_ctx(ctx_or_config) as ctx:
-      dtype = np.dtype(dtype)
-      vfs = tiledb.VFS(ctx.config())
-      with vfs.open(uri, "rb") as f:
-          d = f.read(-1)
-          raw = np.frombuffer(d, dtype=np.uint8)
-          ndim = raw[:4].view(np.int32)[0]
+    with tiledb.scope_ctx(ctx_or_config) as ctx:
+        dtype = np.dtype(dtype)
+        vfs = tiledb.VFS(ctx.config())
+        with vfs.open(uri, "rb") as f:
+            d = f.read(-1)
+            raw = np.frombuffer(d, dtype=np.uint8)
+            ndim = raw[:4].view(np.int32)[0]
 
-          elem_nbytes = int(4 + ndim * dtype.itemsize)
-          if raw.size % elem_nbytes != 0:
-              raise ValueError(
-                  f"Mismatched dims to bytes in file {uri}: {raw.size}, elem_nbytes"
-              )
-          # take a view on the whole array as
-          # (ndim, sizeof(t)*ndim), and return the actual elements
-          #return raw.view(np.uint8).reshape((elem_nbytes,-1))[4:,:].view(dtype).reshape((ndim,-1))
+            elem_nbytes = int(4 + ndim * dtype.itemsize)
+            if raw.size % elem_nbytes != 0:
+                raise ValueError(
+                    f"Mismatched dims to bytes in file {uri}: {raw.size}, elem_nbytes"
+                )
+            # take a view on the whole array as
+            # (ndim, sizeof(t)*ndim), and return the actual elements
+            # return raw.view(np.uint8).reshape((elem_nbytes,-1))[4:,:].view(dtype).reshape((ndim,-1))
 
-          if dtype != np.uint8:
-              return raw.view(np.int32).reshape((-1,ndim + 1))[:,1:].view(dtype)
-          else:
-              return raw.view(np.uint8).reshape((-1,ndim + 1))[:,1:].view(dtype)
-          #return raw
+            if dtype != np.uint8:
+                return raw.view(np.int32).reshape((-1, ndim + 1))[:, 1:].view(dtype)
+            else:
+                return raw.view(np.uint8).reshape((-1, ndim + 1))[:, 1:].view(dtype)
+            # return raw
+
 
 def load_ivecs(uri, ctx_or_config=None):
-  return _load_vecs_t(uri, np.int32, ctx_or_config)
+    return _load_vecs_t(uri, np.int32, ctx_or_config)
+
 
 def load_fvecs(uri, ctx_or_config=None):
-  return _load_vecs_t(uri, np.float32, ctx_or_config)
+    return _load_vecs_t(uri, np.float32, ctx_or_config)
+
 
 def load_bvecs(uri, ctx_or_config=None):
-  return _load_vecs_t(uri, np.uint8, ctx_or_config)
+    return _load_vecs_t(uri, np.uint8, ctx_or_config)

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -83,7 +83,7 @@ def test_ivf_flat_ingestion_u8(tmp_path):
     result = index.query(query_vectors, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
-    index_ram = IVFFlatIndex(uri=array_uri, dtype=dtype, memory_budget=int(size / 10))
+    index_ram = IVFFlatIndex(uri=array_uri, memory_budget=int(size / 10))
     result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
@@ -133,7 +133,7 @@ def test_ivf_flat_ingestion_f32(tmp_path):
     result = index.query(query_vectors, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
-    index_ram = IVFFlatIndex(uri=array_uri, dtype=dtype, memory_budget=int(size / 10))
+    index_ram = IVFFlatIndex(uri=array_uri, memory_budget=int(size / 10))
     result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
@@ -185,9 +185,7 @@ def test_ivf_flat_ingestion_fvec(tmp_path):
     result1 = index.query(query_vectors[10], k=k, nprobe=nprobe)
     assert accuracy(result1, np.array([gt_i[10]])) > MINIMUM_ACCURACY
 
-
-
-    index_ram = IVFFlatIndex(uri=array_uri, dtype=dtype)
+    index_ram = IVFFlatIndex(uri=array_uri)
     result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 


### PR DESCRIPTION
- Add storage format versions so we can keep backwards compatibility when changing storage names
- Write more metadata for the index in the Group metadata
- Remove `dtype` from the index APIs.
- Add a check for `nprobe<=parttions`
- Reformat the code using black