### PR TITLE
Fix corner cases for ingestion

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -1775,7 +1775,7 @@ def ingest(
         # TODO remove temp data for tiledb URIs
         if not index_group_uri.startswith("tiledb://"):
             group = tiledb.Group(index_group_uri, "r")
-            if group.__contains__(PARTIAL_WRITE_ARRAY_DIR):
+            if PARTIAL_WRITE_ARRAY_DIR in group:
                 group.close()
                 group = tiledb.Group(index_group_uri, "w")
                 group.remove(PARTIAL_WRITE_ARRAY_DIR)

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -71,7 +71,10 @@ class CloudTests(unittest.TestCase):
             partitions=partitions,
             input_vectors_per_work_item=5000,
             config=tiledb.cloud.Config().dict(),
-            mode=Mode.BATCH,
+            # TODO Re-enable.
+            #  This is temporarily disabled due to an incompatibility of new ingestion code and previous
+            #  UDF library releases.
+            # mode=Mode.BATCH,
         )
         _, result_i = index.query(query_vectors, k=k, nprobe=nprobe)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -71,10 +71,7 @@ class CloudTests(unittest.TestCase):
             partitions=partitions,
             input_vectors_per_work_item=5000,
             config=tiledb.cloud.Config().dict(),
-            # TODO Re-enable.
-            #  This is temporarily disabled due to an incompatibility of new ingestion code and previous
-            #  UDF library releases.
-            # mode=Mode.BATCH,
+            mode=Mode.BATCH,
         )
         _, result_i = index.query(query_vectors, k=k, nprobe=nprobe)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY


### PR DESCRIPTION
This PR fixes the following bugs:
- In the case of multiple batches per ingestion worker, the task_ids were not generated correctly and the udfs failed to write to the correct partial arrays
- After ingestion, the `temp_data` array was deleted but not removed leading to vector index groups that failed to register in cloud. 