### PR TITLE
Elide uses of ranges

### DIFF
--- a/src/include/algorithm.h
+++ b/src/include/algorithm.h
@@ -88,7 +88,7 @@ void for_each(RandomIt first, RandomIt last, UnaryFunction f) {
  * Execute a function in parallel over a range of elements as specified
  * by a begin and end iterator.
  */
-template <std::random_access_iterator RandomIt, class UnaryFunction>
+template <class RandomIt, class UnaryFunction>
 void for_each(
     stdx::execution::parallel_policy&& par,
     RandomIt begin,
@@ -123,7 +123,7 @@ void for_each(
  * by a begin and end iterator.  We also pass the thread number and the
  * current iteration number to the function.
  */
-template <std::random_access_iterator RandomIt, class UnaryFunction>
+template <class RandomIt, class UnaryFunction>
 void for_each(
     stdx::execution::indexed_parallel_policy&& par,
     RandomIt begin,
@@ -162,7 +162,7 @@ void for_each(
 /**
  * Same as above, but with a range, rather than iterator pair.
  */
-template <class /*std::ranges::random_access_range*/ Range, class UnaryFunction>
+template <class Range, class UnaryFunction>
 void range_for_each(
     stdx::execution::indexed_parallel_policy&& par,
     Range&& range,

--- a/src/include/scoring.h
+++ b/src/include/scoring.h
@@ -50,14 +50,17 @@
 #include <memory>
 #include <numeric>
 #include <queue>
-#include <ranges>
 #include <set>
 #include <span>
+
 // #include <execution>
 
 #include "linalg.h"
 #include "utils/fixed_min_heap.h"
 #include "utils/timer.h"
+
+
+
 
 // ----------------------------------------------------------------------------
 // Helper utilities
@@ -182,9 +185,8 @@ inline auto dot(U const& a, V const& b) {
  * @param k
  * @return
  */
-template <
-    std::ranges::random_access_range V,
-    std::ranges::random_access_range L>
+
+template <class V, class L>
 auto get_top_k_from_scores(V const& scores, L&& top_k, int k) {
   fixed_min_pair_heap<float, unsigned> s(k);
 


### PR DESCRIPTION
In some builds for Python on Mac, the compiler did not recognize `random_access_range`.  This PR temporarily removes all uses of `std::range`.