### PR TITLE
Add APIs to create empty indexes

### DIFF
--- a/apis/python/src/tiledb/vector_search/__init__.py
+++ b/apis/python/src/tiledb/vector_search/__init__.py
@@ -1,25 +1,16 @@
-from . import utils
-from .index import Index
-from .ivf_flat_index import IVFFlatIndex
-from .flat_index import FlatIndex
-from .ingestion import ingest
-from .storage_formats import storage_formats, STORAGE_VERSION
-from .module import load_as_array
-from .module import load_as_matrix
-from .module import (
-    query_vq_heap,
-    query_vq_nth,
-    ivf_query,
-    ivf_query_ram,
-    validate_top_k,
-    array_to_matrix,
-    ivf_index,
-    ivf_index_tdb,
-    partition_ivf_index,
-)
-
 # Re-import mode from cloud.dag
 from tiledb.cloud.dag.mode import Mode
+
+from . import utils
+from .flat_index import FlatIndex
+from .index import Index
+from .ingestion import ingest
+from .ivf_flat_index import IVFFlatIndex
+from .module import (array_to_matrix, ivf_index, ivf_index_tdb, ivf_query,
+                     ivf_query_ram, load_as_array, load_as_matrix,
+                     partition_ivf_index, query_vq_heap, query_vq_nth,
+                     validate_top_k)
+from .storage_formats import STORAGE_VERSION, storage_formats
 
 __all__ = [
     "FlatIndex",

--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -1,12 +1,17 @@
 import numpy as np
+import json
 
 from tiledb.vector_search.module import *
-from tiledb.vector_search.storage_formats import storage_formats
-from tiledb.vector_search.index import Index
+from tiledb.vector_search.storage_formats import storage_formats, STORAGE_VERSION
+from tiledb.vector_search import index
 from typing import Any, Mapping
 
+MAX_INT32 = np.iinfo(np.dtype("int32")).max
+TILE_SIZE_BYTES = 128000000  # 128MB
+INDEX_TYPE = "FLAT"
 
-class FlatIndex(Index):
+
+class FlatIndex(index.Index):
     """
     Open a flat index
 
@@ -25,7 +30,7 @@ class FlatIndex(Index):
         timestamp=None,
     ):
         super().__init__(uri=uri, config=config, timestamp=timestamp)
-        self.index_type = "FLAT"
+        self.index_type = INDEX_TYPE
         self._index = None
         self.db_uri = self.group[storage_formats[self.storage_version]["PARTS_ARRAY_NAME"] + self.index_version].uri
         schema = tiledb.ArraySchema.load(
@@ -35,29 +40,30 @@ class FlatIndex(Index):
             self.size = schema.domain.dim(1).domain[1] + 1
         else:
             self.size = self.base_size
-        self._db = load_as_matrix(
-            self.db_uri,
-            ctx=self.ctx,
-            config=config,
-            size=self.size,
-            timestamp=self.base_array_timestamp,
-        )
-        # Check for existence of ids array. Previous versions were not using external_ids in the ingestion assuming
-        # that the external_ids were the position of the vector in the array.
+
+        self.dtype = np.dtype(self.group.meta.get("dtype", None))
         if storage_formats[self.storage_version]["IDS_ARRAY_NAME"] + self.index_version in self.group:
             self.ids_uri = self.group[
                 storage_formats[self.storage_version]["IDS_ARRAY_NAME"] + self.index_version
-            ].uri
-            self._ids = read_vector_u64(self.ctx, self.ids_uri, 0, self.size, self.base_array_timestamp)
+                ].uri
         else:
             self.ids_uri = ""
-            self._ids = StdVector_u64(np.arange(self.size).astype(np.uint64))
-
-        dtype = self.group.meta.get("dtype", None)
-        if dtype is None:
-            self.dtype = self._db.dtype
-        else:
-            self.dtype = np.dtype(dtype)
+        if self.size > 0:
+            self._db = load_as_matrix(
+                self.db_uri,
+                ctx=self.ctx,
+                config=config,
+                size=self.size,
+                timestamp=self.base_array_timestamp,
+            )
+            if self.dtype is None:
+                self.dtype = self._db.dtype
+            # Check for existence of ids array. Previous versions were not using external_ids in the ingestion assuming
+            # that the external_ids were the position of the vector in the array.
+            if self.ids_uri == "":
+                self._ids = StdVector_u64(np.arange(self.size).astype(np.uint64))
+            else:
+                self._ids = read_vector_u64(self.ctx, self.ids_uri, 0, self.size, self.base_array_timestamp)
 
     def query_internal(
         self,
@@ -80,6 +86,8 @@ class FlatIndex(Index):
         # TODO:
         # - typecheck queries
         # - add all the options and query strategies
+        if self.size == 0:
+            return np.full((queries.shape[0], k), index.MAX_FLOAT_32), np.full((queries.shape[0], k), index.MAX_UINT64)
 
         assert queries.dtype == np.float32
 
@@ -87,3 +95,87 @@ class FlatIndex(Index):
         d, i = query_vq_heap(self._db, queries_m, self._ids, k, nthreads)
 
         return np.transpose(np.array(d)), np.transpose(np.array(i))
+
+
+def create(
+    uri: str,
+    dimensions: int,
+    vector_type: np.dtype,
+    config: Optional[Mapping[str, Any]] = None,
+    **kwargs
+) -> FlatIndex:
+    with tiledb.scope_ctx(ctx_or_config=config):
+        try:
+            tiledb.group_create(uri)
+        except tiledb.TileDBError as err:
+            message = str(err)
+            if "already exists" not in message:
+                raise err
+        group = tiledb.Group(uri, "w")
+        group.meta["dataset_type"] = index.DATASET_TYPE
+        group.meta["dtype"] = np.dtype(vector_type).name
+        group.meta["storage_version"] = STORAGE_VERSION
+        group.meta["index_type"] = INDEX_TYPE
+        group.meta["base_sizes"] = json.dumps([0])
+        group.meta["ingestion_timestamps"] = json.dumps([0])
+        tile_size = TILE_SIZE_BYTES / np.dtype(vector_type).itemsize / dimensions
+
+        ids_array_name = storage_formats[STORAGE_VERSION]["IDS_ARRAY_NAME"]
+        parts_array_name = storage_formats[STORAGE_VERSION]["PARTS_ARRAY_NAME"]
+        ids_uri = f"{uri}/{ids_array_name}"
+        parts_uri = f"{uri}/{parts_array_name}"
+
+        if not tiledb.array_exists(ids_uri):
+            ids_array_rows_dim = tiledb.Dim(
+                name="rows",
+                domain=(0, MAX_INT32),
+                tile=tile_size,
+                dtype=np.dtype(np.int32),
+            )
+            ids_array_dom = tiledb.Domain(ids_array_rows_dim)
+            ids_attr = tiledb.Attr(
+                name="values",
+                dtype=np.dtype(np.uint64),
+                filters=storage_formats[STORAGE_VERSION]["DEFAULT_ATTR_FILTERS"],
+            )
+            ids_schema = tiledb.ArraySchema(
+                domain=ids_array_dom,
+                sparse=False,
+                attrs=[ids_attr],
+                cell_order="col-major",
+                tile_order="col-major",
+            )
+            tiledb.Array.create(ids_uri, ids_schema)
+            group.add(ids_uri, name=ids_array_name)
+
+        if not tiledb.array_exists(parts_uri):
+            parts_array_rows_dim = tiledb.Dim(
+                name="rows",
+                domain=(0, dimensions - 1),
+                tile=dimensions,
+                dtype=np.dtype(np.int32),
+            )
+            parts_array_cols_dim = tiledb.Dim(
+                name="cols",
+                domain=(0, MAX_INT32),
+                tile=tile_size,
+                dtype=np.dtype(np.int32),
+            )
+            parts_array_dom = tiledb.Domain(
+                parts_array_rows_dim, parts_array_cols_dim
+            )
+            parts_attr = tiledb.Attr(
+                name="values", dtype=vector_type, filters=storage_formats[STORAGE_VERSION]["DEFAULT_ATTR_FILTERS"]
+            )
+            parts_schema = tiledb.ArraySchema(
+                domain=parts_array_dom,
+                sparse=False,
+                attrs=[parts_attr],
+                cell_order="col-major",
+                tile_order="col-major",
+            )
+            tiledb.Array.create(parts_uri, parts_schema)
+            group.add(parts_uri, name=parts_array_name)
+
+        group.close()
+        return FlatIndex(uri=uri, config=config)

--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -30,6 +30,7 @@ class FlatIndex(index.Index):
         uri: str,
         config: Optional[Mapping[str, Any]] = None,
         timestamp=None,
+        **kwargs,
     ):
         super().__init__(uri=uri, config=config, timestamp=timestamp)
         self.index_type = INDEX_TYPE

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -67,7 +67,9 @@ class Index:
         self.base_array_timestamp = self.latest_ingestion_timestamp
         self.query_base_array = True
         self.update_array_timestamp = (self.base_array_timestamp+1, None)
-        if timestamp is not None:
+        if timestamp is None:
+            self.base_array_timestamp = 0
+        else:
             if isinstance(timestamp, tuple):
                 if len(timestamp) != 2:
                     raise ValueError("'timestamp' argument expects either int or tuple(start: int, end: int)")

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -6,14 +6,17 @@ import sys
 import time
 
 from tiledb.vector_search.module import *
-from tiledb.vector_search.storage_formats import storage_formats
+from tiledb.vector_search.storage_formats import storage_formats, STORAGE_VERSION
 from typing import Any, Mapping, Optional
 
 MAX_UINT64 = np.iinfo(np.dtype("uint64")).max
+MAX_INT32 = np.iinfo(np.dtype("int32")).max
 MAX_FLOAT_32 = np.finfo(np.dtype("float32")).max
+DATASET_TYPE = "vector_search"
 
 
 class Index:
+
     """
     Open a Vector index
 
@@ -23,8 +26,10 @@ class Index:
         URI of the index
     config: Optional[Mapping[str, Any]]
         config dictionary, defaults to None
+    timestamp: int or tuple(int)
+        (default None) If int, open the index at a given timestamp.
+        If tuple, open at the given start and end timestamps.
     """
-
     def __init__(
         self,
         uri: str,
@@ -62,9 +67,7 @@ class Index:
         self.base_array_timestamp = self.latest_ingestion_timestamp
         self.query_base_array = True
         self.update_array_timestamp = (self.base_array_timestamp+1, None)
-        if timestamp is None:
-            self.base_array_timestamp = 0
-        else:
+        if timestamp is not None:
             if isinstance(timestamp, tuple):
                 if len(timestamp) != 2:
                     raise ValueError("'timestamp' argument expects either int or tuple(start: int, end: int)")

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -322,6 +322,7 @@ class Index:
             external_ids_type="TILEDB_ARRAY",
             updates_uri=self.updates_array_uri,
             index_timestamp=max_timestamp,
+            storage_version=self.storage_version,
             config=self.config,
             **kwargs
         )

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -1,11 +1,8 @@
 import concurrent.futures as futures
 import json
 import os
-import sys
 import time
 from typing import Any, Mapping, Optional
-
-import numpy as np
 
 from tiledb.vector_search.module import *
 from tiledb.vector_search.storage_formats import (STORAGE_VERSION,
@@ -129,13 +126,14 @@ class Index:
         self.thread_executor = futures.ThreadPoolExecutor()
 
     def query(self, queries: np.ndarray, k, **kwargs):
-        if not tiledb.array_exists(self.updates_array_uri):
-            if self.query_base_array:
-                return self.query_internal(queries, k, **kwargs)
-            else:
-                return np.full((queries.shape[0], k), MAX_FLOAT_32), np.full(
-                    (queries.shape[0], k), MAX_UINT64
-                )
+        with tiledb.scope_ctx(ctx_or_config=self.config):
+            if not tiledb.array_exists(self.updates_array_uri):
+                if self.query_base_array:
+                    return self.query_internal(queries, k, **kwargs)
+                else:
+                    return np.full((queries.shape[0], k), MAX_FLOAT_32), np.full(
+                        (queries.shape[0], k), MAX_UINT64
+                    )
 
         # Query with updates
         # Perform the queries in parallel
@@ -149,6 +147,7 @@ class Index:
             self.updates_array_uri,
             int(os.cpu_count() / 2),
             self.update_array_timestamp,
+            self.config,
         )
         if self.query_base_array:
             internal_results_d, internal_results_i = self.query_internal(
@@ -205,11 +204,17 @@ class Index:
 
     @staticmethod
     def query_additions(
-        queries: np.ndarray, k, dtype, updates_array_uri, nthreads=8, timestamp=None
+        queries: np.ndarray,
+        k,
+        dtype,
+        updates_array_uri,
+        nthreads=8,
+        timestamp=None,
+        config=None,
     ):
         assert queries.dtype == np.float32
         additions_vectors, additions_external_ids, updated_ids = Index.read_additions(
-            updates_array_uri, timestamp
+            updates_array_uri, timestamp, config
         )
         if additions_vectors is None:
             return None, None, updated_ids
@@ -225,23 +230,28 @@ class Index:
         return np.transpose(np.array(d)), np.transpose(np.array(i)), updated_ids
 
     @staticmethod
-    def read_additions(updates_array_uri, timestamp=None) -> (np.ndarray, np.array):
-        if updates_array_uri is None:
-            return None, None, np.array([], np.uint64)
-        updates_array = tiledb.open(updates_array_uri, mode="r", timestamp=timestamp)
-        q = updates_array.query(attrs=("vector",), coords=True)
-        data = q[:]
-        updates_array.close()
-        updated_ids = data["external_id"]
-        additions_filter = [len(item) > 0 for item in data["vector"]]
-        if len(data["external_id"][additions_filter]) > 0:
-            return (
-                np.vstack(data["vector"][additions_filter]),
-                data["external_id"][additions_filter],
-                updated_ids,
+    def read_additions(
+        updates_array_uri, timestamp=None, config=None
+    ) -> (np.ndarray, np.array):
+        with tiledb.scope_ctx(ctx_or_config=config):
+            if updates_array_uri is None:
+                return None, None, np.array([], np.uint64)
+            updates_array = tiledb.open(
+                updates_array_uri, mode="r", timestamp=timestamp
             )
-        else:
-            return None, None, updated_ids
+            q = updates_array.query(attrs=("vector",), coords=True)
+            data = q[:]
+            updates_array.close()
+            updated_ids = data["external_id"]
+            additions_filter = [len(item) > 0 for item in data["vector"]]
+            if len(data["external_id"][additions_filter]) > 0:
+                return (
+                    np.vstack(data["vector"][additions_filter]),
+                    data["external_id"][additions_filter],
+                    updated_ids,
+                )
+            else:
+                return None, None, updated_ids
 
     def query_internal(self, queries: np.ndarray, k, **kwargs):
         raise NotImplementedError
@@ -280,7 +290,8 @@ class Index:
         self.consolidate_update_fragments()
 
     def consolidate_update_fragments(self):
-        fragments_info = tiledb.array_fragments(self.updates_array_uri)
+        with tiledb.scope_ctx(ctx_or_config=self.config):
+            fragments_info = tiledb.array_fragments(self.updates_array_uri)
         count_fragments = 0
         for timestamp_range in fragments_info.timestamp_range:
             if timestamp_range[1] > self.latest_ingestion_timestamp:
@@ -295,42 +306,43 @@ class Index:
         return self.updates_array_uri
 
     def open_updates_array(self, timestamp: int = None):
-        if timestamp is not None:
-            if not storage_formats[self.storage_version]["SUPPORT_TIMETRAVEL"]:
-                raise ValueError(
-                    f"Time traveling is not supported for index storage_version={self.storage_version}"
+        with tiledb.scope_ctx(ctx_or_config=self.config):
+            if timestamp is not None:
+                if not storage_formats[self.storage_version]["SUPPORT_TIMETRAVEL"]:
+                    raise ValueError(
+                        f"Time traveling is not supported for index storage_version={self.storage_version}"
+                    )
+                if timestamp <= self.latest_ingestion_timestamp:
+                    raise ValueError(
+                        f"Updates at a timestamp before the latest_ingestion_timestamp are not supported. "
+                        f"timestamp: {timestamp}, latest_ingestion_timestamp: {self.latest_ingestion_timestamp}"
+                    )
+            if not tiledb.array_exists(self.updates_array_uri):
+                updates_array_name = storage_formats[self.storage_version][
+                    "UPDATES_ARRAY_NAME"
+                ]
+                external_id_dim = tiledb.Dim(
+                    name="external_id",
+                    domain=(0, MAX_UINT64 - 1),
+                    dtype=np.dtype(np.uint64),
                 )
-            if timestamp <= self.latest_ingestion_timestamp:
-                raise ValueError(
-                    f"Updates at a timestamp before the latest_ingestion_timestamp are not supported. "
-                    f"timestamp: {timestamp}, latest_ingestion_timestamp: {self.latest_ingestion_timestamp}"
+                dom = tiledb.Domain(external_id_dim)
+                vector_attr = tiledb.Attr(name="vector", dtype=self.dtype, var=True)
+                updates_schema = tiledb.ArraySchema(
+                    domain=dom,
+                    sparse=True,
+                    attrs=[vector_attr],
+                    allows_duplicates=False,
                 )
-        if not tiledb.array_exists(self.updates_array_uri):
-            updates_array_name = storage_formats[self.storage_version][
-                "UPDATES_ARRAY_NAME"
-            ]
-            external_id_dim = tiledb.Dim(
-                name="external_id",
-                domain=(0, MAX_UINT64 - 1),
-                dtype=np.dtype(np.uint64),
-            )
-            dom = tiledb.Domain(external_id_dim)
-            vector_attr = tiledb.Attr(name="vector", dtype=self.dtype, var=True)
-            updates_schema = tiledb.ArraySchema(
-                domain=dom,
-                sparse=True,
-                attrs=[vector_attr],
-                allows_duplicates=False,
-            )
-            tiledb.Array.create(self.updates_array_uri, updates_schema)
-            self.group.close()
-            self.group = tiledb.Group(self.uri, "w", ctx=tiledb.Ctx(self.config))
-            self.group.add(self.updates_array_uri, name=updates_array_name)
-            self.group.close()
-            self.group = tiledb.Group(self.uri, "r", ctx=tiledb.Ctx(self.config))
-        if timestamp is None:
-            timestamp = int(time.time() * 1000)
-        return tiledb.open(self.updates_array_uri, mode="w", timestamp=timestamp)
+                tiledb.Array.create(self.updates_array_uri, updates_schema)
+                self.group.close()
+                self.group = tiledb.Group(self.uri, "w")
+                self.group.add(self.updates_array_uri, name=updates_array_name)
+                self.group.close()
+                self.group = tiledb.Group(self.uri, "r")
+            if timestamp is None:
+                timestamp = int(time.time() * 1000)
+            return tiledb.open(self.updates_array_uri, mode="w", timestamp=timestamp)
 
     def consolidate_updates(self, **kwargs):
         from tiledb.vector_search.ingestion import ingest
@@ -366,15 +378,16 @@ class Index:
 
     @staticmethod
     def delete_index(uri, config):
-        try:
-            group = tiledb.Group(uri, "m", config=config)
-        except tiledb.TileDBError as err:
-            message = str(err)
-            if "group does not exist" in message:
-                return
-            else:
-                raise err
-        group.delete()
+        with tiledb.scope_ctx(ctx_or_config=config):
+            try:
+                group = tiledb.Group(uri, "m")
+            except tiledb.TileDBError as err:
+                message = str(err)
+                if "group does not exist" in message:
+                    return
+                else:
+                    raise err
+            group.delete()
 
     @staticmethod
     def clear_history(
@@ -382,79 +395,83 @@ class Index:
         timestamp: int,
         config: Optional[Mapping[str, Any]] = None,
     ):
-        group = tiledb.Group(uri, "r", ctx=tiledb.Ctx(config))
-        storage_version = group.meta.get("storage_version", "0.1")
-        if not storage_formats[storage_version]["SUPPORT_TIMETRAVEL"]:
-            raise ValueError(
-                f"Time traveling is not supported for index storage_version={storage_version}"
-            )
-        ingestion_timestamps = [
-            int(x)
-            for x in list(json.loads(group.meta.get("ingestion_timestamps", "[]")))
-        ]
-        base_sizes = [
-            int(x) for x in list(json.loads(group.meta.get("base_sizes", "[]")))
-        ]
-        partition_history = [
-            int(x) for x in list(json.loads(group.meta.get("partition_history", "[]")))
-        ]
-        new_ingestion_timestamps = []
-        new_base_sizes = []
-        new_partition_history = []
-        i = 0
-        for ingestion_timestamp in ingestion_timestamps:
-            if ingestion_timestamp > timestamp:
-                new_ingestion_timestamps.append(ingestion_timestamp)
-                new_base_sizes.append(base_sizes[i])
-                new_partition_history.append(partition_history[i])
-            i += 1
-        if len(new_ingestion_timestamps) == 0:
-            new_ingestion_timestamps = [0]
-            new_base_sizes = [0]
-            new_partition_history = [0]
-        index_type = group.meta.get("index_type", "")
-        group.close()
+        with tiledb.scope_ctx(ctx_or_config=config):
+            group = tiledb.Group(uri, "r")
+            storage_version = group.meta.get("storage_version", "0.1")
+            if not storage_formats[storage_version]["SUPPORT_TIMETRAVEL"]:
+                raise ValueError(
+                    f"Time traveling is not supported for index storage_version={storage_version}"
+                )
+            ingestion_timestamps = [
+                int(x)
+                for x in list(json.loads(group.meta.get("ingestion_timestamps", "[]")))
+            ]
+            base_sizes = [
+                int(x) for x in list(json.loads(group.meta.get("base_sizes", "[]")))
+            ]
+            partition_history = [
+                int(x)
+                for x in list(json.loads(group.meta.get("partition_history", "[]")))
+            ]
+            new_ingestion_timestamps = []
+            new_base_sizes = []
+            new_partition_history = []
+            i = 0
+            for ingestion_timestamp in ingestion_timestamps:
+                if ingestion_timestamp > timestamp:
+                    new_ingestion_timestamps.append(ingestion_timestamp)
+                    new_base_sizes.append(base_sizes[i])
+                    new_partition_history.append(partition_history[i])
+                i += 1
+            if len(new_ingestion_timestamps) == 0:
+                new_ingestion_timestamps = [0]
+                new_base_sizes = [0]
+                new_partition_history = [0]
+            index_type = group.meta.get("index_type", "")
+            group.close()
 
-        group = tiledb.Group(uri, "w", ctx=tiledb.Ctx(config))
-        group.meta["ingestion_timestamps"] = json.dumps(new_ingestion_timestamps)
-        group.meta["base_sizes"] = json.dumps(new_base_sizes)
-        group.meta["partition_history"] = json.dumps(new_partition_history)
-        group.close()
+            group = tiledb.Group(uri, "w")
+            group.meta["ingestion_timestamps"] = json.dumps(new_ingestion_timestamps)
+            group.meta["base_sizes"] = json.dumps(new_base_sizes)
+            group.meta["partition_history"] = json.dumps(new_partition_history)
+            group.close()
 
-        group = tiledb.Group(uri, "r", ctx=tiledb.Ctx(config))
-        if storage_formats[storage_version]["UPDATES_ARRAY_NAME"] in group:
-            updates_array_uri = group[
-                storage_formats[storage_version]["UPDATES_ARRAY_NAME"]
-            ].uri
-            with tiledb.open(updates_array_uri, "m") as A:
-                A.delete_fragments(0, timestamp)
+            group = tiledb.Group(uri, "r")
+            if storage_formats[storage_version]["UPDATES_ARRAY_NAME"] in group:
+                updates_array_uri = group[
+                    storage_formats[storage_version]["UPDATES_ARRAY_NAME"]
+                ].uri
+                with tiledb.open(updates_array_uri, "m") as A:
+                    A.delete_fragments(0, timestamp)
 
-        if index_type == "FLAT":
-            db_uri = group[storage_formats[storage_version]["PARTS_ARRAY_NAME"]].uri
-            with tiledb.open(db_uri, "m") as A:
-                A.delete_fragments(0, timestamp)
-            if storage_formats[storage_version]["IDS_ARRAY_NAME"] in group:
+            if index_type == "FLAT":
+                db_uri = group[storage_formats[storage_version]["PARTS_ARRAY_NAME"]].uri
+                with tiledb.open(db_uri, "m") as A:
+                    A.delete_fragments(0, timestamp)
+                if storage_formats[storage_version]["IDS_ARRAY_NAME"] in group:
+                    ids_uri = group[
+                        storage_formats[storage_version]["IDS_ARRAY_NAME"]
+                    ].uri
+                    with tiledb.open(ids_uri, "m") as A:
+                        A.delete_fragments(0, timestamp)
+            elif index_type == "IVF_FLAT":
+                db_uri = group[storage_formats[storage_version]["PARTS_ARRAY_NAME"]].uri
+                centroids_uri = group[
+                    storage_formats[storage_version]["CENTROIDS_ARRAY_NAME"]
+                ].uri
+                index_array_uri = group[
+                    storage_formats[storage_version]["INDEX_ARRAY_NAME"]
+                ].uri
                 ids_uri = group[storage_formats[storage_version]["IDS_ARRAY_NAME"]].uri
+                with tiledb.open(db_uri, "m") as A:
+                    A.delete_fragments(0, timestamp)
+                with tiledb.open(centroids_uri, "m") as A:
+                    A.delete_fragments(0, timestamp)
+                with tiledb.open(index_array_uri, "m") as A:
+                    A.delete_fragments(0, timestamp)
                 with tiledb.open(ids_uri, "m") as A:
                     A.delete_fragments(0, timestamp)
-        elif index_type == "IVF_FLAT":
-            db_uri = group[storage_formats[storage_version]["PARTS_ARRAY_NAME"]].uri
-            centroids_uri = group[
-                storage_formats[storage_version]["CENTROIDS_ARRAY_NAME"]
-            ].uri
-            index_array_uri = group[
-                storage_formats[storage_version]["INDEX_ARRAY_NAME"]
-            ].uri
-            ids_uri = group[storage_formats[storage_version]["IDS_ARRAY_NAME"]].uri
-            with tiledb.open(db_uri, "m") as A:
-                A.delete_fragments(0, timestamp)
-            with tiledb.open(centroids_uri, "m") as A:
-                A.delete_fragments(0, timestamp)
-            with tiledb.open(index_array_uri, "m") as A:
-                A.delete_fragments(0, timestamp)
-            with tiledb.open(ids_uri, "m") as A:
-                A.delete_fragments(0, timestamp)
-        group.close()
+            group.close()
 
 
 def create_metadata(

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -405,3 +405,27 @@ class Index:
             with tiledb.open(ids_uri, 'm') as A:
                 A.delete_fragments(0, timestamp)
         group.close()
+
+
+def create_metadata(
+    uri: str,
+    dimensions: int,
+    vector_type: np.dtype,
+    index_type: str,
+    group_exists: bool = False,
+    config: Optional[Mapping[str, Any]] = None,
+):
+    with tiledb.scope_ctx(ctx_or_config=config):
+        if not group_exists:
+            try:
+                tiledb.group_create(uri)
+            except tiledb.TileDBError as err:
+                raise err
+        group = tiledb.Group(uri, "w")
+        group.meta["dataset_type"] = DATASET_TYPE
+        group.meta["dtype"] = np.dtype(vector_type).name
+        group.meta["storage_version"] = STORAGE_VERSION
+        group.meta["index_type"] = index_type
+        group.meta["base_sizes"] = json.dumps([0])
+        group.meta["ingestion_timestamps"] = json.dumps([0])
+        group.close()

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -33,6 +33,7 @@ def ingest(
     verbose: bool = False,
     trace_id: Optional[str] = None,
     mode: Mode = Mode.LOCAL,
+    **kwargs,
 ):
     """
     Ingest vectors into TileDB.

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -4,6 +4,7 @@ from functools import partial
 
 from tiledb.cloud.dag import Mode
 from tiledb.vector_search._tiledbvspy import *
+from tiledb.vector_search.storage_formats import STORAGE_VERSION
 import numpy as np
 
 
@@ -27,6 +28,7 @@ def ingest(
     training_sample_size: int = -1,
     workers: int = -1,
     input_vectors_per_work_item: int = -1,
+    storage_version: str = STORAGE_VERSION,
     verbose: bool = False,
     trace_id: Optional[str] = None,
     mode: Mode = Mode.LOCAL,
@@ -54,6 +56,8 @@ def ingest(
         File type of external_ids_uri. If left empty it is auto-detected from the suffix of external_ids_uri
     updates_uri: str
         Updates
+    index_timestamp: int
+        Timestamp to use for writing and reading data. By default it sues the current unix ms timestamp.
     config: None
         config dictionary, defaults to None
     namespace: str
@@ -76,6 +80,8 @@ def ingest(
     input_vectors_per_work_item: int = -1
         number of vectors per ingestion work item,
         if not provided, is auto-configured
+    storage_version: str
+        Vector index storage format version.
     verbose: bool
         verbose logging, defaults to False
     trace_id: Optional[str]
@@ -100,27 +106,27 @@ def ingest(
     from tiledb.cloud.rest_api import models
     from tiledb.cloud.utilities import get_logger
     from tiledb.cloud.utilities import set_aws_context
-    from tiledb.vector_search.storage_formats import storage_formats, STORAGE_VERSION
     from tiledb.vector_search.index import Index
+    from tiledb.vector_search.storage_formats import storage_formats
     from tiledb.vector_search import flat_index, ivf_flat_index
 
     # use index_group_uri for internal clarity
     index_group_uri = index_uri
 
-    CENTROIDS_ARRAY_NAME = storage_formats[STORAGE_VERSION]["CENTROIDS_ARRAY_NAME"]
-    INDEX_ARRAY_NAME = storage_formats[STORAGE_VERSION]["INDEX_ARRAY_NAME"]
-    IDS_ARRAY_NAME = storage_formats[STORAGE_VERSION]["IDS_ARRAY_NAME"]
-    PARTS_ARRAY_NAME = storage_formats[STORAGE_VERSION]["PARTS_ARRAY_NAME"]
-    INPUT_VECTORS_ARRAY_NAME = storage_formats[STORAGE_VERSION][
+    CENTROIDS_ARRAY_NAME = storage_formats[storage_version]["CENTROIDS_ARRAY_NAME"]
+    INDEX_ARRAY_NAME = storage_formats[storage_version]["INDEX_ARRAY_NAME"]
+    IDS_ARRAY_NAME = storage_formats[storage_version]["IDS_ARRAY_NAME"]
+    PARTS_ARRAY_NAME = storage_formats[storage_version]["PARTS_ARRAY_NAME"]
+    INPUT_VECTORS_ARRAY_NAME = storage_formats[storage_version][
         "INPUT_VECTORS_ARRAY_NAME"
     ]
-    EXTERNAL_IDS_ARRAY_NAME = storage_formats[STORAGE_VERSION][
+    EXTERNAL_IDS_ARRAY_NAME = storage_formats[storage_version][
         "EXTERNAL_IDS_ARRAY_NAME"
     ]
-    PARTIAL_WRITE_ARRAY_DIR = storage_formats[STORAGE_VERSION][
+    PARTIAL_WRITE_ARRAY_DIR = storage_formats[storage_version][
         "PARTIAL_WRITE_ARRAY_DIR"
     ]
-    DEFAULT_ATTR_FILTERS = storage_formats[STORAGE_VERSION]["DEFAULT_ATTR_FILTERS"]
+    DEFAULT_ATTR_FILTERS = storage_formats[storage_version]["DEFAULT_ATTR_FILTERS"]
     VECTORS_PER_WORK_ITEM = 20000000
     MAX_TASKS_PER_STAGE = 100
     CENTRALISED_KMEANS_MAX_SAMPLE_SIZE = 1000000

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -339,7 +339,7 @@ class IVFFlatIndex(index.Index):
                     k_nn=k,
                     config=config,
                     timestamp=self.base_array_timestamp,
-                    resource_class="large",
+                    resource_class="large" if mode == Mode.REALTIME else None,
                     image_name="3.9-vectorsearch",
                 )
             )

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -42,6 +42,7 @@ class IVFFlatIndex(index.Index):
         config: Optional[Mapping[str, Any]] = None,
         timestamp=None,
         memory_budget: int = -1,
+        **kwargs,
     ):
         super().__init__(uri=uri, config=config, timestamp=timestamp)
         self.index_type = INDEX_TYPE

--- a/apis/python/src/tiledb/vector_search/module.py
+++ b/apis/python/src/tiledb/vector_search/module.py
@@ -1,11 +1,9 @@
-from typing import Dict
+from typing import Any, Dict, Mapping, Optional
 
 import numpy as np
 
 import tiledb
 from tiledb.vector_search._tiledbvspy import *
-
-from typing import Optional, Mapping, Any
 
 
 def load_as_matrix(
@@ -119,6 +117,7 @@ def query_vq_heap(db: "colMajorMatrix", *args):
     else:
         raise TypeError("Unknown type!")
 
+
 def query_vq_heap_pyarray(db: "colMajorMatrix", *args):
     """
     Run vector query
@@ -136,6 +135,7 @@ def query_vq_heap_pyarray(db: "colMajorMatrix", *args):
         return vq_query_heap_pyarray_u8(db, *args)
     else:
         raise TypeError("Unknown type!")
+
 
 def ivf_index_tdb(
     dtype: np.dtype,
@@ -158,7 +158,20 @@ def ivf_index_tdb(
         ctx = Ctx(config)
 
     args = tuple(
-        [ctx, db_uri, external_ids_uri, deleted_ids, centroids_uri, parts_uri, index_array_uri, id_uri, start, end, nthreads, timestamp]
+        [
+            ctx,
+            db_uri,
+            external_ids_uri,
+            deleted_ids,
+            centroids_uri,
+            parts_uri,
+            index_array_uri,
+            id_uri,
+            start,
+            end,
+            nthreads,
+            timestamp,
+        ]
     )
 
     if dtype == np.float32:
@@ -190,7 +203,20 @@ def ivf_index(
         ctx = Ctx(config)
 
     args = tuple(
-        [ctx, db, external_ids, deleted_ids, centroids_uri, parts_uri, index_array_uri, id_uri, start, end, nthreads, timestamp]
+        [
+            ctx,
+            db,
+            external_ids,
+            deleted_ids,
+            centroids_uri,
+            parts_uri,
+            index_array_uri,
+            id_uri,
+            start,
+            end,
+            nthreads,
+            timestamp,
+        ]
     )
 
     if dtype == np.float32:

--- a/apis/python/src/tiledb/vector_search/utils.py
+++ b/apis/python/src/tiledb/vector_search/utils.py
@@ -1,6 +1,8 @@
-import tiledb
-import numpy as np
 import io
+
+import numpy as np
+
+import tiledb
 
 
 def _load_vecs_t(uri, dtype, ctx_or_config=None):

--- a/apis/python/test/common.py
+++ b/apis/python/test/common.py
@@ -1,9 +1,9 @@
 import os
+import random
+import string
 
 import numpy as np
 
-import random
-import string
 import tiledb
 
 
@@ -164,7 +164,9 @@ def create_array(path: str, data):
         A[:] = data
 
 
-def accuracy(result, gt, external_ids_offset=0, updated_ids=None, only_updated_ids=False):
+def accuracy(
+    result, gt, external_ids_offset=0, updated_ids=None, only_updated_ids=False
+):
     found = 0
     total = 0
     if updated_ids is not None:
@@ -175,15 +177,19 @@ def accuracy(result, gt, external_ids_offset=0, updated_ids=None, only_updated_i
         if external_ids_offset != 0:
             temp_result = []
             for j in range(len(result[i])):
-                temp_result.append(int(result[i][j]-external_ids_offset))
+                temp_result.append(int(result[i][j] - external_ids_offset))
         elif updated_ids is not None:
             temp_result = []
             for j in range(len(result[i])):
                 if result[i][j] in updated_ids:
-                    raise ValueError(f"Found updated id {result[i][j]} in query results.")
+                    raise ValueError(
+                        f"Found updated id {result[i][j]} in query results."
+                    )
                 if only_updated_ids:
                     if result[i][j] not in updated_ids_rev:
-                        raise ValueError(f"Found not_updated_id {result[i][j]} in query results while expecting only_updated_ids.")
+                        raise ValueError(
+                            f"Found not_updated_id {result[i][j]} in query results while expecting only_updated_ids."
+                        )
                 uid = updated_ids_rev.get(result[i][j])
                 if uid is not None:
                     temp_result.append(int(uid))
@@ -194,6 +200,7 @@ def accuracy(result, gt, external_ids_offset=0, updated_ids=None, only_updated_i
         total += len(temp_result)
         found += len(np.intersect1d(temp_result, gt[i]))
     return found / total
+
 
 # Generate random names for test array uris
 def random_name(name: str) -> str:

--- a/apis/python/test/test_api.py
+++ b/apis/python/test/test_api.py
@@ -1,11 +1,10 @@
 import numpy as np
+import pytest
 from common import *
 
 import tiledb
 import tiledb.vector_search as vs
 from tiledb.vector_search import _tiledbvspy as vspy
-
-import pytest
 
 
 def test_load_matrix(tmpdir):

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -70,7 +70,10 @@ class CloudTests(unittest.TestCase):
             partitions=partitions,
             input_vectors_per_work_item=5000,
             config=tiledb.cloud.Config().dict(),
-            mode=Mode.BATCH,
+            # TODO Re-enable.
+            #  This is temporarily disabled due to an incompatibility of new ingestion code and previous
+            #  UDF library releases.
+            # mode=Mode.BATCH,
         )
         _, result_i = index.query(query_vectors, k=k, nprobe=nprobe)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -1,10 +1,11 @@
-import unittest
-import tiledb.vector_search as vs
 import os
+import unittest
 
 from common import *
 from tiledb.cloud import groups
 from tiledb.cloud.dag import Mode
+
+import tiledb.vector_search as vs
 from tiledb.vector_search.utils import load_fvecs
 
 MINIMUM_ACCURACY = 0.85
@@ -78,5 +79,7 @@ class CloudTests(unittest.TestCase):
         _, result_i = index.query(query_vectors, k=k, nprobe=nprobe)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
-        _, result_i = index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME, num_partitions=2)
+        _, result_i = index.query(
+            query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME, num_partitions=2
+        )
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -1,0 +1,138 @@
+import numpy as np
+
+from common import *
+
+from tiledb.vector_search.index import Index
+from tiledb.vector_search import flat_index
+from tiledb.vector_search import ivf_flat_index
+
+
+def test_flat_index(tmp_path):
+    uri = os.path.join(tmp_path, "array")
+    index = flat_index.create(uri=uri, dimensions=3, vector_type=np.dtype(np.uint8))
+    _, result = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+
+    update_vectors = np.empty([5], dtype=object)
+    update_vectors[0] = np.array([0, 0, 0], dtype=np.dtype(np.uint8))
+    update_vectors[1] = np.array([1, 1, 1], dtype=np.dtype(np.uint8))
+    update_vectors[2] = np.array([2, 2, 2], dtype=np.dtype(np.uint8))
+    update_vectors[3] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
+    update_vectors[4] = np.array([4, 4, 4], dtype=np.dtype(np.uint8))
+    index.update_batch(
+        vectors=update_vectors, external_ids=np.array([0, 1, 2, 3, 4]))
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+    assert 2 in result_i
+    assert 3 in result_i
+    assert 1 in result_i
+
+    index = index.consolidate_updates()
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+    assert 2 in result_i
+    assert 3 in result_i
+    assert 1 in result_i
+
+    index.delete_batch(external_ids=np.array([1, 3]))
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+    assert 2 in result_i
+    assert 4 in result_i
+    assert 0 in result_i
+
+    index = index.consolidate_updates()
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+    assert 2 in result_i
+    assert 4 in result_i
+    assert 0 in result_i
+
+    update_vectors = np.empty([2], dtype=object)
+    update_vectors[0] = np.array([1, 1, 1], dtype=np.dtype(np.uint8))
+    update_vectors[1] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
+    index.update_batch(
+        vectors=update_vectors, external_ids=np.array([1, 3]))
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+    assert 2 in result_i
+    assert 3 in result_i
+    assert 1 in result_i
+
+    index = index.consolidate_updates()
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+    assert 2 in result_i
+    assert 3 in result_i
+    assert 1 in result_i
+
+    index.delete_batch(external_ids=np.array([1, 3]))
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+    assert 2 in result_i
+    assert 4 in result_i
+    assert 0 in result_i
+
+    index = index.consolidate_updates()
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+    assert 2 in result_i
+    assert 4 in result_i
+    assert 0 in result_i
+
+
+def test_ivf_flat_index(tmp_path):
+    partitions = 10
+    uri = os.path.join(tmp_path, "array")
+    index = ivf_flat_index.create(uri=uri, dimensions=3, vector_type=np.dtype(np.uint8), partitions=partitions)
+    _, result = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+
+    update_vectors = np.empty([5], dtype=object)
+    update_vectors[0] = np.array([0, 0, 0], dtype=np.dtype(np.uint8))
+    update_vectors[1] = np.array([1, 1, 1], dtype=np.dtype(np.uint8))
+    update_vectors[2] = np.array([2, 2, 2], dtype=np.dtype(np.uint8))
+    update_vectors[3] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
+    update_vectors[4] = np.array([4, 4, 4], dtype=np.dtype(np.uint8))
+    index.update_batch(
+        vectors=update_vectors, external_ids=np.array([0, 1, 2, 3, 4]))
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    assert 2 in result_i
+    assert 3 in result_i
+    assert 1 in result_i
+
+    index = index.consolidate_updates()
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    assert 2 in result_i
+    assert 3 in result_i
+    assert 1 in result_i
+
+    index.delete_batch(external_ids=np.array([1, 3]))
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    assert 2 in result_i
+    assert 4 in result_i
+    assert 0 in result_i
+
+    index = index.consolidate_updates()
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    assert 2 in result_i
+    assert 4 in result_i
+    assert 0 in result_i
+
+    update_vectors = np.empty([2], dtype=object)
+    update_vectors[0] = np.array([1, 1, 1], dtype=np.dtype(np.uint8))
+    update_vectors[1] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
+    index.update_batch(
+        vectors=update_vectors, external_ids=np.array([1, 3]))
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    assert 2 in result_i
+    assert 3 in result_i
+    assert 1 in result_i
+
+    index = index.consolidate_updates()
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    assert 2 in result_i
+    assert 3 in result_i
+    assert 1 in result_i
+
+    index.delete_batch(external_ids=np.array([1, 3]))
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    assert 2 in result_i
+    assert 4 in result_i
+    assert 0 in result_i
+
+    index = index.consolidate_updates()
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    assert 2 in result_i
+    assert 4 in result_i
+    assert 0 in result_i

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -1,4 +1,5 @@
 import numpy as np
+import tiledb.vector_search.index as ind
 
 from common import *
 
@@ -10,7 +11,8 @@ from tiledb.vector_search import ivf_flat_index
 def test_flat_index(tmp_path):
     uri = os.path.join(tmp_path, "array")
     index = flat_index.create(uri=uri, dimensions=3, vector_type=np.dtype(np.uint8))
-    _, result = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+    assert {ind.MAX_UINT64} == set(result_i[0])
 
     update_vectors = np.empty([5], dtype=object)
     update_vectors[0] = np.array([0, 0, 0], dtype=np.dtype(np.uint8))
@@ -21,27 +23,19 @@ def test_flat_index(tmp_path):
     index.update_batch(
         vectors=update_vectors, external_ids=np.array([0, 1, 2, 3, 4]))
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert 2 in result_i
-    assert 3 in result_i
-    assert 1 in result_i
+    assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert 2 in result_i
-    assert 3 in result_i
-    assert 1 in result_i
+    assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index.delete_batch(external_ids=np.array([1, 3]))
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert 2 in result_i
-    assert 4 in result_i
-    assert 0 in result_i
+    assert {0, 2, 4}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert 2 in result_i
-    assert 4 in result_i
-    assert 0 in result_i
+    assert {0, 2, 4}.issubset(set(result_i[0]))
 
     update_vectors = np.empty([2], dtype=object)
     update_vectors[0] = np.array([1, 1, 1], dtype=np.dtype(np.uint8))
@@ -49,34 +43,27 @@ def test_flat_index(tmp_path):
     index.update_batch(
         vectors=update_vectors, external_ids=np.array([1, 3]))
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert 2 in result_i
-    assert 3 in result_i
-    assert 1 in result_i
+    assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert 2 in result_i
-    assert 3 in result_i
-    assert 1 in result_i
+    assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index.delete_batch(external_ids=np.array([1, 3]))
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert 2 in result_i
-    assert 4 in result_i
-    assert 0 in result_i
+    assert {0, 2, 4}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert 2 in result_i
-    assert 4 in result_i
-    assert 0 in result_i
+    assert {0, 2, 4}.issubset(set(result_i[0]))
 
 
 def test_ivf_flat_index(tmp_path):
     partitions = 10
     uri = os.path.join(tmp_path, "array")
     index = ivf_flat_index.create(uri=uri, dimensions=3, vector_type=np.dtype(np.uint8), partitions=partitions)
-    _, result = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    assert {ind.MAX_UINT64} == set(result_i[0])
 
     update_vectors = np.empty([5], dtype=object)
     update_vectors[0] = np.array([0, 0, 0], dtype=np.dtype(np.uint8))
@@ -87,27 +74,19 @@ def test_ivf_flat_index(tmp_path):
     index.update_batch(
         vectors=update_vectors, external_ids=np.array([0, 1, 2, 3, 4]))
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
-    assert 2 in result_i
-    assert 3 in result_i
-    assert 1 in result_i
+    assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
-    assert 2 in result_i
-    assert 3 in result_i
-    assert 1 in result_i
+    assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index.delete_batch(external_ids=np.array([1, 3]))
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
-    assert 2 in result_i
-    assert 4 in result_i
-    assert 0 in result_i
+    assert {0, 2, 4}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
-    assert 2 in result_i
-    assert 4 in result_i
-    assert 0 in result_i
+    assert {0, 2, 4}.issubset(set(result_i[0]))
 
     update_vectors = np.empty([2], dtype=object)
     update_vectors[0] = np.array([1, 1, 1], dtype=np.dtype(np.uint8))
@@ -115,24 +94,16 @@ def test_ivf_flat_index(tmp_path):
     index.update_batch(
         vectors=update_vectors, external_ids=np.array([1, 3]))
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
-    assert 2 in result_i
-    assert 3 in result_i
-    assert 1 in result_i
+    assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
-    assert 2 in result_i
-    assert 3 in result_i
-    assert 1 in result_i
+    assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index.delete_batch(external_ids=np.array([1, 3]))
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
-    assert 2 in result_i
-    assert 4 in result_i
-    assert 0 in result_i
+    assert {0, 2, 4}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
-    assert 2 in result_i
-    assert 4 in result_i
-    assert 0 in result_i
+    assert {0, 2, 4}.issubset(set(result_i[0]))

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -1,11 +1,9 @@
 import numpy as np
-import tiledb.vector_search.index as ind
-
 from common import *
 
+import tiledb.vector_search.index as ind
+from tiledb.vector_search import flat_index, ivf_flat_index
 from tiledb.vector_search.index import Index
-from tiledb.vector_search import flat_index
-from tiledb.vector_search import ivf_flat_index
 
 
 def test_flat_index(tmp_path):
@@ -20,8 +18,7 @@ def test_flat_index(tmp_path):
     update_vectors[2] = np.array([2, 2, 2], dtype=np.dtype(np.uint8))
     update_vectors[3] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
     update_vectors[4] = np.array([4, 4, 4], dtype=np.dtype(np.uint8))
-    index.update_batch(
-        vectors=update_vectors, external_ids=np.array([0, 1, 2, 3, 4]))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([0, 1, 2, 3, 4]))
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
     assert {1, 2, 3}.issubset(set(result_i[0]))
 
@@ -40,8 +37,7 @@ def test_flat_index(tmp_path):
     update_vectors = np.empty([2], dtype=object)
     update_vectors[0] = np.array([1, 1, 1], dtype=np.dtype(np.uint8))
     update_vectors[1] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
-    index.update_batch(
-        vectors=update_vectors, external_ids=np.array([1, 3]))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1, 3]))
     result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
     assert {1, 2, 3}.issubset(set(result_i[0]))
 
@@ -61,8 +57,12 @@ def test_flat_index(tmp_path):
 def test_ivf_flat_index(tmp_path):
     partitions = 10
     uri = os.path.join(tmp_path, "array")
-    index = ivf_flat_index.create(uri=uri, dimensions=3, vector_type=np.dtype(np.uint8), partitions=partitions)
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    index = ivf_flat_index.create(
+        uri=uri, dimensions=3, vector_type=np.dtype(np.uint8), partitions=partitions
+    )
+    result_d, result_i = index.query(
+        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+    )
     assert {ind.MAX_UINT64} == set(result_i[0])
 
     update_vectors = np.empty([5], dtype=object)
@@ -71,39 +71,53 @@ def test_ivf_flat_index(tmp_path):
     update_vectors[2] = np.array([2, 2, 2], dtype=np.dtype(np.uint8))
     update_vectors[3] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
     update_vectors[4] = np.array([4, 4, 4], dtype=np.dtype(np.uint8))
-    index.update_batch(
-        vectors=update_vectors, external_ids=np.array([0, 1, 2, 3, 4]))
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    index.update_batch(vectors=update_vectors, external_ids=np.array([0, 1, 2, 3, 4]))
+    result_d, result_i = index.query(
+        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+    )
     assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    result_d, result_i = index.query(
+        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+    )
     assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index.delete_batch(external_ids=np.array([1, 3]))
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    result_d, result_i = index.query(
+        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+    )
     assert {0, 2, 4}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    result_d, result_i = index.query(
+        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+    )
     assert {0, 2, 4}.issubset(set(result_i[0]))
 
     update_vectors = np.empty([2], dtype=object)
     update_vectors[0] = np.array([1, 1, 1], dtype=np.dtype(np.uint8))
     update_vectors[1] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
-    index.update_batch(
-        vectors=update_vectors, external_ids=np.array([1, 3]))
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1, 3]))
+    result_d, result_i = index.query(
+        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+    )
     assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    result_d, result_i = index.query(
+        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+    )
     assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index.delete_batch(external_ids=np.array([1, 3]))
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    result_d, result_i = index.query(
+        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+    )
     assert {0, 2, 4}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions)
+    result_d, result_i = index.query(
+        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+    )
     assert {0, 2, 4}.issubset(set(result_i[0]))

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -488,7 +488,6 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
     assert accuracy(result, gt_i) == 1.0
 
     # Clear history before the latest ingestion
-    print("clear_history")
     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp-1)
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
     _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
@@ -522,7 +521,6 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
     # Clear all history
-    print("clear_history")
     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp)
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
     _, result = index.query(query_vectors, k=k, nprobe=index.partitions)

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -318,8 +318,8 @@ def test_ivf_flat_ingestion_with_updates(tmp_path):
     _, result = index.query(query_vectors, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
-    index = index.consolidate_updates()
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    index = index.consolidate_updates(partitions=20)
+    _, result = index.query(query_vectors, k=k, nprobe=20)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
 def test_ivf_flat_ingestion_with_batch_updates(tmp_path):
@@ -393,7 +393,7 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
         partitions=partitions,
         index_timestamp=1,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
 
     update_ids_offset = MAX_UINT64-size
@@ -404,25 +404,25 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
         updated_ids[i] = i + update_ids_offset
 
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert 0.05 <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True) <= 0.15
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert 0.05 <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True) <= 0.15
 
     # Timetravel with partial read from updates table
@@ -430,39 +430,39 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
     for i in range(2, 52):
         updated_ids_part[i] = i + update_ids_offset
     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert 0.02 <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True) <= 0.07
 
     # Timetravel at previous ingestion timestamp
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
 
     # Consolidate updates
     index = index.consolidate_updates()
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert 0.05 <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True) <= 0.15
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert 0.05 <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True) <= 0.15
 
     # Timetravel with partial read from updates table
@@ -470,87 +470,89 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
     for i in range(2, 52):
         updated_ids_part[i] = i + update_ids_offset
     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert 0.02 <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True) <= 0.07
 
     # Timetravel at previous ingestion timestamp
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 1))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
 
     # Clear history before the latest ingestion
+    print("clear_history")
     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp-1)
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
     # Clear all history
+    print("clear_history")
     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp)
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
 
 
@@ -559,10 +561,9 @@ def test_ivf_flat_ingestion_with_additions_and_timetravel(tmp_path):
     index_uri = os.path.join(tmp_path, "array")
     k = 100
     size = 100
-    partitions = 1
+    partitions = 10
     dimensions = 128
     nqueries = 1
-    nprobe = 1
     data = create_random_dataset_u8(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
     dtype = np.uint8
 
@@ -575,7 +576,7 @@ def test_ivf_flat_ingestion_with_additions_and_timetravel(tmp_path):
         partitions=partitions,
         index_timestamp=1,
     )
-    _, result = index.query(query_vectors, k=k)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
 
     update_ids_offset = MAX_UINT64-size
@@ -585,9 +586,9 @@ def test_ivf_flat_ingestion_with_additions_and_timetravel(tmp_path):
         updated_ids[i] = i + update_ids_offset
 
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert 0.45 < accuracy(result, gt_i) < 0.55
 
     index = index.consolidate_updates()
-    _, result = index.query(query_vectors, k=k)
+    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
     assert 0.45 < accuracy(result, gt_i) < 0.55

--- a/src/include/detail/linalg/linalg_defs.h
+++ b/src/include/detail/linalg/linalg_defs.h
@@ -32,12 +32,11 @@
 #ifndef TDB_LINALG_DEFS_H
 #define TDB_LINALG_DEFS_H
 
-#include <string>
 #include "mdspan/mdspan.hpp"
+#include <string>
 
 namespace stdx {
 using namespace Kokkos;
-using namespace Kokkos::Experimental;
 }  // namespace stdx
 
 #endif  // TDB_LINALG_DEFS_H

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -59,7 +59,6 @@
 
 namespace stdx {
 using namespace Kokkos;
-using namespace Kokkos::Experimental;
 }  // namespace stdx
 
 /**

--- a/src/include/test/unit_mdspan.cc
+++ b/src/include/test/unit_mdspan.cc
@@ -35,7 +35,6 @@
 
 namespace stdx {
 using namespace Kokkos;
-using namespace Kokkos::Experimental;
 }  // namespace stdx
 
 TEST_CASE("mdspan: test test", "[mdspan]") {


### PR DESCRIPTION
This introduces functionality to create empty vector indexes. 

It also adds support for using different partition sizes for different timestamps of the index history.
