### PR TITLE
Fix building the wheels when pushing tags.

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - release-*
-      - refs/tags/*
+    tags:
+      - '*'
   pull_request:
     branches:
       - '*wheel*'  # must quote since "*" is a YAML reserved character; we want a string


### PR DESCRIPTION
[SC-32544](https://app.shortcut.com/tiledb-inc/story/32544/run-build-wheels-job-on-tag)

I made a test release in my fork and [the workflow launches](https://github.com/teo-tsirpanis/TileDB-Vector-Search/actions/runs/5760490146).