### PR TITLE
Fix missing flat ids

### DIFF
--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -36,12 +36,15 @@ class FlatIndex(Index):
             ctx=self.ctx,
             config=config,
         )
-        self.ids_uri = self.group[
-            storage_formats[self.storage_version]["IDS_ARRAY_NAME"] + self.index_version
-        ].uri
-        if tiledb.array_exists(self.ids_uri, self.ctx):
-            self._ids = read_vector_u64(self.ctx, self.ids_uri, 0, 0)
-        else:
+        try:
+            self.ids_uri = self.group[
+                storage_formats[self.storage_version]["IDS_ARRAY_NAME"] + self.index_version
+            ].uri
+            if tiledb.array_exists(self.ids_uri, self.ctx):
+                self._ids = read_vector_u64(self.ctx, self.ids_uri, 0, 0)
+            else:
+                self._ids = StdVector_u64(np.arange(self.size).astype(np.uint64))
+        except tiledb.TileDBError:
             self._ids = StdVector_u64(np.arange(self.size).astype(np.uint64))
 
         dtype = self.group.meta.get("dtype", None)

--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -36,15 +36,12 @@ class FlatIndex(Index):
             ctx=self.ctx,
             config=config,
         )
-        try:
+        if storage_formats[self.storage_version]["IDS_ARRAY_NAME"] + self.index_version in self.group:
             self.ids_uri = self.group[
                 storage_formats[self.storage_version]["IDS_ARRAY_NAME"] + self.index_version
             ].uri
-            if tiledb.array_exists(self.ids_uri, self.ctx):
-                self._ids = read_vector_u64(self.ctx, self.ids_uri, 0, 0)
-            else:
-                self._ids = StdVector_u64(np.arange(self.size).astype(np.uint64))
-        except tiledb.TileDBError:
+            self._ids = read_vector_u64(self.ctx, self.ids_uri, 0, 0)
+        else:
             self._ids = StdVector_u64(np.arange(self.size).astype(np.uint64))
 
         dtype = self.group.meta.get("dtype", None)

--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -36,6 +36,9 @@ class FlatIndex(Index):
             ctx=self.ctx,
             config=config,
         )
+
+        # Check for existence of ids array. Previous versions were not using external_ids in the ingestion assuming
+        # that the external_ids were the position of the vector in the array.
         if storage_formats[self.storage_version]["IDS_ARRAY_NAME"] + self.index_version in self.group:
             self.ids_uri = self.group[
                 storage_formats[self.storage_version]["IDS_ARRAY_NAME"] + self.index_version


### PR DESCRIPTION
This was causing backwards compatibility issues for old arrays that don't have an ids array.
