### PR TITLE
Replace tests for __APPLE__ with tests for __cpp_lib_smart_ptr_for_overwrite

### DIFF
--- a/src/include/detail/linalg/tdb_matrix.h
+++ b/src/include/detail/linalg/tdb_matrix.h
@@ -183,7 +183,7 @@ class tdbBlockedMatrix : public Matrix<T, LayoutPolicy, I> {
       blocksize_ = upper_bound;
     }
 
-#ifndef __APPLE__
+#ifdef __cpp_lib_smart_ptr_for_overwrite
     auto data_ = std::make_unique_for_overwrite<T[]>(dimension * blocksize_);
 #else
     // auto data_ = std::make_unique<T[]>(new T[mat_rows_ * mat_cols_]);
@@ -341,7 +341,7 @@ class tdbBlockedMatrix : public Matrix<T, LayoutPolicy, I> {
     auto num_rows = row_end - row_begin;
     auto num_cols = col_end - col_begin;
 
-#ifndef __APPLE__
+#ifdef __cpp_lib_smart_ptr_for_overwrite
     auto data_ = std::make_unique_for_overwrite<T[]>(num_rows * num_cols);
 #else
     // auto data_ = std::make_unique<T[]>(new T[mat_rows_ * mat_cols_]);

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -252,7 +252,7 @@ class tdbPartitionedMatrix : public Matrix<T, LayoutPolicy, I> {
       ids_.resize(max_cols_);
     }
 
-#ifndef __APPLE__
+#ifdef __cpp_lib_smart_ptr_for_overwrite
     auto data_ = std::make_unique_for_overwrite<T[]>(dimension * max_cols_);
 #else
     auto data_ = std::unique_ptr<T[]>(new T[dimension * max_cols_]);


### PR DESCRIPTION
This is an extremely small PR that finishes replacing the use of the __APPLE__ macro to properly using C++20 feature testing macros, notably ` __cpp_lib_smart_ptr_for_overwrite`.