### PR TITLE
Fix empty results

### DIFF
--- a/apis/python/src/tiledb/vector_search/module.cc
+++ b/apis/python/src/tiledb/vector_search/module.cc
@@ -279,7 +279,7 @@ static void declare_ivf_index_tdb(py::module& m, const std::string& suffix) {
         }, py::keep_alive<1,2>());
 }
 
-template <class T=float, class U=size_t>
+template <class T=float, class U=uint64_t>
 static void declareFixedMinPairHeap(py::module& mod) {
   using PyFixedMinPairHeap = py::class_<fixed_min_pair_heap<T, U>>;
   PyFixedMinPairHeap cls(mod, "FixedMinPairHeap", py::buffer_protocol());
@@ -356,7 +356,7 @@ void declareStdVector(py::module& m, const std::string& suffix) {
     });
 }
 
-template <typename T, typename indices_type = size_t>
+template <typename T, typename indices_type = uint64_t>
 void declarePartitionIvfIndex(py::module& m, const std::string& suffix) {
   m.def(("partition_ivf_index_" + suffix).c_str(),
         [](ColMajorMatrix<float>& centroids,
@@ -496,7 +496,7 @@ PYBIND11_MODULE(_tiledbvspy, m) {
         [](ColMajorMatrix<float>& data,
            ColMajorMatrix<float>& query_vectors,
            int k,
-           size_t nthreads) -> std::tuple<ColMajorMatrix<float>, ColMajorMatrix<size_t>> {
+           size_t nthreads) -> std::tuple<ColMajorMatrix<float>, ColMajorMatrix<uint64_t>> {
           auto r = detail::flat::vq_query_heap(data, query_vectors, k, nthreads);
           return r;
         });
@@ -505,13 +505,13 @@ PYBIND11_MODULE(_tiledbvspy, m) {
         [](tdbColMajorMatrix<uint8_t>& data,
            ColMajorMatrix<float>& query_vectors,
            int k,
-           size_t nthreads) -> std::tuple<ColMajorMatrix<float>, ColMajorMatrix<size_t>> {
+           size_t nthreads) -> std::tuple<ColMajorMatrix<float>, ColMajorMatrix<uint64_t>> {
           auto r = detail::flat::vq_query_heap(data, query_vectors, k, nthreads);
           return r;
         });
 
   m.def("validate_top_k_u64",
-      [](const ColMajorMatrix<size_t>& top_k,
+      [](const ColMajorMatrix<uint64_t>& top_k,
          const ColMajorMatrix<int32_t>& ground_truth) -> bool {
         return validate_top_k(top_k, ground_truth);
       });

--- a/apis/python/src/tiledb/vector_search/module.cc
+++ b/apis/python/src/tiledb/vector_search/module.cc
@@ -126,7 +126,7 @@ static void declare_qv_query_heap_infinite_ram(py::module& m, const std::string&
          size_t k_nn,
          size_t nthreads) -> py::tuple { //std::pair<ColMajorMatrix<float>, ColMajorMatrix<size_t>> { // TODO change return type
 
-        auto r = detail::ivf::qv_query_heap_infinite_ram(
+        auto r = detail::ivf::qv_query_heap_infinite_ram<Id_Type>(
             parts,
             centroids,
             query_vectors,

--- a/apis/python/src/tiledb/vector_search/module.cc
+++ b/apis/python/src/tiledb/vector_search/module.cc
@@ -11,8 +11,6 @@
 namespace py = pybind11;
 using Ctx = tiledb::Context;
 
-bool global_debug = false;
-
 bool enable_stats = false;
 std::vector<json> core_stats;
 
@@ -535,9 +533,11 @@ PYBIND11_MODULE(_tiledbvspy, m) {
     return json{core_stats}.dump();
   });
 
+#if 0
   m.def("set_debug", [](bool debug) {
     global_debug = debug;
   });
+#endif
 
   declare_vq_query_heap<uint8_t>(m, "u8");
   declare_vq_query_heap<float>(m, "f32");

--- a/apis/python/src/tiledb/vector_search/module.cc
+++ b/apis/python/src/tiledb/vector_search/module.cc
@@ -124,7 +124,8 @@ static void declare_qv_query_heap_infinite_ram(py::module& m, const std::string&
          size_t k_nn,
          size_t nthreads) -> py::tuple { //std::pair<ColMajorMatrix<float>, ColMajorMatrix<size_t>> { // TODO change return type
 
-        auto r = detail::ivf::qv_query_heap_infinite_ram<Id_Type>(
+        // auto r = detail::ivf::qv_query_heap_infinite_ram(
+        auto r = detail::ivf::query_infinite_ram(
             parts,
             centroids,
             query_vectors,
@@ -176,7 +177,7 @@ static void declare_nuv_query_heap_infinite_ram(py::module& m, const std::string
          std::vector<Id_Type>& ids,
          size_t nprobe,
          size_t k_nn,
-         size_t nthreads) -> std::tuple<ColMajorMatrix<float>, ColMajorMatrix<size_t>> { // TODO change return type
+         size_t nthreads) -> std::tuple<ColMajorMatrix<float>, ColMajorMatrix<uint64_t>> { // TODO change return type
 
         auto r = detail::ivf::nuv_query_heap_infinite_ram_reg_blocked(
             parts,
@@ -203,7 +204,7 @@ static void declare_nuv_query_heap_finite_ram(py::module& m, const std::string& 
          size_t nprobe,
          size_t k_nn,
          size_t upper_bound,
-         size_t nthreads) -> std::tuple<ColMajorMatrix<float>, ColMajorMatrix<size_t>> { // TODO change return type
+         size_t nthreads) -> std::tuple<ColMajorMatrix<float>, ColMajorMatrix<uint64_t>> { // TODO change return type
 
         auto r = detail::ivf::nuv_query_heap_finite_ram_reg_blocked<T, Id_Type>(
             ctx,
@@ -399,8 +400,8 @@ static void declare_vq_query_heap(py::module& m, const std::string& suffix) {
            ColMajorMatrix<float>& query_vectors,
            const std::vector<uint64_t> &ids,
            int k,
-           size_t nthreads) -> std::tuple<ColMajorMatrix<float>, ColMajorMatrix<size_t>> {
-          auto r = detail::flat::vq_query_heap<tdbColMajorMatrix<T>, ColMajorMatrix<float>, uint64_t>(data, query_vectors, ids, k, nthreads);
+           size_t nthreads) -> std::tuple<ColMajorMatrix<float>, ColMajorMatrix<uint64_t>> {
+          auto r = detail::flat::vq_query_heap(data, query_vectors, ids, k, nthreads);
           return r;
         });
 }
@@ -412,8 +413,8 @@ static void declare_vq_query_heap_pyarray(py::module& m, const std::string& suff
            ColMajorMatrix<float>& query_vectors,
            const std::vector<uint64_t> &ids,
            int k,
-           size_t nthreads) -> std::tuple<ColMajorMatrix<float>, ColMajorMatrix<size_t>> {
-          auto r = detail::flat::vq_query_heap<ColMajorMatrix<T>, ColMajorMatrix<float>, uint64_t>(data, query_vectors, ids, k, nthreads);
+           size_t nthreads) -> std::tuple<ColMajorMatrix<float>, ColMajorMatrix<uint64_t>> {
+          auto r = detail::flat::vq_query_heap(data, query_vectors, ids, k, nthreads);
           return r;
         });
 }

--- a/src/include/detail/flat/qv.h
+++ b/src/include/detail/flat/qv.h
@@ -128,7 +128,7 @@ auto qv_query_heap(
 template <class DB, class Q>
 auto qv_query_heap(const DB& db, const Q& q, int k_nn, unsigned nthreads) {
   return qv_query_heap(
-      without_ids{}, db, q, std::vector<size_t>{}, k_nn, nthreads);
+      without_ids{}, db, q, std::vector<uint64_t>{}, k_nn, nthreads);
 }
 
 template <class DB, class Q, class ID>
@@ -209,7 +209,7 @@ auto qv_query_heap_tiled(
 template <class DB, class Q>
 auto qv_query_heap_tiled(DB& db, const Q& q, int k_nn, unsigned nthreads) {
   return qv_query_heap_tiled(
-      without_ids{}, db, q, std::vector<size_t>{}, k_nn, nthreads);
+      without_ids{}, db, q, std::vector<uint64_t>{}, k_nn, nthreads);
 }
 
 template <class DB, class Q, class ID>
@@ -226,11 +226,11 @@ auto qv_query_heap_tiled(
     [[maybe_unused]] const ID& ids,
     int k_nn,
     unsigned nthreads) {
-  
+
   // using feature_type = typename std::remove_reference_t<decltype(db)>::value_type;
   using id_type = typename std::remove_reference_t<decltype(ids)>::value_type;
   using score_type = float;
-  
+
   if constexpr (is_loadable_v<decltype(db)>) {
     db.load();
   }

--- a/src/include/detail/flat/vq.h
+++ b/src/include/detail/flat/vq.h
@@ -138,7 +138,7 @@ auto vq_query_heap(
   }
 
   consolidate_scores(scores);
-  auto top_k = get_top_k_with_scores(scores, k_nn);
+  auto top_k = get_top_k_with_scores<fixed_min_pair_heap<float, Index>, Index>(scores, k_nn);
 
   return top_k;
 }
@@ -223,7 +223,7 @@ auto vq_query_heap_tiled(
   } while (load(db));
 
   consolidate_scores(scores);
-  auto top_k = get_top_k_with_scores(scores, k_nn);
+  auto top_k = get_top_k_with_scores<fixed_min_pair_heap<float, Index>, Index>(scores, k_nn);
 
   return top_k;
 }
@@ -300,7 +300,7 @@ auto vq_query_heap_2(
   } while (load(db));
 
   consolidate_scores(scores);
-  auto top_k = get_top_k_with_scores(scores, k_nn);
+  auto top_k = get_top_k_with_scores<fixed_min_pair_heap<float, Index>, Index>(scores, k_nn);
 
   return top_k;
 }

--- a/src/include/detail/flat/vq.h
+++ b/src/include/detail/flat/vq.h
@@ -145,6 +145,9 @@ auto vq_query_heap(
   consolidate_scores(scores);
   auto top_k = get_top_k_with_scores(scores, k_nn);
 
+  debug_slice(std::get<0>(top_k));
+  debug_slice(std::get<1>(top_k));
+
   return top_k;
 }
 

--- a/src/include/detail/flat/vq.h
+++ b/src/include/detail/flat/vq.h
@@ -63,7 +63,7 @@ auto vq_query_heap(
 template <class DB, class Q>
 auto vq_query_heap(DB& db, const Q& q, int k_nn, unsigned nthreads) {
   return vq_query_heap(
-      without_ids{}, db, q, std::vector<size_t>{}, k_nn, nthreads);
+      without_ids{}, db, q, std::vector<uint64_t>{}, k_nn, nthreads);
 }
 
 template <class DB, class Q, class ID>
@@ -83,11 +83,11 @@ auto vq_query_heap(
     unsigned nthreads) {
   // @todo Need to get the total number of queries, not just the first block
   // @todo Use Matrix here rather than vector of vectors
-  
+
   // using feature_type = typename std::remove_reference_t<decltype(db)>::value_type;
   using id_type = typename std::remove_reference_t<decltype(ids)>::value_type;
   using score_type = float;
-  
+
   std::vector<std::vector<fixed_min_pair_heap<score_type, id_type>>> scores(
       nthreads,
       std::vector<fixed_min_pair_heap<score_type, id_type>>(
@@ -173,7 +173,7 @@ auto vq_query_heap_tiled(
 template <class DB, class Q>
 auto vq_query_heap_tiled(DB& db, const Q& q, int k_nn, unsigned nthreads) {
   return vq_query_heap_tiled(
-      without_ids{}, db, q, std::vector<size_t>{}, k_nn, nthreads);
+      without_ids{}, db, q, std::vector<uint64_t>{}, k_nn, nthreads);
 }
 
 template <class DB, class Q, class ID>
@@ -192,11 +192,11 @@ auto vq_query_heap_tiled(
     unsigned nthreads) {
   // @todo Need to get the total number of queries, not just the first block
   // @todo Use Matrix here rather than vector of vectors
-  
+
   // using feature_type = typename std::remove_reference_t<decltype(db)>::value_type;
   using id_type = typename std::remove_reference_t<decltype(ids)>::value_type;
   using score_type = float;
-  
+
   std::vector<std::vector<fixed_min_pair_heap<score_type, id_type>>> scores(
       nthreads,
       std::vector<fixed_min_pair_heap<score_type, id_type>>(
@@ -255,7 +255,7 @@ auto vq_query_heap_2(
 template <class DB, class Q>
 auto vq_query_heap_2(DB& db, const Q& q, int k_nn, unsigned nthreads) {
   return vq_query_heap_2(
-      without_ids{}, db, q, std::vector<size_t>{}, k_nn, nthreads);
+      without_ids{}, db, q, std::vector<uint64_t>{}, k_nn, nthreads);
 }
 
 template <class DB, class Q, class ID>

--- a/src/include/detail/ivf/dist_qv.h
+++ b/src/include/detail/ivf/dist_qv.h
@@ -65,7 +65,7 @@ namespace detail::ivf {
  * Should be able to use only the indices and the query vectors that are active
  * on this node, and return only the min heaps for the active query vectors
  */
-template <typename T, class shuffled_ids_type>
+template <class feature_type, class shuffled_ids_type>
 auto dist_qv_finite_ram_part(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -80,6 +80,8 @@ auto dist_qv_finite_ram_part(
     nthreads = std::thread::hardware_concurrency();
   }
 
+
+  using score_type = float;
   using parts_type =
       typename std::remove_reference_t<decltype(active_partitions)>::value_type;
   using indices_type =
@@ -88,7 +90,7 @@ auto dist_qv_finite_ram_part(
   size_t num_queries = size(query);
 
   auto shuffled_db = tdbColMajorPartitionedMatrix<
-      T,
+      feature_type,
       shuffled_ids_type,
       indices_type,
       parts_type>(ctx, part_uri, indices, active_partitions, id_uri, 0);
@@ -111,8 +113,8 @@ auto dist_qv_finite_ram_part(
   }
   assert(shuffled_db.num_cols() == size(shuffled_db.ids()));
 
-  auto min_scores = std::vector<fixed_min_pair_heap<float, size_t>>(
-      num_queries, fixed_min_pair_heap<float, size_t>(k_nn));
+  auto min_scores = std::vector<fixed_min_pair_heap<score_type, shuffled_ids_type>>(
+      num_queries, fixed_min_pair_heap<score_type, shuffled_ids_type>(k_nn));
 
   auto current_part_size = shuffled_db.num_col_parts();
 
@@ -165,10 +167,10 @@ auto dist_qv_finite_ram_part(
 
 #if 0
   auto min_scores =
-      std::vector<std::vector<fixed_min_pair_heap<float, size_t>>>(
+      std::vector<std::vector<fixed_min_pair_heap<score_type, id_type>>>(
           nthreads,
-          std::vector<fixed_min_pair_heap<float, size_t>>(
-              num_queries, fixed_min_pair_heap<float, size_t>(k_nn)));
+          std::vector<fixed_min_pair_heap<score_type, id_type>>(
+              num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn)));
 
   size_t parts_per_thread =
       (shuffled_db.num_col_parts() + nthreads - 1) / nthreads;
@@ -221,8 +223,8 @@ auto dist_qv_finite_ram_part(
     futs[n].get();
   }
 
-  auto min_min_scores = std::vector<fixed_min_pair_heap<float, size_t>>(
-      num_queries, fixed_min_pair_heap<float, size_t>(k_nn));
+  auto min_min_scores = std::vector<fixed_min_pair_heap<score_type, id_type>>(
+      num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn));
 
   for (size_t j = 0; j < num_queries; ++j) {
     for (size_t n = 0; n < nthreads; ++n) {
@@ -235,7 +237,7 @@ auto dist_qv_finite_ram_part(
   return min_min_scores;
 #endif
 
-template <typename T, class shuffled_ids_type>
+template <class feature_type, class shuffled_ids_type>
 auto dist_qv_finite_ram(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -253,6 +255,7 @@ auto dist_qv_finite_ram(
   // Check that the size of the indices vector is correct
   assert(size(indices) == centroids.num_cols() + 1);
 
+  using score_type = float;
   using indices_type =
       typename std::remove_reference_t<decltype(indices)>::value_type;
 
@@ -268,8 +271,8 @@ auto dist_qv_finite_ram(
   auto num_parts = size(active_partitions);
   using parts_type = typename decltype(active_partitions)::value_type;
 
-  std::vector<fixed_min_pair_heap<float, size_t>> min_scores(
-      num_queries, fixed_min_pair_heap<float, size_t>(k_nn));
+  std::vector<fixed_min_pair_heap<score_type, shuffled_ids_type>> min_scores(
+      num_queries, fixed_min_pair_heap<score_type, shuffled_ids_type>(k_nn));
 
   size_t parts_per_node = (num_parts + num_nodes - 1) / num_nodes;
 
@@ -293,7 +296,7 @@ auto dist_qv_finite_ram(
       /*
        * Each compute node returns a min_heap of its own min_scores
        */
-      auto dist_min_scores = dist_qv_finite_ram_part<T, shuffled_ids_type>(
+      auto dist_min_scores = dist_qv_finite_ram_part<feature_type, shuffled_ids_type>(
           ctx,
           part_uri,
           dist_partitions,

--- a/src/include/detail/ivf/qv.h
+++ b/src/include/detail/ivf/qv.h
@@ -72,13 +72,33 @@ namespace detail::ivf {
 // Functions for searching with infinite RAM, OG qv ordering
 // ----------------------------------------------------------------------------
 
-// Forward declarations
+
 /**
+ * @brief The OG version of querying with qv loop ordering.
+ * Queries a set of query vectors against an indexed vector database. The
+ * arrays part_uri, centroids, indices, and id_uri comprise the index.  The
+ * partitioned database is stored in part_uri, the centroids are stored in
+ * centroids, the indices demarcating partitions is stored in indices, and the
+ * labels for the vectors in the original database are stored in id_uri.
+ * The query is stored in q.
  *
- * Overload for already opened arrays.  Since the array is already opened, we
- * don't need to specify its type with a template parameter.
+ * * "Infinite RAM" means the entire index is loaded into memory before any
+ * queries are applied, regardless of which partitions are to be queried.
+ *
+ * @param partitioned_db Partitioned database
+ * @param centroids Centroids of the vectors in the original database (and
+ * the partitioned database).  The ith centroid is the centroid of the ith
+ * partition.
+ * @param q The query to be searched
+ * @param indices The demarcations of partitions
+ * @param partitioned_ids Labels for the vectors in the original database
+ * @param nprobe How many partitions to search
+ * @param k_nn How many nearest neighbors to return
+ * @param nth Unused
+ * @param nthreads How many threads to use for parallel execution
+ * @return The indices of the top_k neighbors for each query vector
  */
-template <class ids_type = size_t>
+// @todo We should still order the queries so partitions are searched in order
 auto qv_query_heap_infinite_ram(
     auto&& partitioned_db,
     auto&& centroids,
@@ -87,7 +107,62 @@ auto qv_query_heap_infinite_ram(
     auto&& partitioned_ids,
     size_t nprobe,
     size_t k_nn,
-    size_t nthreads);
+    size_t nthreads) {
+  if (num_loads(partitioned_db) == 0) {
+    load(partitioned_db);
+  }
+  scoped_timer _{"Total time " + tdb_func__};
+  
+  // using feature_type = typename std::remove_reference_t<decltype(partitioned_db)>::value_type;
+  using id_type = typename std::remove_reference_t<decltype(partitioned_ids)>::value_type;
+  using score_type = float;
+
+  assert(partitioned_db.num_cols() == partitioned_ids.size());
+
+  // Check that the indices vector is the right size
+  assert(size(indices) == centroids.num_cols() + 1);
+
+  debug_matrix(partitioned_db, "partitioned_db");
+  debug_slice(partitioned_db, "partitioned_db");
+  debug_matrix(partitioned_ids, "partitioned_ids");
+
+  // get closest centroid for each query vector
+  // auto top_k = qv_query(centroids, q, nprobe, nthreads);
+  //  auto top_centroids = vq_query_heap(centroids, q, nprobe, nthreads);
+
+  // @todo is this the best (fastest) algorithm to use?  (it takes miniscule
+  // time at rate)
+  auto top_centroids =
+      detail::flat::qv_query_heap_0(centroids, q, nprobe, nthreads);
+
+  auto min_scores = std::vector<fixed_min_pair_heap<score_type, id_type>>(
+      size(q), fixed_min_pair_heap<score_type, id_type>(k_nn));
+
+  // Parallelizing over q is not going to be very efficient
+  {
+    scoped_timer __{tdb_func__ + std::string{"_in_ram"}};
+    auto par = stdx::execution::indexed_parallel_policy{nthreads};
+    stdx::range_for_each(
+        std::move(par),
+        q,
+        [&, nprobe](auto&& q_vec, auto&& n = 0, auto&& j = 0) {
+          for (size_t p = 0; p < nprobe; ++p) {
+            size_t start = indices[top_centroids(p, j)];
+            size_t stop = indices[top_centroids(p, j) + 1];
+
+            for (size_t i = start; i < stop; ++i) {
+              auto score = L2(q_vec /*q[j]*/, partitioned_db[i]);
+              min_scores[j].insert(score, partitioned_ids[i]);
+            }
+          }
+        });
+  }
+
+  auto top_k = get_top_k_with_scores(min_scores, k_nn);
+  return top_k;
+}
+
+
 
 /**
  * @brief Query a (small) set of query vectors against a vector database.
@@ -96,13 +171,13 @@ auto qv_query_heap_infinite_ram(
  *
  * For now that type of the array needs to be passed as a template argument.
  */
-template <typename T, class partitioned_ids_type>
+template <class feature_type, class id_type>
 auto qv_query_heap_infinite_ram(
     tiledb::Context& ctx,
     const std::string& part_uri,
-    auto&& centroids,
-    auto&& q,
-    auto&& indices,
+    const auto& centroids,
+    const auto& q,
+    const auto& indices,
     const std::string& id_uri,
     size_t nprobe,
     size_t k_nn,
@@ -110,11 +185,10 @@ auto qv_query_heap_infinite_ram(
   scoped_timer _{tdb_func__};
 
   // Read the shuffled database and ids
-  // @todo To this more systematically
-  auto partitioned_db = tdbColMajorMatrix<T>(ctx, part_uri);
-  auto partitioned_ids = read_vector<partitioned_ids_type>(ctx, id_uri);
+  auto partitioned_db = tdbColMajorMatrix<feature_type>(ctx, part_uri);
+  auto partitioned_ids = read_vector<id_type>(ctx, id_uri);
 
-  return qv_query_heap_infinite_ram<partitioned_ids_type>(
+  return qv_query_heap_infinite_ram(
       partitioned_db,
       centroids,
       q,
@@ -149,7 +223,7 @@ auto qv_query_heap_infinite_ram(
  * @param nthreads How many threads to use for parallel execution
  * @return The indices of the top_k neighbors for each query vector
  */
-template <class ids_type = size_t>
+template <class feature_type, class id_type>
 auto qv_query_heap_infinite_ram(
     const std::string& part_uri,
     auto&& centroids,
@@ -160,95 +234,7 @@ auto qv_query_heap_infinite_ram(
     size_t k_nn,
     size_t nthreads) {
   tiledb::Context ctx;
-  return qv_query_heap_infinite_ram<ids_type>(
-      ctx, part_uri, centroids, q, indices, id_uri, nprobe, k_nn, nthreads);
-}
-
-/**
- * @brief The OG version of querying with qv loop ordering.
- * Queries a set of query vectors against an indexed vector database. The
- * arrays part_uri, centroids, indices, and id_uri comprise the index.  The
- * partitioned database is stored in part_uri, the centroids are stored in
- * centroids, the indices demarcating partitions is stored in indices, and the
- * labels for the vectors in the original database are stored in id_uri.
- * The query is stored in q.
- *
- * * "Infinite RAM" means the entire index is loaded into memory before any
- * queries are applied, regardless of which partitions are to be queried.
- *
- * @param partitioned_db Partitioned database
- * @param centroids Centroids of the vectors in the original database (and
- * the partitioned database).  The ith centroid is the centroid of the ith
- * partition.
- * @param q The query to be searched
- * @param indices The demarcations of partitions
- * @param partitioned_ids Labels for the vectors in the original database
- * @param nprobe How many partitions to search
- * @param k_nn How many nearest neighbors to return
- * @param nth Unused
- * @param nthreads How many threads to use for parallel execution
- * @return The indices of the top_k neighbors for each query vector
- */
-// @todo We should still order the queries so partitions are searched in order
-template <class ids_type>
-auto qv_query_heap_infinite_ram(
-    auto&& partitioned_db,
-    auto&& centroids,
-    auto&& q,
-    auto&& indices,
-    auto&& partitioned_ids,
-    size_t nprobe,
-    size_t k_nn,
-    size_t nthreads) {
-  if (num_loads(partitioned_db) == 0) {
-    load(partitioned_db);
-  }
-  scoped_timer _{"Total time " + tdb_func__};
-
-  assert(partitioned_db.num_cols() == partitioned_ids.size());
-
-  // Check that the indices vector is the right size
-  assert(size(indices) == centroids.num_cols() + 1);
-
-  debug_matrix(partitioned_db, "partitioned_db");
-  debug_slice(partitioned_db, "partitioned_db");
-
-  debug_matrix(partitioned_ids, "partitioned_ids");
-
-  // get closest centroid for each query vector
-  // auto top_k = qv_query(centroids, q, nprobe, nthreads);
-  //  auto top_centroids = vq_query_heap(centroids, q, nprobe, nthreads);
-
-  // @todo is this the best (fastest) algorithm to use?  (it takes miniscule
-  // time at rate)
-  auto top_centroids =
-      detail::flat::qv_query_heap_0(centroids, q, nprobe, nthreads);
-
-  auto min_scores = std::vector<fixed_min_pair_heap<float, ids_type>>(
-      size(q), fixed_min_pair_heap<float, ids_type>(k_nn));
-
-  // Parallelizing over q is not going to be very efficient
-  {
-    scoped_timer __{tdb_func__ + std::string{"_in_ram"}};
-    auto par = stdx::execution::indexed_parallel_policy{nthreads};
-    stdx::range_for_each(
-        std::move(par),
-        q,
-        [&, nprobe](auto&& q_vec, auto&& n = 0, auto&& j = 0) {
-          for (size_t p = 0; p < nprobe; ++p) {
-            size_t start = indices[top_centroids(p, j)];
-            size_t stop = indices[top_centroids(p, j) + 1];
-
-            for (size_t i = start; i < stop; ++i) {
-              auto score = L2(q_vec /*q[j]*/, partitioned_db[i]);
-              min_scores[j].insert(score, partitioned_ids[i]);
-            }
-          }
-        });
-  }
-
-  auto top_k = get_top_k_with_scores<fixed_min_pair_heap<float, ids_type>, ids_type>(min_scores, k_nn);
-  return top_k;
+  return qv_query_heap_infinite_ram<feature_type, id_type>(ctx, part_uri, centroids, q, indices, id_uri, nprobe, k_nn, nthreads);
 }
 
 // ----------------------------------------------------------------------------
@@ -265,7 +251,7 @@ auto nuv_query_heap_infinite_ram(
     size_t k_nn,
     size_t nthreads);
 
-template <typename T, class partitioned_ids_type>
+template <class feature_type, class id_type>
 auto nuv_query_heap_infinite_ram(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -280,8 +266,8 @@ auto nuv_query_heap_infinite_ram(
 
   // Read the shuffled database and ids
   // @todo To this more systematically
-  auto partitioned_db = tdbColMajorMatrix<T>(ctx, part_uri);
-  auto partitioned_ids = read_vector<partitioned_ids_type>(ctx, id_uri);
+  auto partitioned_db = tdbColMajorMatrix<feature_type>(ctx, part_uri);
+  auto partitioned_ids = read_vector<id_type>(ctx, id_uri);
 
   return nuv_query_heap_infinite_ram(
       partitioned_db,
@@ -332,12 +318,15 @@ auto nuv_query_heap_infinite_ram(
     load(partitioned_db);
   }
   scoped_timer _{tdb_func__ + std::string{"_in_ram"}};
+  
+  // using feature_type = typename std::remove_reference_t<decltype(partitioned_db)>::value_type;
+  using id_type = typename std::remove_reference_t<decltype(partitioned_ids)>::value_type;
+  using score_type = float;
 
   assert(partitioned_db.num_cols() == partitioned_ids.size());
 
   debug_matrix(partitioned_db, "partitioned_db");
   debug_slice(partitioned_db, "partitioned_db");
-
   debug_matrix(partitioned_ids, "partitioned_ids");
 
   // Check that the indices vector is the right size
@@ -349,10 +338,10 @@ auto nuv_query_heap_infinite_ram(
       partition_ivf_index(centroids, query, nprobe, nthreads);
 
   auto min_scores =
-      std::vector<std::vector<fixed_min_pair_heap<float, size_t>>>(
+      std::vector<std::vector<fixed_min_pair_heap<score_type, id_type>>>(
           nthreads,
-          std::vector<fixed_min_pair_heap<float, size_t>>(
-              num_queries, fixed_min_pair_heap<float, size_t>(k_nn)));
+          std::vector<fixed_min_pair_heap<score_type, id_type>>(
+              num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn)));
 
   size_t parts_per_thread = (size(active_partitions) + nthreads - 1) / nthreads;
 
@@ -423,7 +412,7 @@ auto nuv_query_heap_infinite_ram_reg_blocked(
     size_t k_nn,
     size_t nthreads);
 
-template <typename T, class partitioned_ids_type>
+template <class feature_type, class id_type>
 auto nuv_query_heap_infinite_ram_reg_blocked(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -438,8 +427,8 @@ auto nuv_query_heap_infinite_ram_reg_blocked(
 
   // Read the shuffled database and ids
   // @todo To this more systematically
-  auto partitioned_db = tdbColMajorMatrix<T>(ctx, part_uri);
-  auto partitioned_ids = read_vector<partitioned_ids_type>(ctx, id_uri);
+  auto partitioned_db = tdbColMajorMatrix<feature_type>(ctx, part_uri);
+  auto partitioned_ids = read_vector<id_type>(ctx, id_uri);
 
   return nuv_query_heap_infinite_ram_reg_blocked(
       partitioned_db,
@@ -495,6 +484,10 @@ auto nuv_query_heap_infinite_ram_reg_blocked(
     load(partitioned_db);
   }
   scoped_timer _{tdb_func__ + std::string{"_in_ram"}};
+  
+  // using feature_type = typename std::remove_reference_t<decltype(partitioned_db)>::value_type;
+  using id_type = typename std::remove_reference_t<decltype(partitioned_ids)>::value_type;
+  using score_type = float;
 
   assert(partitioned_db.num_cols() == partitioned_ids.size());
 
@@ -508,13 +501,13 @@ auto nuv_query_heap_infinite_ram_reg_blocked(
   auto&& [active_partitions, active_queries] =
       partition_ivf_index(centroids, query, nprobe, nthreads);
 
-  // auto min_scores = std::vector<fixed_min_pair_heap<float, size_t>>(
-  //     size(q), fixed_min_pair_heap<float, size_t>(k_nn));
+  // auto min_scores = std::vector<fixed_min_pair_heap<score_type, id_type>>(
+  //     size(q), fixed_min_pair_heap<score_type, id_type>(k_nn));
 
-  std::vector<std::vector<fixed_min_pair_heap<float, size_t>>> min_scores(
+  auto min_scores = std::vector<std::vector<fixed_min_pair_heap<score_type, id_type>>> (
       nthreads,
-      std::vector<fixed_min_pair_heap<float, size_t>>(
-          num_queries, fixed_min_pair_heap<float, size_t>(k_nn)));
+      std::vector<fixed_min_pair_heap<score_type, id_type>>(
+          num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn)));
 
   size_t parts_per_thread = (size(active_partitions) + nthreads - 1) / nthreads;
 
@@ -620,7 +613,7 @@ auto nuv_query_heap_infinite_ram_reg_blocked(
 /**
  * Forward declaration
  */
-template <typename T, class partitioned_ids_type>
+template <class feature_type, class id_type>
 auto qv_query_heap_finite_ram(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -637,8 +630,8 @@ auto qv_query_heap_finite_ram(
  * Interface with uris for all arguments.
  */
 template <
-    typename db_type,
-    class partitioned_ids_type,
+    class feature_type,
+    class id_type,
     class centroids_type,
     class indices_type>
 auto qv_query_heap_finite_ram(
@@ -657,7 +650,7 @@ auto qv_query_heap_finite_ram(
   auto centroids = tdbColMajorMatrix<centroids_type>(ctx, centroids_uri);
   centroids.load();
 
-  auto query = tdbColMajorMatrix<db_type, partitioned_ids_type>(
+  auto query = tdbColMajorMatrix<feature_type>(
       ctx, query_uri, nqueries);
   query.load();
 
@@ -713,7 +706,7 @@ auto qv_query_heap_finite_ram(
  * @param nthreads How many threads to use for parallel execution
  * @return The indices of the top_k neighbors for each query vector
  */
-template <typename T, class partitioned_ids_type>
+template <class feature_type, class id_type>
 auto qv_query_heap_finite_ram(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -727,6 +720,7 @@ auto qv_query_heap_finite_ram(
     size_t nthreads) {
   scoped_timer _{tdb_func__};
 
+  using score_type = float;
   using indices_type =
       typename std::remove_reference_t<decltype(indices)>::value_type;
 
@@ -750,7 +744,7 @@ auto qv_query_heap_finite_ram(
    * We also need to know the "active" centroids, i.e., the ones having at
    * least one query.
    */
-  auto centroid_query = std::multimap<parts_type, size_t>{};
+  auto centroid_query = std::multimap<parts_type, id_type>{};
   auto active_centroids = std::set<parts_type>{};
   for (size_t j = 0; j < num_queries; ++j) {
     for (size_t p = 0; p < nprobe; ++p) {
@@ -764,8 +758,8 @@ auto qv_query_heap_finite_ram(
       std::vector<parts_type>(begin(active_centroids), end(active_centroids));
 
   auto partitioned_db = tdbColMajorPartitionedMatrix<
-      T,
-      partitioned_ids_type,
+      feature_type,
+      id_type,
       indices_type,
       parts_type>(
       ctx, part_uri, indices, active_partitions, id_uri, upper_bound);
@@ -784,11 +778,11 @@ auto qv_query_heap_finite_ram(
       max_partition_size = std::max<size_t>(max_partition_size, partition_size);
       _memory_data.insert_entry(
           tdb_func__ + " (predicted)",
-          partition_size * sizeof(T) * partitioned_db.num_rows());
+          partition_size * sizeof(feature_type) * partitioned_db.num_rows());
     }
     _memory_data.insert_entry(
         tdb_func__ + " (upper bound)",
-        nprobe * num_queries * sizeof(T) * max_partition_size);
+        nprobe * num_queries * sizeof(feature_type) * max_partition_size);
   }
 
   assert(partitioned_db.num_cols() == size(partitioned_db.ids()));
@@ -796,13 +790,13 @@ auto qv_query_heap_finite_ram(
   debug_matrix(partitioned_db, "partitioned_db");
   debug_matrix(partitioned_db.ids(), "partitioned_db.ids()");
 
-  // auto min_scores = std::vector<fixed_min_pair_heap<float, size_t>>(
-  //       size(q), fixed_min_pair_heap<float, size_t>(k_nn));
+  // auto min_scores = std::vector<fixed_min_pair_heap<score_type, id_type>>(
+  //       size(q), fixed_min_pair_heap<score_type, id_type>(k_nn));
 
-  std::vector<std::vector<fixed_min_pair_heap<float, size_t>>> min_scores(
+  auto min_scores = std::vector<std::vector<fixed_min_pair_heap<score_type, id_type>>> (
       nthreads,
-      std::vector<fixed_min_pair_heap<float, size_t>>(
-          num_queries, fixed_min_pair_heap<float, size_t>(k_nn)));
+      std::vector<fixed_min_pair_heap<score_type, id_type>>(
+          num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn)));
 
   log_timer _i{tdb_func__ + " in RAM"};
 
@@ -886,7 +880,7 @@ auto qv_query_heap_finite_ram(
 // Functions for searching with finite RAM, new qv (nuv) ordering
 // ----------------------------------------------------------------------------
 
-template <typename T, class partitioned_ids_type>
+template <class feature_type, class id_type>
 auto nuv_query_heap_finite_ram(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -903,8 +897,8 @@ auto nuv_query_heap_finite_ram(
  * Interface with uris for all arguments.
  */
 template <
-    typename db_type,
-    class partitioned_ids_type,
+    typename feature_type,
+    class id_type,
     class centroids_type,
     class indices_type>
 auto nuv_query_heap_finite_ram(
@@ -922,7 +916,7 @@ auto nuv_query_heap_finite_ram(
 
   // using centroid_type =
   // std::invoke_result_t<tdbColMajorMatrix<centroids_type>>;
-  using query_type = std::invoke_result_t<tdbColMajorMatrix<db_type>>;
+  using query_type = std::invoke_result_t<tdbColMajorMatrix<feature_type>>;
   using idx_type = std::invoke_result_t<tdbColMajorMatrix<indices_type>>;
 
   std::future<centroids_type> centroids_future =
@@ -935,13 +929,13 @@ auto nuv_query_heap_finite_ram(
   // centroids.load();
 
   std::future<query_type> query_future = std::async(std::launch::async, [&]() {
-    auto query = tdbColMajorMatrix<db_type, partitioned_ids_type>(
+    auto query = tdbColMajorMatrix<feature_type, id_type>(
         ctx, query_uri, nqueries);
     query.load();
     return query;
   });
   // auto query =
-  //      tdbColMajorMatrix<db_type, partitioned_ids_type>(ctx, query_uri,
+  //      tdbColMajorMatrix<db_type, id_type>(ctx, query_uri,
   //      nqueries);
   // query.load();
 
@@ -1006,7 +1000,7 @@ auto nuv_query_heap_finite_ram(
  * @param nthreads How many threads to use for parallel execution
  * @return The indices of the top_k neighbors for each query vector
  */
-template <typename T, class partitioned_ids_type>
+template <class feature_type, class id_type>
 auto nuv_query_heap_finite_ram(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -1023,6 +1017,7 @@ auto nuv_query_heap_finite_ram(
   // Check that the size of the indices vector is correct
   assert(size(indices) == centroids.num_cols() + 1);
 
+  using score_type = float;
   using indices_type =
       typename std::remove_reference_t<decltype(indices)>::value_type;
 
@@ -1034,8 +1029,8 @@ auto nuv_query_heap_finite_ram(
   using parts_type = typename decltype(active_partitions)::value_type;
 
   auto partitioned_db = tdbColMajorPartitionedMatrix<
-      T,
-      partitioned_ids_type,
+      feature_type,
+      id_type,
       indices_type,
       parts_type>(
       ctx, part_uri, indices, active_partitions, id_uri, upper_bound);
@@ -1055,24 +1050,24 @@ auto nuv_query_heap_finite_ram(
       max_partition_size = std::max<size_t>(max_partition_size, partition_size);
       _memory_data.insert_entry(
           tdb_func__ + " (predicted)",
-          partition_size * sizeof(T) * partitioned_db.num_rows());
+          partition_size * sizeof(feature_type) * partitioned_db.num_rows());
     }
     _memory_data.insert_entry(
         tdb_func__ + " (upper bound)",
-        nprobe * num_queries * sizeof(T) * max_partition_size);
+        nprobe * num_queries * sizeof(feature_type) * max_partition_size);
   }
 
   assert(partitioned_db.num_cols() == size(partitioned_db.ids()));
   debug_matrix(partitioned_db, "partitioned_db");
   debug_matrix(partitioned_db.ids(), "partitioned_db.ids()");
 
-  // auto min_scores = std::vector<fixed_min_pair_heap<float, size_t>>(
-  //       size(q), fixed_min_pair_heap<float, size_t>(k_nn));
+  // auto min_scores = std::vector<fixed_min_pair_heap<score_type, id_type>>(
+  //       size(q), fixed_min_pair_heap<score_type, id_type>(k_nn));
 
-  std::vector<std::vector<fixed_min_pair_heap<float, size_t>>> min_scores(
+  std::vector<std::vector<fixed_min_pair_heap<score_type, id_type>>> min_scores(
       nthreads,
-      std::vector<fixed_min_pair_heap<float, size_t>>(
-          num_queries, fixed_min_pair_heap<float, size_t>(k_nn)));
+      std::vector<fixed_min_pair_heap<score_type, id_type>>(
+          num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn)));
 
   log_timer _i{tdb_func__ + " in RAM"};
 
@@ -1181,7 +1176,7 @@ auto nuv_query_heap_finite_ram(
  * @param nthreads How many threads to use for parallel execution
  * @return The indices of the top_k neighbors for each query vector
  */
-template <typename T, class partitioned_ids_type>
+template <class feature_type, class id_type>
 auto nuv_query_heap_finite_ram_reg_blocked(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -1198,6 +1193,7 @@ auto nuv_query_heap_finite_ram_reg_blocked(
   // Check that the size of the indices vector is correct
   assert(size(indices) == centroids.num_cols() + 1);
 
+  using score_type = float;
   using indices_type =
       typename std::remove_reference_t<decltype(indices)>::value_type;
 
@@ -1209,8 +1205,8 @@ auto nuv_query_heap_finite_ram_reg_blocked(
   using parts_type = typename decltype(active_partitions)::value_type;
 
   auto partitioned_db = tdbColMajorPartitionedMatrix<
-      T,
-      partitioned_ids_type,
+      feature_type,
+      id_type,
       indices_type,
       parts_type>(
       ctx, part_uri, indices, active_partitions, id_uri, upper_bound);
@@ -1230,24 +1226,24 @@ auto nuv_query_heap_finite_ram_reg_blocked(
       max_partition_size = std::max<size_t>(max_partition_size, partition_size);
       _memory_data.insert_entry(
           tdb_func__ + " (predicted)",
-          partition_size * sizeof(T) * partitioned_db.num_rows());
+          partition_size * sizeof(feature_type) * partitioned_db.num_rows());
     }
     _memory_data.insert_entry(
         tdb_func__ + " (upper bound)",
-        nprobe * num_queries * sizeof(T) * max_partition_size);
+        nprobe * num_queries * sizeof(feature_type) * max_partition_size);
   }
 
   assert(partitioned_db.num_cols() == size(partitioned_db.ids()));
   debug_matrix(partitioned_db, "partitioned_db");
   debug_matrix(partitioned_db.ids(), "partitioned_db.ids()");
 
-  // auto min_scores = std::vector<fixed_min_pair_heap<float, size_t>>(
-  //       size(q), fixed_min_pair_heap<float, size_t>(k_nn));
+  // auto min_scores = std::vector<fixed_min_pair_heap<score_type, id_type>>(
+  //       size(q), fixed_min_pair_heap<score_type, id_type>(k_nn));
 
-  std::vector<std::vector<fixed_min_pair_heap<float, size_t>>> min_scores(
+  std::vector<std::vector<fixed_min_pair_heap<score_type, id_type>>> min_scores(
       nthreads,
-      std::vector<fixed_min_pair_heap<float, size_t>>(
-          num_queries, fixed_min_pair_heap<float, size_t>(k_nn)));
+      std::vector<fixed_min_pair_heap<score_type, id_type>>(
+          num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn)));
 
   log_timer _i{tdb_func__ + " in RAM"};
 
@@ -1411,9 +1407,13 @@ auto apply_query(
     size_t last_part) {
   //  print_types(query, partitioned_db, new_indices, active_queries);
 
+  // using feature_type = typename std::remove_reference_t<decltype(partitioned_db)>::value_type;
+  using id_type = typename std::remove_reference_t<decltype(ids)>::value_type;
+  using score_type = float;
+  
   auto num_queries = size(query);
-  auto min_scores = std::vector<fixed_min_pair_heap<float, size_t>>(
-      num_queries, fixed_min_pair_heap<float, size_t>(k_nn));
+  auto min_scores = std::vector<fixed_min_pair_heap<score_type, id_type>>(
+      num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn));
 
   size_t part_offset = 0;
   size_t col_offset = 0;
@@ -1532,7 +1532,7 @@ auto apply_query(
  * @param min_parts_per_thread Unused (WIP for threading heuristics)
  * @return The indices of the top_k neighbors for each query vector
  */
-template <class T, class partitioned_ids_type>
+template <class feature_type, class id_type>
 auto query_finite_ram(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -1546,10 +1546,11 @@ auto query_finite_ram(
     size_t nthreads,
     size_t min_parts_per_thread = 0) {
   scoped_timer _{tdb_func__ + " " + part_uri};
-
+  
   // Check that the size of the indices vector is correct
   assert(size(indices) == centroids.num_cols() + 1);
 
+  using score_type = float;
   using indices_type =
       typename std::remove_reference_t<decltype(indices)>::value_type;
 
@@ -1561,8 +1562,8 @@ auto query_finite_ram(
   using parts_type = typename decltype(active_partitions)::value_type;
 
   auto partitioned_db = tdbColMajorPartitionedMatrix<
-      T,
-      partitioned_ids_type,
+      feature_type,
+      id_type,
       indices_type,
       parts_type>(
       ctx, part_uri, indices, active_partitions, id_uri, upper_bound);
@@ -1584,19 +1585,19 @@ auto query_finite_ram(
       max_partition_size = std::max<size_t>(max_partition_size, partition_size);
       _memory_data.insert_entry(
           tdb_func__ + " (predicted)",
-          partition_size * sizeof(T) * partitioned_db.num_rows());
+          partition_size * sizeof(feature_type) * partitioned_db.num_rows());
     }
     _memory_data.insert_entry(
         tdb_func__ + " (upper bound)",
-        nprobe * num_queries * sizeof(T) * max_partition_size);
+        nprobe * num_queries * sizeof(feature_type) * max_partition_size);
   }
 
   assert(partitioned_db.num_cols() == size(partitioned_db.ids()));
   debug_matrix(partitioned_db, "partitioned_db");
   debug_matrix(partitioned_db.ids(), "partitioned_db.ids()");
 
-  auto min_scores = std::vector<fixed_min_pair_heap<float, size_t>>(
-      num_queries, fixed_min_pair_heap<float, size_t>(k_nn));
+  auto min_scores = std::vector<fixed_min_pair_heap<score_type, id_type>>(
+      num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn));
 
   while (partitioned_db.load()) {
     _i.start();
@@ -1699,6 +1700,10 @@ auto query_infinite_ram(
     size_t nthreads) {
   scoped_timer _{tdb_func__ + std::string{"_in_ram"}};
 
+  // using feature_type = typename std::remove_reference_t<decltype(partitioned_db)>::value_type;
+  using id_type = typename std::remove_reference_t<decltype(partitioned_ids)>::value_type;
+  using score_type = float;
+  
   assert(partitioned_db.num_cols() == partitioned_ids.size());
 
   // Check that the indices vector is the right size
@@ -1715,8 +1720,8 @@ auto query_infinite_ram(
 
   std::vector<parts_type> new_indices(size(active_partitions) + 1);
 
-  auto min_scores = std::vector<fixed_min_pair_heap<float, size_t>>(
-      num_queries, fixed_min_pair_heap<float, size_t>(k_nn));
+  auto min_scores = std::vector<fixed_min_pair_heap<score_type, id_type>>(
+      num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn));
 
   size_t parts_per_thread = (size(active_partitions) + nthreads - 1) / nthreads;
 
@@ -1771,7 +1776,7 @@ auto query_infinite_ram(
   return top_k;
 }
 
-template <typename T, class partitioned_ids_type>
+template <class feature_type, class id_type>
 auto query_infinite_ram(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -1786,9 +1791,9 @@ auto query_infinite_ram(
 
   // Read the shuffled database and ids
   // @todo To this more systematically
-  auto partitioned_db = tdbColMajorMatrix<T>(ctx, part_uri);
+  auto partitioned_db = tdbColMajorMatrix<feature_type>(ctx, part_uri);
   partitioned_db.load();
-  auto partitioned_ids = read_vector<partitioned_ids_type>(ctx, id_uri);
+  auto partitioned_ids = read_vector<id_type>(ctx, id_uri);
 
   return query_infinite_ram(
       partitioned_db,

--- a/src/include/detail/ivf/vq.h
+++ b/src/include/detail/ivf/vq.h
@@ -78,7 +78,7 @@ namespace detail::ivf {
  * Note that this algorithm is essentially the transpose of the one in qv.h.
  *
  * @param query The set of all query vectors.
- * @param shuffled_db The partitioned set of vectors to be searched
+ * @param partitioned_db The partitioned set of vectors to be searched
  * @param new_indices The indices delimiting the partitions.
  * @param active_queries Indicates which queries to apply to each of the active
  * partitions.
@@ -92,7 +92,7 @@ namespace detail::ivf {
  */
 auto vq_apply_query(
     auto&& query,
-    auto&& shuffled_db,
+    auto&& partitioned_db,
     auto&& new_indices,
     auto&& active_queries,
     auto&& ids,
@@ -102,18 +102,20 @@ auto vq_apply_query(
     size_t last_part) {
   auto num_queries = size(query);
 
-  // std::cout << "thread " << n << " running " << first_part << " to " <<
-  // last_part << std::endl;
+  // using feature_type = typename
+  // std::remove_reference_t<decltype(partitioned_db)>::value_type;
+  using id_type = typename std::remove_reference_t<decltype(ids)>::value_type;
+  using score_type = float;
 
   size_t part_offset = 0;
   size_t col_offset = 0;
-  if constexpr (has_num_col_parts<decltype(shuffled_db)>) {
-    part_offset = shuffled_db.col_part_offset();
-    col_offset = shuffled_db.col_offset();
+  if constexpr (has_num_col_parts<decltype(partitioned_db)>) {
+    part_offset = partitioned_db.col_part_offset();
+    col_offset = partitioned_db.col_offset();
   }
 
-  auto min_scores = std::vector<fixed_min_pair_heap<float, size_t>>(
-      num_queries, fixed_min_pair_heap<float, size_t>(k_nn));
+  auto min_scores = std::vector<fixed_min_pair_heap<score_type, id_type>>(
+      num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn));
 
   /**
    * Loop over given partitons to be searched
@@ -123,7 +125,7 @@ auto vq_apply_query(
 
     // @todo this is a bit of a hack
     auto quartno = partno;
-    if constexpr (!has_num_col_parts<decltype(shuffled_db)>) {
+    if constexpr (!has_num_col_parts<decltype(partitioned_db)>) {
       quartno = active_partitions[partno];
     }
 
@@ -151,10 +153,10 @@ auto vq_apply_query(
         auto q_vec_0 = query[j0];
         auto q_vec_1 = query[j1];
 
-        auto score_00 = L2(q_vec_0, shuffled_db[kp + 0]);
-        auto score_01 = L2(q_vec_0, shuffled_db[kp + 1]);
-        auto score_10 = L2(q_vec_1, shuffled_db[kp + 0]);
-        auto score_11 = L2(q_vec_1, shuffled_db[kp + 1]);
+        auto score_00 = L2(q_vec_0, partitioned_db[kp + 0]);
+        auto score_01 = L2(q_vec_0, partitioned_db[kp + 1]);
+        auto score_10 = L2(q_vec_1, partitioned_db[kp + 0]);
+        auto score_11 = L2(q_vec_1, partitioned_db[kp + 1]);
 
         min_scores[j0].insert(score_00, ids[kp + 0]);
         min_scores[j0].insert(score_01, ids[kp + 1]);
@@ -169,8 +171,8 @@ auto vq_apply_query(
         auto j0 = j[0];
         auto q_vec_0 = query[j0];
 
-        auto score_00 = L2(q_vec_0, shuffled_db[kp + 0]);
-        auto score_01 = L2(q_vec_0, shuffled_db[kp + 1]);
+        auto score_00 = L2(q_vec_0, partitioned_db[kp + 0]);
+        auto score_01 = L2(q_vec_0, partitioned_db[kp + 1]);
         min_scores[j0].insert(score_00, ids[kp + 0]);
         min_scores[j0].insert(score_01, ids[kp + 1]);
       }
@@ -186,8 +188,8 @@ auto vq_apply_query(
         auto q_vec_0 = query[j0];
         auto q_vec_1 = query[j1];
 
-        auto score_00 = L2(q_vec_0, shuffled_db[kp + 0]);
-        auto score_10 = L2(q_vec_1, shuffled_db[kp + 0]);
+        auto score_00 = L2(q_vec_0, partitioned_db[kp + 0]);
+        auto score_10 = L2(q_vec_1, partitioned_db[kp + 0]);
 
         min_scores[j0].insert(score_00, ids[kp + 0]);
         min_scores[j1].insert(score_10, ids[kp + 0]);
@@ -200,7 +202,7 @@ auto vq_apply_query(
         auto j0 = j[0];
         auto q_vec_0 = query[j0];
 
-        auto score_00 = L2(q_vec_0, shuffled_db[kp + 0]);
+        auto score_00 = L2(q_vec_0, partitioned_db[kp + 0]);
         min_scores[j0].insert(score_00, ids[kp + 0]);
       }
     }
@@ -214,17 +216,23 @@ auto vq_apply_query(
  * already have loaded all of its data.
  */
 auto vq_query_infinite_ram(
-    auto&& shuffled_db,
+    auto&& partitioned_db,
     auto&& centroids,
     auto&& query,
     auto&& indices,
-    auto&& shuffled_ids,
+    auto&& partitioned_ids,
     size_t nprobe,
     size_t k_nn,
     size_t nthreads) {
   scoped_timer _{tdb_func__ + std::string{"_in_ram"}};
 
-  assert(shuffled_db.num_cols() == shuffled_ids.size());
+  // using feature_type = typename
+  // std::remove_reference_t<decltype(partitioned_db)>::value_type;
+  using id_type =
+      typename std::remove_reference_t<decltype(partitioned_ids)>::value_type;
+  using score_type = float;
+
+  assert(partitioned_db.num_cols() == partitioned_ids.size());
 
   // Check that the indices vector is the right size
   assert(size(indices) == centroids.num_cols() + 1);
@@ -240,8 +248,8 @@ auto vq_query_infinite_ram(
 
   std::vector<parts_type> new_indices(size(active_partitions) + 1);
 
-  auto min_scores = std::vector<fixed_min_pair_heap<float, size_t>>(
-      num_queries, fixed_min_pair_heap<float, size_t>(k_nn));
+  auto min_scores = std::vector<fixed_min_pair_heap<score_type, id_type>>(
+      num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn));
 
   size_t parts_per_thread = (size(active_partitions) + nthreads - 1) / nthreads;
 
@@ -258,20 +266,20 @@ auto vq_query_infinite_ram(
       futs.emplace_back(std::async(
           std::launch::async,
           [&query,
-           &shuffled_db,
+           &partitioned_db,
            &indices,
            &active_queries = active_queries,
            &active_partitions = active_partitions,
-           &shuffled_ids,
+           &partitioned_ids,
            k_nn,
            first_part,
            last_part]() {
             return vq_apply_query(
                 query,
-                shuffled_db,
+                partitioned_db,
                 indices,
                 active_queries,
-                shuffled_ids,
+                partitioned_ids,
                 active_partitions,
                 k_nn,
                 first_part,
@@ -301,7 +309,7 @@ auto vq_query_infinite_ram(
  * loads them each into a matrix, and then calls `vq_query_infinite_ram`
  * above.
  */
-template <typename T, class shuffled_ids_type>
+template <class feature_type, class id_type>
 auto vq_query_infinite_ram(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -314,14 +322,14 @@ auto vq_query_infinite_ram(
     size_t nthreads) {
   scoped_timer _{tdb_func__};
 
-  // Read the shuffled database and ids
+  // Read the partitioned database and ids
   // @todo To this more systematically
-  auto shuffled_db = tdbColMajorMatrix<T>(ctx, part_uri);
-  shuffled_db.load();
-  auto shuffled_ids = read_vector<shuffled_ids_type>(ctx, id_uri);
+  auto partitioned_db = tdbColMajorMatrix<feature_type>(ctx, part_uri);
+  partitioned_db.load();
+  auto partitioned_ids = read_vector<id_type>(ctx, id_uri);
 
   return vq_query_infinite_ram(
-      shuffled_db, centroids, q, indices, shuffled_ids, nprobe, k_nn, nthreads);
+      partitioned_db, centroids, q, indices, partitioned_ids, nprobe, k_nn, nthreads);
 }
 
 /**
@@ -330,20 +338,24 @@ auto vq_query_infinite_ram(
  * already have loaded all of its data.
  */
 auto vq_query_infinite_ram_2(
-    auto&& shuffled_db,
+    auto&& partitioned_db,
     auto&& centroids,
     auto&& query,
     auto&& indices,
-    auto&& shuffled_ids,
+    auto&& partitioned_ids,
     size_t nprobe,
     size_t k_nn,
     size_t nthreads) {
   scoped_timer _{tdb_func__ + std::string{"_in_ram"}};
 
-  assert(shuffled_db.num_cols() == shuffled_ids.size());
+  assert(partitioned_db.num_cols() == partitioned_ids.size());
 
   // Check that the indices vector is the right size
   assert(size(indices) == centroids.num_cols() + 1);
+  
+  // using feature_type = typename std::remove_reference<decltype(partitioned_db)>::value_type;
+  using id_type = typename std::remove_reference<decltype(partitioned_ids)>::value_type;
+  using score_type = float;
 
   auto num_queries = size(query);
 
@@ -356,8 +368,8 @@ auto vq_query_infinite_ram_2(
 
   std::vector<parts_type> new_indices(size(active_partitions) + 1);
 
-  auto min_scores = std::vector<fixed_min_pair_heap<float, size_t>>(
-      num_queries, fixed_min_pair_heap<float, size_t>(k_nn));
+  auto min_scores = std::vector<fixed_min_pair_heap<score_type, id_type>>(
+      num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn));
 
   size_t parts_per_thread = (size(active_partitions) + nthreads - 1) / nthreads;
 
@@ -375,7 +387,7 @@ auto vq_query_infinite_ram_2(
           std::launch::async,
           [&query,
            &min_scores,
-           &shuffled_db,
+           &partitioned_db,
            &new_indices = indices,
            &active_queries = active_queries,
            &active_partitions = active_partitions,
@@ -396,15 +408,15 @@ auto vq_query_infinite_ram_2(
                */
 
               for (size_t k = start; k < stop; ++k) {
-                auto kp = k - shuffled_db.col_offset();
+                auto kp = k - partitioned_db.col_offset();
 
                 for (auto j : active_queries[partno]) {
                   // @todo shift start / stop back by the offset
 
-                  auto score = L2(query[j], shuffled_db[kp]);
+                  auto score = L2(query[j], partitioned_db[kp]);
 
                   // @todo any performance with apparent extra indirection?
-                  min_scores[j].insert(score, shuffled_db.ids()[kp]);
+                  min_scores[j].insert(score, partitioned_db.ids()[kp]);
                 }
               }
             }
@@ -433,7 +445,7 @@ auto vq_query_infinite_ram_2(
  * loads them each into a matrix, and then calls `vq_query_infinite_ram`
  * above.
  */
-template <typename T, class shuffled_ids_type>
+template <typename T, class id_type>
 auto vq_query_infinite_ram_2(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -446,14 +458,14 @@ auto vq_query_infinite_ram_2(
     size_t nthreads) {
   scoped_timer _{tdb_func__};
 
-  // Read the shuffled database and ids
+  // Read the partitioned database and ids
   // @todo To this more systematically
-  auto shuffled_db = tdbColMajorMatrix<T>(ctx, part_uri);
-  shuffled_db.load();
-  auto shuffled_ids = read_vector<shuffled_ids_type>(ctx, id_uri);
+  auto partitioned_db = tdbColMajorMatrix<T>(ctx, part_uri);
+  partitioned_db.load();
+  auto partitioned_ids = read_vector<id_type>(ctx, id_uri);
 
   return vq_query_infinite_ram(
-      shuffled_db, centroids, q, indices, shuffled_ids, nprobe, k_nn, nthreads);
+      partitioned_db, centroids, q, indices, partitioned_ids, nprobe, k_nn, nthreads);
 }
 
 /*
@@ -465,7 +477,7 @@ auto vq_query_infinite_ram_2(
  * function then invoked `vq_apply_query` on the partitioned matrix in
  * parallel fashion, decomposing over the partitions.
  */
-template <class T, class shuffled_ids_type>
+template <class feature_type, class id_type>
 auto vq_query_finite_ram(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -483,6 +495,8 @@ auto vq_query_finite_ram(
   // Check that the size of the indices vector is correct
   assert(size(indices) == centroids.num_cols() + 1);
 
+  using score_type = float;
+  
   using indices_type =
       typename std::remove_reference_t<decltype(indices)>::value_type;
 
@@ -493,13 +507,13 @@ auto vq_query_finite_ram(
 
   using parts_type = typename decltype(active_partitions)::value_type;
 
-  auto shuffled_db = tdbColMajorPartitionedMatrix<
-      T,
-      shuffled_ids_type,
+  auto partitioned_db = tdbColMajorPartitionedMatrix<
+      feature_type,
+      id_type,
       indices_type,
       parts_type>(
       ctx, part_uri, indices, active_partitions, id_uri, upper_bound);
-  load(shuffled_db);
+  load(partitioned_db);
 
   log_timer _i{tdb_func__ + " in RAM"};
 
@@ -518,24 +532,24 @@ auto vq_query_finite_ram(
       max_partition_size = std::max<size_t>(max_partition_size, partition_size);
       _memory_data.insert_entry(
           tdb_func__ + " (predicted)",
-          partition_size * sizeof(T) * shuffled_db.num_rows());
+          partition_size * sizeof(feature_type) * partitioned_db.num_rows());
     }
     _memory_data.insert_entry(
         tdb_func__ + " (upper bound)",
-        nprobe * num_queries * sizeof(T) * max_partition_size);
+        nprobe * num_queries * sizeof(feature_type) * max_partition_size);
   }
 
-  assert(shuffled_db.num_cols() == size(shuffled_db.ids()));
-  debug_matrix(shuffled_db, "shuffled_db");
-  debug_matrix(shuffled_db.ids(), "shuffled_db.ids()");
+  assert(partitioned_db.num_cols() == size(partitioned_db.ids()));
+  debug_matrix(partitioned_db, "partitioned_db");
+  debug_matrix(partitioned_db.ids(), "partitioned_db.ids()");
 
-  auto min_scores = std::vector<fixed_min_pair_heap<float, size_t>>(
-      num_queries, fixed_min_pair_heap<float, size_t>(k_nn));
+  auto min_scores = std::vector<fixed_min_pair_heap<score_type, id_type>>(
+      num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn));
 
   do {
     _i.start();
 
-    auto current_part_size = shuffled_db.num_col_parts();
+    auto current_part_size = partitioned_db.num_col_parts();
 
     size_t parts_per_thread = (current_part_size + nthreads - 1) / nthreads;
 
@@ -553,7 +567,7 @@ auto vq_query_finite_ram(
           futs.emplace_back(std::async(
               std::launch::async,
               [&query,
-               &shuffled_db,
+               &partitioned_db,
                &new_indices,
                &active_queries = active_queries,
                &active_partitions = active_partitions,
@@ -562,10 +576,10 @@ auto vq_query_finite_ram(
                last_part]() {
                 return vq_apply_query(
                     query,
-                    shuffled_db,
+                    partitioned_db,
                     new_indices,
                     active_queries,
-                    shuffled_db.ids(),
+                    partitioned_db.ids(),
                     active_partitions,
                     k_nn,
                     first_part,
@@ -586,14 +600,14 @@ auto vq_query_finite_ram(
     }
 
     _i.stop();
-  } while (load(shuffled_db));
+  } while (load(partitioned_db));
 
   auto top_k = get_top_k_with_scores(min_scores, k_nn);
 
   return top_k;
 }
 
-template <class T, class shuffled_ids_type>
+template <class feature_type, class id_type>
 auto vq_query_finite_ram_2(
     tiledb::Context& ctx,
     const std::string& part_uri,
@@ -608,6 +622,7 @@ auto vq_query_finite_ram_2(
     size_t min_parts_per_thread = 0) {
   scoped_timer _{tdb_func__ + " " + part_uri};
 
+  using score_type = float;
   using indices_type =
       typename std::remove_reference_t<decltype(indices)>::value_type;
 
@@ -618,9 +633,9 @@ auto vq_query_finite_ram_2(
 
   using parts_type = typename decltype(active_partitions)::value_type;
 
-  auto shuffled_db = tdbColMajorPartitionedMatrix<
-      T,
-      shuffled_ids_type,
+  auto partitioned_db = tdbColMajorPartitionedMatrix<
+      feature_type,
+      id_type,
       indices_type,
       parts_type>(
       ctx, part_uri, indices, active_partitions, id_uri, upper_bound);
@@ -635,15 +650,15 @@ auto vq_query_finite_ram_2(
   }
 
   auto min_scores =
-      std::vector<std::vector<fixed_min_pair_heap<float, size_t>>>(
+      std::vector<std::vector<fixed_min_pair_heap<score_type, id_type>>>(
           nthreads,
-          std::vector<fixed_min_pair_heap<float, size_t>>(
-              num_queries, fixed_min_pair_heap<float, size_t>(k_nn)));
+          std::vector<fixed_min_pair_heap<score_type, id_type>>(
+              num_queries, fixed_min_pair_heap<score_type, id_type>(k_nn)));
 
-  while (shuffled_db.load()) {
+  while (partitioned_db.load()) {
     _i.start();
 
-    auto current_part_size = shuffled_db.num_col_parts();
+    auto current_part_size = partitioned_db.num_col_parts();
 
     size_t parts_per_thread = (current_part_size + nthreads - 1) / nthreads;
 
@@ -662,7 +677,7 @@ auto vq_query_finite_ram_2(
               std::launch::async,
               [&query,
                &min_scores,
-               &shuffled_db,
+               &partitioned_db,
                &new_indices,
                &active_queries = active_queries,
                n,
@@ -673,7 +688,7 @@ auto vq_query_finite_ram_2(
                  * partition as their top centroid.
                  */
                 for (size_t p = first_part; p < last_part; ++p) {
-                  auto partno = p + shuffled_db.col_part_offset();
+                  auto partno = p + partitioned_db.col_part_offset();
 
                   auto start = new_indices[partno];
                   auto stop = new_indices[partno + 1];
@@ -683,15 +698,15 @@ auto vq_query_finite_ram_2(
                    */
 
                   for (size_t k = start; k < stop; ++k) {
-                    auto kp = k - shuffled_db.col_offset();
+                    auto kp = k - partitioned_db.col_offset();
 
                     for (auto j : active_queries[partno]) {
                       // @todo shift start / stop back by the offset
 
-                      auto score = L2(query[j], shuffled_db[kp]);
+                      auto score = L2(query[j], partitioned_db[kp]);
 
                       // @todo any performance with apparent extra indirection?
-                      min_scores[n][j].insert(score, shuffled_db.ids()[kp]);
+                      min_scores[n][j].insert(score, partitioned_db.ids()[kp]);
                     }
                   }
                 }

--- a/src/include/detail/linalg/linalg_defs.h
+++ b/src/include/detail/linalg/linalg_defs.h
@@ -40,8 +40,4 @@ using namespace Kokkos;
 using namespace Kokkos::Experimental;
 }  // namespace stdx
 
-extern bool global_verbose;
-extern bool global_debug;
-extern std::string global_region;
-
 #endif  // TDB_LINALG_DEFS_H

--- a/src/include/detail/linalg/matrix.h
+++ b/src/include/detail/linalg/matrix.h
@@ -293,9 +293,11 @@ std::string matrix_info(const std::span<T>& A, const std::string& msg = "") {
   return str;
 }
 
+static bool matrix_printf = false;
+
 template <class Matrix>
 void debug_matrix(const Matrix& A, const std::string& msg = "") {
-  if (global_debug) {
+  if (matrix_printf) {
     std::cout << matrix_info(A, msg) << std::endl;
   }
 }
@@ -306,7 +308,7 @@ void debug_slice(
     const std::string& msg = "",
     size_t rows = 5,
     size_t cols = 15) {
-  if (global_debug) {
+  if (matrix_printf) {
     rows = std::min(rows, A.num_rows());
     cols = std::min(cols, A.num_cols());
 
@@ -328,7 +330,7 @@ void debug_slices_diff(
     const std::string& msg = "",
     size_t rows = 5,
     size_t cols = 15) {
-  if (global_debug) {
+  if (matrix_printf) {
     rows = std::min(rows, A.num_rows());
     cols = std::min(cols, A.num_cols());
 

--- a/src/include/detail/linalg/tdb_io.h
+++ b/src/include/detail/linalg/tdb_io.h
@@ -45,9 +45,6 @@ void create_matrix(
     const tiledb::Context& ctx,
     const Matrix<T, LayoutPolicy, I>& A,
     const std::string& uri) {
-  if (global_debug) {
-    std::cerr << "# Creating Matrix: " << uri << std::endl;
-  }
 
   // @todo: make this a parameter
   size_t num_parts = 10;
@@ -86,9 +83,6 @@ void write_matrix(
     size_t start_pos = 0,
     bool create = true) {
   scoped_timer _{tdb_func__ + " " + std::string{uri}};
-  if (global_debug) {
-    std::cerr << "# Writing Matrix: " << uri << std::endl;
-  }
 
   if (create) {
     create_matrix<T, LayoutPolicy, I>(ctx, A, uri);
@@ -124,9 +118,6 @@ void write_matrix(
 template <class T>
 void create_vector(
     const tiledb::Context& ctx, std::vector<T>& v, const std::string& uri) {
-  if (global_debug) {
-    std::cerr << "# Creating std::vector: " << uri << std::endl;
-  }
 
   size_t num_parts = 10;
   size_t tile_extent = (size(v) + num_parts - 1) / num_parts;
@@ -155,10 +146,6 @@ void write_vector(
     size_t start_pos = 0,
     bool create = true) {
   scoped_timer _{tdb_func__ + " " + std::string{uri}};
-
-  if (global_debug) {
-    std::cerr << "# Writing std::vector: " << uri << std::endl;
-  }
 
   if (create) {
     create_vector<T>(ctx, v, uri);
@@ -196,10 +183,6 @@ std::vector<T> read_vector(
     size_t start_pos = 0,
     size_t end_pos = 0) {
   scoped_timer _{tdb_func__ + " " + std::string{uri}};
-
-  if (global_debug) {
-    std::cerr << "# Reading std::vector: " << uri << std::endl;
-  }
 
   tiledb::Array array_ =
       tiledb_helpers::open_array(tdb_func__, ctx, uri, TILEDB_READ);

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -62,10 +62,6 @@ using namespace Kokkos;
 using namespace Kokkos::Experimental;
 }  // namespace stdx
 
-extern bool global_verbose;
-extern bool global_debug;
-extern std::string global_region;
-
 /**
  *
  * @note The template parameters indices_type and parts_type are deduced using

--- a/src/include/scoring.h
+++ b/src/include/scoring.h
@@ -47,6 +47,7 @@
 #include <cmath>
 #include <future>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <queue>
@@ -58,9 +59,6 @@
 #include "linalg.h"
 #include "utils/fixed_min_heap.h"
 #include "utils/timer.h"
-
-
-
 
 // ----------------------------------------------------------------------------
 // Helper utilities
@@ -292,7 +290,7 @@ inline auto get_top_k(std::vector<std::vector<Heap>>& scores, size_t k_nn) {
 // ----------------------------------------------------------------------------
 // Functions for computing top k neighbors with scores
 // ----------------------------------------------------------------------------
-
+template <class Index = size_t, class score_type = float>
 inline void get_top_k_with_scores_from_heap(
     auto&& min_scores, auto&& top_k, auto&& top_k_scores) {
   std::sort_heap(begin(min_scores), end(min_scores), [](auto&& a, auto&& b) {
@@ -306,6 +304,10 @@ inline void get_top_k_with_scores_from_heap(
       begin(min_scores), end(min_scores), begin(top_k), ([](auto&& e) {
         return std::get<1>(e);
       }));
+  for (size_t i = min_scores.size(); i < top_k.size(); ++i) {
+    top_k[i] = std::numeric_limits<Index>::max();
+    top_k_scores[i] = std::numeric_limits<score_type>::max();
+  }
 }
 
 // Overload for one-d scores
@@ -320,7 +322,7 @@ inline auto get_top_k_with_scores(std::vector<Heap>& scores, size_t k_nn) {
   ColMajorMatrix<score_type> top_scores(k_nn, num_queries);
 
   for (size_t j = 0; j < num_queries; ++j) {
-    get_top_k_with_scores_from_heap(scores[j], top_k[j], top_scores[j]);
+    get_top_k_with_scores_from_heap<Index, score_type>(scores[j], top_k[j], top_scores[j]);
   }
   return std::make_tuple(std::move(top_scores), std::move(top_k));
 }

--- a/src/include/test/unit_flat_qv.cc
+++ b/src/include/test/unit_flat_qv.cc
@@ -38,7 +38,7 @@ TEST_CASE("qv test test", "[qv]") {
 }
 
 // @todo: test with tdbMatrix
-TEST_CASE("flat vq all or nothing", "[flat vq]") {
+TEST_CASE("flat qv all or nothing", "[flat vq]") {
   auto ids = std::vector<size_t>(sift_base.num_cols());
   std::iota(ids.rbegin(), ids.rend(), 9);
 

--- a/src/include/test/unit_ivf_index.cc
+++ b/src/include/test/unit_ivf_index.cc
@@ -38,8 +38,6 @@
 #include "../ivf_index.h"
 #include "../linalg.h"
 
-bool global_debug = false;
-
 TEST_CASE("ivf_index: test test", "[ivf_index]") {
   REQUIRE(true);
 }

--- a/src/include/test/unit_ivf_qv.cc
+++ b/src/include/test/unit_ivf_qv.cc
@@ -36,9 +36,6 @@
 #include "detail/linalg/tdb_io.h"
 #include "query_common.h"
 
-bool global_verbose = false;
-bool global_debug = true;
-
 TEST_CASE("qv: test test", "[qv]") {
   REQUIRE(true);
 }

--- a/src/include/test/unit_ivf_qv.cc
+++ b/src/include/test/unit_ivf_qv.cc
@@ -291,7 +291,6 @@ TEST_CASE("ivf qv: finite all or none", "[ivf qv][ci-skip]") {
     CHECK(std::equal(D00.data(), D00.data() + D00.size(), D04.data()));
 
 #if 1
-
     SECTION("dist_qv_finite_ram") {
       auto num_nodes = GENERATE(5 /*, 1,*/);
       std::cout << "num nodes " << num_nodes << std::endl;

--- a/src/include/test/unit_ivf_vq.cc
+++ b/src/include/test/unit_ivf_vq.cc
@@ -37,9 +37,6 @@
 #include "query_common.h"
 #include "utils/utils.h"
 
-bool global_verbose = false;
-bool global_debug = false;
-
 TEST_CASE("vq: test test", "[ivf vq]") {
   REQUIRE(true);
 }

--- a/src/include/test/unit_linalg.cc
+++ b/src/include/test/unit_linalg.cc
@@ -37,8 +37,6 @@
 #include "linalg.h"
 #include "utils/utils.h"
 
-bool global_debug = false;
-
 using TestTypes =
     std::tuple<float, uint8_t, double, int, char, size_t, uint32_t>;
 

--- a/src/include/test/unit_matrix.cc
+++ b/src/include/test/unit_matrix.cc
@@ -34,8 +34,6 @@
 #include <vector>
 #include "detail/linalg/matrix.h"
 
-bool global_debug = false;
-
 using TestTypes = std::tuple<float, double, int, char, size_t, uint32_t>;
 
 TEST_CASE("matrix: test test", "[matrix]") {

--- a/src/include/test/unit_scoring.cc
+++ b/src/include/test/unit_scoring.cc
@@ -38,7 +38,7 @@
 
 #ifdef TILEDB_VS_ENABLE_BLAS
 
-TEST_CASE("defs: vector test", "[defs]") {
+TEST_CASE("scoring: vector test", "[scoring]") {
   std::vector<std::vector<float>> a{
       {1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}};
   std::vector<float> b{0, 0, 0, 0};
@@ -79,22 +79,43 @@ TEST_CASE("defs: vector test", "[defs]") {
 // cosine
 // dot
 // jaccard WIP
-
+using scoring_typelist = std::tuple<
+    std::tuple<float, int, int>,
+    std::tuple<float, unsigned, unsigned>,
+    std::tuple<float, size_t, size_t>,
+    std::tuple<float, unsigned, size_t>,
+    std::tuple<float, int, size_t>,
+    std::tuple<float, size_t, int>>;
 // get_top_k (heap) from scores array
-TEST_CASE("get_top_k (heap) from scores array", "[get_top_k]") {
-  std::vector<float> scores = {8, 6, 7, 5, 3, 0, 9, 1, 2, 4};
+TEMPLATE_LIST_TEST_CASE(
+    "scoring: get_top_k_from_scores vector",
+    "[scoring][get_top_k]",
+    scoring_typelist) {
+  using score_type = std::tuple_element_t<0, TestType>;
+  using index_type = std::tuple_element_t<1, TestType>;
+  // using groundtruth_type = std::tuple_element_t<2, TestType>;
+  std::vector<score_type> scores = {8, 6, 7, 5, 3, 0, 9, 1, 2, 4, 3.14159};
 
-  std::vector<unsigned> top_k(3);
-  get_top_k_from_scores(scores, top_k, 3);
-  CHECK(top_k.size() == 3);
-  CHECK(top_k[0] == 5);  // 0
-  CHECK(top_k[1] == 7);  // 1
-  CHECK(top_k[2] == 8);  // 2
+  std::vector<index_type> top_k(5);
+  get_top_k_from_scores(scores, top_k, 5);
+  CHECK(top_k.size() == 5);
+  CHECK(top_k[0] == 5);   // 0
+  CHECK(top_k[1] == 7);   // 1
+  CHECK(top_k[2] == 8);   // 2
+  CHECK(top_k[3] == 4);   // 3
+  CHECK(top_k[4] == 10);  // 3.14159
 }
 
 // get_top_k (heap) from scores matrix, parallel
-TEST_CASE("get_top_k (heap) from scores matrix, parallel", "[get_top_k]") {
-  ColMajorMatrix<float> scores{
+TEMPLATE_LIST_TEST_CASE(
+    "scoring: get_top_k_from_scores matrix",
+    "[scoring][get_top_k]",
+    scoring_typelist) {
+  using score_type = std::tuple_element_t<0, TestType>;
+  using index_type = std::tuple_element_t<1, TestType>;
+  using groundtruth_type = std::tuple_element_t<2, TestType>;
+
+  ColMajorMatrix<score_type> scores{
       //  0  1  2  3  4  5  6  7  8
       {8, 6, 7, 5, 3, 0, 9, 1, 2},
       {3, 1, 4, 1, 5, 9, 2, 6, 7},
@@ -116,18 +137,18 @@ TEST_CASE("get_top_k (heap) from scores matrix, parallel", "[get_top_k]") {
   // 2 2 3
   // 1 1 3
   // 0 1 1
-  std::vector<unsigned> gt_scores{
+  std::vector<score_type> gt_scores{
       0, 1, 2, 1, 1, 2, 1, 2, 3, 1, 2, 3, 2, 2, 3, 1, 1, 3, 0, 1, 1,
   };
-  std::vector<unsigned> gt_neighbors{
+  std::vector<groundtruth_type> gt_neighbors{
       5, 7, 8, 1, 3, 6, 0, 1, 2, 8, 7, 6, 7, 3, 6, 8, 6, 2, 3, 8, 5,
   };
 
   SECTION("single thread") {
-    auto top_k = get_top_k_from_scores(scores, 3);
+    auto top_k = get_top_k_from_scores<index_type>(scores, 3);
     CHECK(top_k.num_rows() == 3);
     CHECK(top_k.num_cols() == 7);
-    std::vector<unsigned> foo(top_k.data(), top_k.data() + top_k.size());
+    std::vector<index_type> foo(top_k.data(), top_k.data() + top_k.size());
     CHECK(std::equal(begin(gt_neighbors), end(gt_neighbors), top_k.data()));
   }
 // no multithreaded version WIP
@@ -143,9 +164,14 @@ TEST_CASE("get_top_k (heap) from scores matrix, parallel", "[get_top_k]") {
 }
 
 // consolidate scores
-TEST_CASE("scoring consolidate scores", "[scoring]") {
-  std::vector<fixed_min_pair_heap<float, unsigned>> scores00{
-      fixed_min_pair_heap<float, unsigned>(
+TEMPLATE_LIST_TEST_CASE(
+    "scoring: consolidate scores", "[scoring]", scoring_typelist) {
+  using score_type = std::tuple_element_t<0, TestType>;
+  using index_type = std::tuple_element_t<1, TestType>;
+  // using groundtruth_type = std::tuple_element_t<2, TestType>;
+
+  std::vector<fixed_min_pair_heap<score_type, index_type>> scores00{
+      fixed_min_pair_heap<score_type, index_type>(
           3,
           {
               {0.1, 0},
@@ -154,7 +180,7 @@ TEST_CASE("scoring consolidate scores", "[scoring]") {
               {0.4, 3},
               {0.5, 4},
           }),
-      fixed_min_pair_heap<float, unsigned>(
+      fixed_min_pair_heap<score_type, index_type>(
           3,
           {
               {0.9, 0},
@@ -163,7 +189,7 @@ TEST_CASE("scoring consolidate scores", "[scoring]") {
               {0.6, 3},
               {0.5, 4},
           }),
-      fixed_min_pair_heap<float, unsigned>(
+      fixed_min_pair_heap<score_type, index_type>(
           3,
           {
               {0.6, 5},
@@ -172,7 +198,7 @@ TEST_CASE("scoring consolidate scores", "[scoring]") {
               {0.9, 8},
               {1.0, 9},
           }),
-      fixed_min_pair_heap<float, unsigned>(
+      fixed_min_pair_heap<score_type, index_type>(
           3,
           {
               {0.4, 5},
@@ -182,8 +208,8 @@ TEST_CASE("scoring consolidate scores", "[scoring]") {
               {0.0, 9},
           }),
   };
-  std::vector<fixed_min_pair_heap<float, unsigned>> scores01{
-      fixed_min_pair_heap<float, unsigned>(
+  std::vector<fixed_min_pair_heap<score_type, index_type>> scores01{
+      fixed_min_pair_heap<score_type, index_type>(
           3,
           {
               {0.1, 4},
@@ -192,7 +218,7 @@ TEST_CASE("scoring consolidate scores", "[scoring]") {
               {0.4, 7},
               {0.5, 8},
           }),
-      fixed_min_pair_heap<float, unsigned>(
+      fixed_min_pair_heap<score_type, index_type>(
           3,
           {
               {0.6, 4},
@@ -201,7 +227,7 @@ TEST_CASE("scoring consolidate scores", "[scoring]") {
               {0.9, 7},
               {1.0, 8},
           }),
-      fixed_min_pair_heap<float, unsigned>(
+      fixed_min_pair_heap<score_type, index_type>(
           3,
           {
               {0.9, 0},
@@ -210,7 +236,7 @@ TEST_CASE("scoring consolidate scores", "[scoring]") {
               {0.6, 3},
               {0.5, 4},
           }),
-      fixed_min_pair_heap<float, unsigned>(
+      fixed_min_pair_heap<score_type, index_type>(
           3,
           {
               {0.4, 9},
@@ -220,41 +246,61 @@ TEST_CASE("scoring consolidate scores", "[scoring]") {
               {0.0, 6},
           }),
   };
-  auto scores = std::vector<std::vector<fixed_min_pair_heap<float, unsigned>>>{
-      scores00, scores01};
+  auto scores =
+      std::vector<std::vector<fixed_min_pair_heap<score_type, index_type>>>{
+          scores00, scores01};
   CHECK(scores.size() == 2);
   consolidate_scores(scores);
   CHECK(scores.size() == 2);
   auto s = scores[0];
-  CHECK(s.size() == 4);
-  for (auto&& j : s) {
-    std::sort_heap(j.begin(), j.end());
+  CHECK(size(s) == 4);
+  for (auto& j : s) {
+    std::sort_heap(begin(j), end(j));
   }
+
+  CHECK(size(s[0]) == 3);
+  CHECK(size(s[1]) == 3);
+  CHECK(size(s[2]) == 3);
+  CHECK(size(s[3]) == 3);
   CHECK(std::equal(
       begin(s[0]),
       end(s[0]),
-      std::vector<std::tuple<float, unsigned>>({{0.1, 0}, {0.1, 4}, {0.2, 5}})
+      std::vector<std::tuple<score_type, index_type>>(
+          {{0.1, 0}, {0.1, 4}, {0.2, 1}})
           .begin()));
   CHECK(std::equal(
       begin(s[1]),
       end(s[1]),
-      std::vector<std::tuple<float, unsigned>>({{0.2, 5}, {0.5, 4}, {0.6, 4}})
+      std::vector<std::tuple<score_type, index_type>>(
+          {{0.2, 5}, {0.5, 4}, {0.6, 4}})
           .begin()));
   CHECK(std::equal(
       begin(s[2]),
       end(s[2]),
-      std::vector<std::tuple<float, unsigned>>({{0.5, 4}, {0.6, 3}, {0.6, 5}})
+      std::vector<std::tuple<score_type, index_type>>(
+          {{0.5, 4}, {0.6, 3}, {0.6, 5}})
           .begin()));
   CHECK(std::equal(
       begin(s[3]),
       end(s[3]),
-      std::vector<std::tuple<float, unsigned>>({{0.0, 6}, {0.0, 9}, {0.1, 5}})
+      std::vector<std::tuple<score_type, index_type>>(
+          {{0.0, 6}, {0.0, 9}, {0.1, 5}})
           .begin()));
 }
 
-TEST_CASE("scoring get_top_k_from_heap one min_heap", "[scoring]") {
-  fixed_min_pair_heap<float, unsigned> a(
-      5,
+TEMPLATE_LIST_TEST_CASE(
+    "scoring: get_top_k_from_heap one min_heap",
+    "[scoring]",
+    scoring_typelist) {
+  using score_type = std::tuple_element_t<0, TestType>;
+  using index_type = std::tuple_element_t<1, TestType>;
+  using groundtruth_type = std::tuple_element_t<2, TestType>;
+
+  groundtruth_type k_nn = GENERATE(1, 3, 5);
+  groundtruth_type asize = GENERATE(1, 3, 5);
+
+  fixed_min_pair_heap<score_type, index_type> a(
+      asize,
       {
           {10, 0},
           {9, 1},
@@ -267,30 +313,221 @@ TEST_CASE("scoring get_top_k_from_heap one min_heap", "[scoring]") {
           {2, 8},
           {1, 9},
       });
-  std::vector<unsigned> gt_neighbors{
-      9,
-      8,
-      7,
-      6,
-      5,
-  };
+  std::vector<groundtruth_type> gt_neighbors{9, 8, 7, 6, 5, 4, 3, 2, 1};
 
   SECTION("std::vector") {
-    std::vector<unsigned> top_k(5);
+    std::vector<index_type> top_k(k_nn);
     get_top_k_from_heap(a, top_k);
-    CHECK(top_k.size() == 5);
-    CHECK(std::equal(begin(gt_neighbors), end(gt_neighbors), top_k.begin()));
+    REQUIRE(top_k.size() == k_nn);
+    auto l_nn = std::min<size_t>(k_nn, a.size());
+    CHECK(std::equal(
+        begin(gt_neighbors), begin(gt_neighbors) + l_nn, top_k.begin()));
   }
+
   SECTION("std::span") {
-    std::vector<unsigned> top_k(5);
-    get_top_k_from_heap(a, std::span(top_k.data(), 5));
-    CHECK(top_k.size() == 5);
-    CHECK(std::equal(begin(gt_neighbors), end(gt_neighbors), top_k.begin()));
+    std::vector<index_type> top_k(k_nn);
+    get_top_k_from_heap(a, std::span(top_k.data(), k_nn));
+    REQUIRE(top_k.size() == k_nn);
+    auto l_nn = std::min<size_t>(k_nn, a.size());
+    CHECK(std::equal(
+        begin(gt_neighbors), begin(gt_neighbors) + l_nn, top_k.begin()));
+  }
+
+  SECTION("std::vector, pad") {
+    groundtruth_type pad = 2;
+    std::vector<index_type> top_k(k_nn + pad);
+    get_top_k_from_heap(a, top_k);
+    REQUIRE(top_k.size() == k_nn + pad);
+    auto l_nn = std::min<size_t>(k_nn + pad, a.size());
+    CHECK(std::equal(
+        begin(gt_neighbors), begin(gt_neighbors) + l_nn, top_k.begin()));
+    CHECK(end(top_k) == begin(top_k) + k_nn + pad);
+    CHECK(end(top_k) - begin(top_k) == k_nn + pad);
+    CHECK(std::equal(
+        begin(top_k) + l_nn,
+        begin(top_k) + k_nn + pad,
+        std::vector<index_type>(
+            k_nn + pad - l_nn, std::numeric_limits<index_type>::max())
+            .begin()));
+  }
+
+  SECTION("std::span, pad") {
+    groundtruth_type pad = 2;
+    std::vector<index_type> top_k(k_nn + pad);
+    get_top_k_from_heap(a, std::span(top_k.data(), k_nn + pad));
+    REQUIRE(top_k.size() == k_nn + pad);
+    auto l_nn = std::min<size_t>(k_nn + pad, a.size());
+    CHECK(std::equal(
+        begin(gt_neighbors), begin(gt_neighbors) + l_nn, top_k.begin()));
+    CHECK(end(top_k) == begin(top_k) + k_nn + pad);
+    CHECK(end(top_k) - begin(top_k) == k_nn + pad);
+    CHECK(std::equal(
+        begin(top_k) + l_nn,
+        begin(top_k) + k_nn + pad,
+        std::vector<index_type>(
+            k_nn + pad - l_nn, std::numeric_limits<index_type>::max())
+            .begin()));
   }
 }
 
-TEST_CASE("scoring get_top_k_from_heap vector of min_heap", "[scoring]") {
-  fixed_min_pair_heap<float, unsigned> a(
+TEMPLATE_LIST_TEST_CASE("scoring: get_top_k", "[scoring]", scoring_typelist) {
+  using score_type = std::tuple_element_t<0, TestType>;
+  using index_type = std::tuple_element_t<1, TestType>;
+  using groundtruth_type = std::tuple_element_t<2, TestType>;
+
+  groundtruth_type k_nn = GENERATE(1, 3, 5);
+  groundtruth_type asize = GENERATE(1, 3, 5);
+  groundtruth_type bsize = GENERATE(0, 1);
+  size_t num_vectors{2};
+
+  std::vector<fixed_min_pair_heap<score_type, index_type>> scores00{
+      fixed_min_pair_heap<score_type, index_type>(
+          asize,
+          {
+              {0.1, 0},
+              {0.2, 1},
+              {0.3, 2},
+              {0.4, 3},
+              {0.5, 4},
+              {0.6, 5},
+              {0.7, 6},
+              {0.8, 7},
+              {0.9, 8},
+              {1.0, 9},
+          }),
+      fixed_min_pair_heap<score_type, index_type>(
+          asize + bsize,
+          {
+              {0.9, 0},
+              {0.8, 1},
+              {0.7, 2},
+              {0.6, 3},
+              {0.5, 4},
+              {0.4, 5},
+              {0.3, 6},
+              {0.2, 7},
+              {0.1, 8},
+              {0.0, 9},
+          })};
+
+  // Matrix not used
+  ColMajorMatrix<groundtruth_type> gt_neighbors_mat{
+      {0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+      {9, 8, 7, 6, 5, 4, 3, 2, 1, 0},
+  };
+  ColMajorMatrix<score_type> gt_scores_mat{
+      {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0},
+      {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9},
+  };
+
+  SECTION("std::vector get_top_k") {
+    CHECK(size(scores00[0]) == asize);
+    CHECK(size(scores00[1]) == asize + bsize);
+
+    auto top_k = get_top_k(scores00, k_nn);
+
+    for (size_t i = 0; i < num_vectors; ++i) {
+      auto l_nn = std::min<size_t>(top_k[0].size(), scores00[i].size());
+      CHECK(std::equal(
+          begin(gt_neighbors_mat[i]),
+          begin(gt_neighbors_mat[i]) + l_nn,
+          begin(top_k[i])));
+      CHECK(std::equal(
+          begin(top_k[i]) + l_nn,
+          begin(top_k[i]) + k_nn,
+          std::vector<index_type>(
+              k_nn - l_nn, std::numeric_limits<index_type>::max())
+              .begin()));
+    }
+  }
+  SECTION("std::vector get_top_k_with_scores") {
+    CHECK(size(scores00[0]) == asize);
+    CHECK(size(scores00[1]) == asize + bsize);
+
+    auto&& [top_k_scores, top_k] = get_top_k_with_scores(scores00, k_nn);
+
+    for (size_t i = 0; i < num_vectors; ++i) {
+      auto l_nn = std::min<size_t>(top_k[0].size(), scores00[i].size());
+      CHECK(std::equal(
+          begin(gt_neighbors_mat[i]),
+          begin(gt_neighbors_mat[i]) + l_nn,
+          begin(top_k[i])));
+      CHECK(std::equal(
+          begin(top_k[i]) + l_nn,
+          begin(top_k[i]) + k_nn,
+          std::vector<index_type>(
+              k_nn - l_nn, std::numeric_limits<index_type>::max())
+              .begin()));
+      CHECK(std::equal(
+          begin(gt_scores_mat[i]),
+          begin(gt_scores_mat[i]) + l_nn,
+          begin(top_k_scores[i])));
+      CHECK(std::equal(
+          begin(top_k_scores[i]) + l_nn,
+          begin(top_k_scores[i]) + k_nn,
+          std::vector<score_type>(
+              k_nn - l_nn, std::numeric_limits<score_type>::max())
+              .begin()));
+
+    }
+  }
+
+#if 0
+  SECTION("std::span get_top_k") {
+    std::vector<index_type> top_k(k_nn);
+    get_top_k_from_heap(a, std::span(top_k.data(), k_nn));
+    REQUIRE(top_k.size() == k_nn);
+    auto l_nn = std::min<size_t>(k_nn, a.size());
+    CHECK(std::equal(
+        begin(gt_neighbors), begin(gt_neighbors) + l_nn, top_k.begin()));
+  }
+
+  SECTION("std::vector get_top_k, pad") {
+    groundtruth_type pad = 2;
+    std::vector<index_type> top_k(k_nn + pad);
+    get_top_k_from_heap(a, top_k);
+    REQUIRE(top_k.size() == k_nn + pad);
+    auto l_nn = std::min<size_t>(k_nn + pad, a.size());
+    CHECK(std::equal(
+        begin(gt_neighbors), begin(gt_neighbors) + l_nn, top_k.begin()));
+    CHECK(end(top_k) == begin(top_k) + k_nn + pad);
+    CHECK(end(top_k) - begin(top_k) == k_nn + pad);
+    CHECK(std::equal(
+        begin(top_k) + l_nn,
+        begin(top_k) + k_nn + pad,
+        std::vector<index_type>(
+            k_nn + pad - l_nn, std::numeric_limits<index_type>::max())
+            .begin()));
+  }
+
+  SECTION("std::span get_top_k, pad") {
+    groundtruth_type pad = 2;
+    std::vector<index_type> top_k(k_nn + pad);
+    get_top_k_from_heap(a, std::span(top_k.data(), k_nn + pad));
+    REQUIRE(top_k.size() == k_nn + pad);
+    auto l_nn = std::min<size_t>(k_nn + pad, a.size());
+    CHECK(std::equal(
+        begin(gt_neighbors), begin(gt_neighbors) + l_nn, top_k.begin()));
+    CHECK(end(top_k) == begin(top_k) + k_nn + pad);
+    CHECK(end(top_k) - begin(top_k) == k_nn + pad);
+    CHECK(std::equal(
+        begin(top_k) + l_nn,
+        begin(top_k) + k_nn + pad,
+        std::vector<index_type>(
+            k_nn + pad - l_nn, std::numeric_limits<index_type>::max())
+            .begin()));
+  }
+#endif
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "scoring: get_top_k_from_heap vector of min_heap",
+    "[scoring]",
+    scoring_typelist) {
+  using score_type = std::tuple_element_t<0, TestType>;
+  using index_type = std::tuple_element_t<1, TestType>;
+  using groundtruth_type = std::tuple_element_t<2, TestType>;
+  fixed_min_pair_heap<score_type, index_type> a(
       5,
       {
           {10, 0},
@@ -304,7 +541,7 @@ TEST_CASE("scoring get_top_k_from_heap vector of min_heap", "[scoring]") {
           {2, 8},
           {1, 9},
       });
-  fixed_min_pair_heap<float, unsigned> b(
+  fixed_min_pair_heap<score_type, index_type> b(
       5,
       {
           {2, 0},
@@ -318,11 +555,7 @@ TEST_CASE("scoring get_top_k_from_heap vector of min_heap", "[scoring]") {
           {9, 8},
           {0, 9},
       });
-  ColMajorMatrix<unsigned> gt_neighbors_mat{
-      {9, 8, 7, 6, 5},
-      {9, 4, 0, 5, 1},
-  };
-  std::vector<unsigned> gt_neighbors_vec{
+  std::vector<groundtruth_type> gt_neighbors_vec{
       9,
       8,
       7,
@@ -334,11 +567,7 @@ TEST_CASE("scoring get_top_k_from_heap vector of min_heap", "[scoring]") {
       5,
       1,
   };
-  ColMajorMatrix<unsigned> gt_scores_mat{
-      {1, 2, 3, 4, 5},
-      {0, 1, 2, 3, 4},
-  };
-  std::vector<unsigned> gt_scores_vec{
+  std::vector<score_type> gt_scores_vec{
       1,
       2,
       3,
@@ -350,7 +579,17 @@ TEST_CASE("scoring get_top_k_from_heap vector of min_heap", "[scoring]") {
       3,
       4,
   };
-  std::vector<fixed_min_pair_heap<float, unsigned>> scores{a, b};
+
+  // Matrix not used
+  ColMajorMatrix<groundtruth_type> gt_neighbors_mat{
+      {9, 8, 7, 6, 5},
+      {9, 4, 0, 5, 1},
+  };
+  ColMajorMatrix<score_type> gt_scores_mat{
+      {1, 2, 3, 4, 5},
+      {0, 1, 2, 3, 4},
+  };
+  std::vector<fixed_min_pair_heap<score_type, index_type>> scores{a, b};
   SECTION("std::vector") {
     auto top_k = get_top_k(scores, 5);
     CHECK(top_k.num_rows() == 5);
@@ -385,6 +624,53 @@ TEST_CASE("scoring get_top_k_from_heap vector of min_heap", "[scoring]") {
         begin(gt_scores_vec), end(gt_scores_vec), top_scores.data()));
   }
 }
+
+// test pad with sentinel
+TEMPLATE_LIST_TEST_CASE(
+    "scoring: pad_with_sentinels", "[scoring]", scoring_typelist) {
+  using score_type = std::tuple_element_t<0, TestType>;
+  using index_type = std::tuple_element_t<1, TestType>;
+  using groundtruth_type = std::tuple_element_t<2, TestType>;
+
+  auto v = std::vector<index_type>{8, 6, 7, 5, 3, 0, 9, 1, 2, 4, 3};
+  auto w = v;
+  auto x = std::vector<score_type>{
+      3.1, 4.1, 5.9, 2.6, 5.3, 5.8, 9.7, 9.3, 2.3, 8.4, 6.2};
+  auto y = x;
+  groundtruth_type start = GENERATE(1, 3, 9, 11);
+
+  SECTION("top_k") {
+    pad_with_sentinels(start, v);
+    CHECK(std::equal(begin(v), begin(v) + start, begin(w)));
+    CHECK(std::equal(
+        begin(v) + start,
+        end(v),
+        std::vector<index_type>(
+            size(v) - start, std::numeric_limits<index_type>::max())
+            .begin()));
+  }
+  SECTION("top_k_with_scores") {
+    pad_with_sentinels(start, v, x);
+    CHECK(std::equal(begin(v), begin(v) + start, begin(w)));
+    CHECK(std::equal(
+        begin(v) + start,
+        end(v),
+        std::vector<index_type>(
+            size(v) - start, std::numeric_limits<index_type>::max())
+            .begin()));
+
+    CHECK(std::equal(begin(x), begin(x) + start, begin(y)));
+    CHECK(std::equal(
+        begin(x) + start,
+        end(x),
+        std::vector<score_type>(
+            size(x) - start, std::numeric_limits<score_type>::max())
+            .begin()));
+  }
+}
+
+// test get_top_k_from_heap and get_top_k_from_heap_with_scores with padding
+// test get_top_k and get_top_k_with_scores with padding
 
 // get_top_k_from_heap (vector of vectors of min_heaps)
 // get_top_k_with_scores_from_heap (one min_heap)

--- a/src/include/utils/fixed_min_heap.h
+++ b/src/include/utils/fixed_min_heap.h
@@ -109,6 +109,7 @@ class fixed_min_set_heap_2 : public std::vector<T> {
 template <class T, class U>
 class fixed_min_pair_heap : public std::vector<std::tuple<T, U>> {
   using Base = std::vector<std::tuple<T, U>>;
+
   // using Base::Base;
   unsigned max_size{0};
 
@@ -147,6 +148,20 @@ class fixed_min_pair_heap : public std::vector<std::tuple<T, U>> {
     }
   }
 };
+
+template <class Heap>
+struct heap_traits {
+  using value_type = typename Heap::value_type;
+  using score_type = typename std::tuple_element<0, typename Heap::value_type>::type;
+  using index_type = typename std::tuple_element<1, typename Heap::value_type>::type;
+};
+
+template <class Heap>
+using heap_score_t = typename heap_traits<Heap>::score_type;
+
+template <class Heap>
+using heap_index_t = typename heap_traits<Heap>::index_type;
+
 
 // template <class T>
 // using fixed_min_heap = fixed_min_set_heap_1<T>;

--- a/src/include/utils/fixed_min_heap.h
+++ b/src/include/utils/fixed_min_heap.h
@@ -57,11 +57,8 @@ class fixed_min_set_heap_1 : public std::vector<T> {
 
   void insert(T const& x) {
     if (Base::size() < max_size) {
-      Base::push_back(x);
-      // std::push_heap(begin(*this), end(*this), std::less<T>());
-      if (Base::size() == max_size) {
-        std::make_heap(begin(*this), end(*this), std::less<T>());
-      }
+      this->push_back(x);
+      std::push_heap(begin(*this), end(*this), std::less<T>());
     } else if (x < this->front()) {
       std::pop_heap(begin(*this), end(*this), std::less<T>());
       this->pop_back();
@@ -91,12 +88,8 @@ class fixed_min_set_heap_2 : public std::vector<T> {
 
   void insert(T const& x) {
     if (Base::size() < max_size) {
-      Base::push_back(x);
-      // std::push_heap(begin(*this), end(*this), std::less<T>());
-      if (Base::size() == max_size) {
-        // std::make_heap(begin(*this), end(*this), std::less<T>());
-        std::make_heap(begin(*this), end(*this));
-      }
+      this->push_back(x);
+      std::push_heap(begin(*this), end(*this));
     } else if (x < this->front()) {
       // std::pop_heap(begin(*this), end(*this), std::less<T>());
       std::pop_heap(begin(*this), end(*this));
@@ -138,13 +131,10 @@ class fixed_min_pair_heap : public std::vector<std::tuple<T, U>> {
 
   void insert(const T& x, const U& y) {
     if (Base::size() < max_size) {
-      Base::emplace_back(x, y);
-      // std::push_heap(begin(*this), end(*this), std::less<T>());
-      if (Base::size() == max_size) {
-        std::make_heap(begin(*this), end(*this), [&](auto& a, auto& b) {
-          return std::get<0>(a) < std::get<0>(b);
-        });
-      }
+      this->emplace_back(x, y);
+      std::push_heap(begin(*this), end(*this), [&](auto& a, auto& b) {
+        return std::get<0>(a) < std::get<0>(b);
+      });
     } else if (x < std::get<0>(this->front())) {
       std::pop_heap(begin(*this), end(*this), [&](auto& a, auto& b) {
         return std::get<0>(a) < std::get<0>(b);

--- a/src/src/flat_l2.cc
+++ b/src/src/flat_l2.cc
@@ -91,7 +91,6 @@
 
 bool verbose = false;
 bool debug = false;
-bool global_debug = false;
 
 bool enable_stats = false;
 std::vector<json> core_stats;
@@ -144,7 +143,7 @@ int main(int argc, char* argv[]) {
     return 0;
   }
 
-  global_debug = debug = args["--debug"].asBool();
+  // global_debug = debug = args["--debug"].asBool();
   verbose = args["--verbose"].asBool();
   enable_stats = args["--stats"].asBool();
 

--- a/src/src/flat_l2.cc
+++ b/src/src/flat_l2.cc
@@ -171,6 +171,7 @@ int main(int argc, char* argv[]) {
   tiledb::Context ctx;
 
   auto db = tdbColMajorMatrix<db_type>(ctx, db_uri, blocksize);  // blocked
+  db.load();
 
   auto query =
       tdbColMajorMatrix<uint8_t>(ctx, query_uri, nqueries);  // just a slice
@@ -180,7 +181,7 @@ int main(int argc, char* argv[]) {
   std::cout << load_time << std::endl;
 
   // @todo decide on what the type of top_k::value should be
-  auto [top_k, top_k_scores] = [&]() {
+  auto [top_k_scores, top_k] = [&]() {
     if (alg_name == "vq_heap" || alg_name == "vq") {
       if (verbose) {
         std::cout << "# Using vq_heap" << std::endl;

--- a/src/src/index.cc
+++ b/src/src/index.cc
@@ -46,9 +46,6 @@
 #include "linalg.h"
 #include "utils/utils.h"
 
-bool global_verbose = false;
-bool global_debug = false;
-
 bool enable_stats = false;
 std::vector<json> core_stats;
 
@@ -108,8 +105,8 @@ int main(int argc, char* argv[]) {
   if (nthreads == 0) {
     nthreads = std::thread::hardware_concurrency();
   }
-  global_debug = args["--debug"].asBool();
-  global_verbose = args["--verbose"].asBool();
+  // global_debug = args["--debug"].asBool();
+  // global_verbose = args["--verbose"].asBool();
   enable_stats = args["--stats"].asBool();
   bool dryrun = args["--dryrun"].asBool();
 

--- a/src/src/ivf_flat.cc
+++ b/src/src/ivf_flat.cc
@@ -73,8 +73,6 @@
 #include "utils/timer.h"
 #include "utils/utils.h"
 
-bool global_verbose = false;
-bool global_debug = false;
 
 bool enable_stats = false;
 std::vector<json> core_stats;
@@ -144,8 +142,8 @@ int main(int argc, char* argv[]) {
   if (nthreads == 0) {
     nthreads = std::thread::hardware_concurrency();
   }
-  global_debug = args["--debug"].asBool();
-  global_verbose = args["--verbose"].asBool();
+  // global_debug = args["--debug"].asBool();
+  // global_verbose = args["--verbose"].asBool();
   enable_stats = args["--stats"].asBool();
 
   auto part_uri = args["--parts_uri"].asString();
@@ -419,7 +417,7 @@ int main(int argc, char* argv[]) {
         tdbColMajorMatrix<groundtruth_type>(ctx, groundtruth_uri, nqueries);
     groundtruth.load();
 
-    if (global_debug) {
+    if (false) {
       std::cout << std::endl;
 
       debug_matrix(groundtruth, "groundtruth");


### PR DESCRIPTION
- Change `fixed_min_pair_heap` to update a heap even if it is not yet at max size
- Add deterministic (max uint, max float) fill values for empty results
- Initialize `min_scores` with correct `ids_type` from the template