### PR TITLE
Run queries twice to test for idempotence

### DIFF
--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -6,7 +6,7 @@ from tiledb.vector_search import flat_index, ivf_flat_index
 from tiledb.vector_search.index import Index
 
 def query_and_check(index, queries, k, expected, **kwargs):
-    for _ in range(5):
+    for _ in range(3):
         result_d, result_i = index.query(queries, k=k, **kwargs)
         assert expected.issubset(set(result_i[0]))
 

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -9,8 +9,9 @@ from tiledb.vector_search.index import Index
 def test_flat_index(tmp_path):
     uri = os.path.join(tmp_path, "array")
     index = flat_index.create(uri=uri, dimensions=3, vector_type=np.dtype(np.uint8))
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert {ind.MAX_UINT64} == set(result_i[0])
+    for _ in range(2):
+        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+        assert {ind.MAX_UINT64} == set(result_i[0])
 
     update_vectors = np.empty([5], dtype=object)
     update_vectors[0] = np.array([0, 0, 0], dtype=np.dtype(np.uint8))
@@ -19,39 +20,47 @@ def test_flat_index(tmp_path):
     update_vectors[3] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
     update_vectors[4] = np.array([4, 4, 4], dtype=np.dtype(np.uint8))
     index.update_batch(vectors=update_vectors, external_ids=np.array([0, 1, 2, 3, 4]))
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert {1, 2, 3}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+        assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert {1, 2, 3}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+        assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index.delete_batch(external_ids=np.array([1, 3]))
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert {0, 2, 4}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+        assert {0, 2, 4}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert {0, 2, 4}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+        assert {0, 2, 4}.issubset(set(result_i[0]))
 
     update_vectors = np.empty([2], dtype=object)
     update_vectors[0] = np.array([1, 1, 1], dtype=np.dtype(np.uint8))
     update_vectors[1] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
     index.update_batch(vectors=update_vectors, external_ids=np.array([1, 3]))
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert {1, 2, 3}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+        assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert {1, 2, 3}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+        assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index.delete_batch(external_ids=np.array([1, 3]))
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert {0, 2, 4}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+        assert {0, 2, 4}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
-    result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-    assert {0, 2, 4}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
+        assert {0, 2, 4}.issubset(set(result_i[0]))
 
 
 def test_ivf_flat_index(tmp_path):
@@ -60,10 +69,11 @@ def test_ivf_flat_index(tmp_path):
     index = ivf_flat_index.create(
         uri=uri, dimensions=3, vector_type=np.dtype(np.uint8), partitions=partitions
     )
-    result_d, result_i = index.query(
-        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-    )
-    assert {ind.MAX_UINT64} == set(result_i[0])
+    for _ in range(2):
+        result_d, result_i = index.query(
+            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+        )
+        assert {ind.MAX_UINT64} == set(result_i[0])
 
     update_vectors = np.empty([5], dtype=object)
     update_vectors[0] = np.array([0, 0, 0], dtype=np.dtype(np.uint8))
@@ -72,52 +82,60 @@ def test_ivf_flat_index(tmp_path):
     update_vectors[3] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
     update_vectors[4] = np.array([4, 4, 4], dtype=np.dtype(np.uint8))
     index.update_batch(vectors=update_vectors, external_ids=np.array([0, 1, 2, 3, 4]))
-    result_d, result_i = index.query(
-        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-    )
-    assert {1, 2, 3}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(
+            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+        )
+        assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
-    result_d, result_i = index.query(
-        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-    )
-    assert {1, 2, 3}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(
+            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+        )
+        assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index.delete_batch(external_ids=np.array([1, 3]))
-    result_d, result_i = index.query(
-        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-    )
-    assert {0, 2, 4}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(
+            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+        )
+        assert {0, 2, 4}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
-    result_d, result_i = index.query(
-        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-    )
-    assert {0, 2, 4}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(
+            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+        )
+        assert {0, 2, 4}.issubset(set(result_i[0]))
 
     update_vectors = np.empty([2], dtype=object)
     update_vectors[0] = np.array([1, 1, 1], dtype=np.dtype(np.uint8))
     update_vectors[1] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
     index.update_batch(vectors=update_vectors, external_ids=np.array([1, 3]))
-    result_d, result_i = index.query(
-        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-    )
-    assert {1, 2, 3}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(
+            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+        )
+        assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
-    result_d, result_i = index.query(
-        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-    )
-    assert {1, 2, 3}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(
+            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+        )
+        assert {1, 2, 3}.issubset(set(result_i[0]))
 
     index.delete_batch(external_ids=np.array([1, 3]))
-    result_d, result_i = index.query(
-        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-    )
-    assert {0, 2, 4}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(
+            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+        )
+        assert {0, 2, 4}.issubset(set(result_i[0]))
 
     index = index.consolidate_updates()
-    result_d, result_i = index.query(
-        np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-    )
-    assert {0, 2, 4}.issubset(set(result_i[0]))
+    for _ in range(2):
+        result_d, result_i = index.query(
+            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
+        )
+        assert {0, 2, 4}.issubset(set(result_i[0]))

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -13,9 +13,7 @@ def query_and_check(index, queries, k, expected, **kwargs):
 def test_flat_index(tmp_path):
     uri = os.path.join(tmp_path, "array")
     index = flat_index.create(uri=uri, dimensions=3, vector_type=np.dtype(np.uint8))
-    for _ in range(2):
-        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-        assert {ind.MAX_UINT64} == set(result_i[0])
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {ind.MAX_UINT64})
 
     update_vectors = np.empty([5], dtype=object)
     update_vectors[0] = np.array([0, 0, 0], dtype=np.dtype(np.uint8))

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -5,6 +5,10 @@ import tiledb.vector_search.index as ind
 from tiledb.vector_search import flat_index, ivf_flat_index
 from tiledb.vector_search.index import Index
 
+def query_and_check(index, queries, k, expected, **kwargs):
+    for _ in range(5):
+        result_d, result_i = index.query(queries, k=k, **kwargs)
+        assert expected.issubset(set(result_i[0]))
 
 def test_flat_index(tmp_path):
     uri = os.path.join(tmp_path, "array")
@@ -20,47 +24,31 @@ def test_flat_index(tmp_path):
     update_vectors[3] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
     update_vectors[4] = np.array([4, 4, 4], dtype=np.dtype(np.uint8))
     index.update_batch(vectors=update_vectors, external_ids=np.array([0, 1, 2, 3, 4]))
-    for _ in range(2):
-        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-        assert {1, 2, 3}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {1, 2, 3})
 
     index = index.consolidate_updates()
-    for _ in range(2):
-        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-        assert {1, 2, 3}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {1, 2, 3})
 
     index.delete_batch(external_ids=np.array([1, 3]))
-    for _ in range(2):
-        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-        assert {0, 2, 4}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {0, 2, 4})
 
     index = index.consolidate_updates()
-    for _ in range(2):
-        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-        assert {0, 2, 4}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {0, 2, 4})
 
     update_vectors = np.empty([2], dtype=object)
     update_vectors[0] = np.array([1, 1, 1], dtype=np.dtype(np.uint8))
     update_vectors[1] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
     index.update_batch(vectors=update_vectors, external_ids=np.array([1, 3]))
-    for _ in range(2):
-        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-        assert {1, 2, 3}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {1, 2, 3})
 
     index = index.consolidate_updates()
-    for _ in range(2):
-        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-        assert {1, 2, 3}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {1, 2, 3})
 
     index.delete_batch(external_ids=np.array([1, 3]))
-    for _ in range(2):
-        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-        assert {0, 2, 4}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {0, 2, 4})
 
     index = index.consolidate_updates()
-    for _ in range(2):
-        result_d, result_i = index.query(np.array([[2, 2, 2]], dtype=np.float32), k=3)
-        assert {0, 2, 4}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {0, 2, 4})
 
 
 def test_ivf_flat_index(tmp_path):
@@ -69,11 +57,7 @@ def test_ivf_flat_index(tmp_path):
     index = ivf_flat_index.create(
         uri=uri, dimensions=3, vector_type=np.dtype(np.uint8), partitions=partitions
     )
-    for _ in range(2):
-        result_d, result_i = index.query(
-            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-        )
-        assert {ind.MAX_UINT64} == set(result_i[0])
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {ind.MAX_UINT64}, nprobe=partitions)
 
     update_vectors = np.empty([5], dtype=object)
     update_vectors[0] = np.array([0, 0, 0], dtype=np.dtype(np.uint8))
@@ -82,60 +66,28 @@ def test_ivf_flat_index(tmp_path):
     update_vectors[3] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
     update_vectors[4] = np.array([4, 4, 4], dtype=np.dtype(np.uint8))
     index.update_batch(vectors=update_vectors, external_ids=np.array([0, 1, 2, 3, 4]))
-    for _ in range(2):
-        result_d, result_i = index.query(
-            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-        )
-        assert {1, 2, 3}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {1, 2, 3}, nprobe=partitions)
 
     index = index.consolidate_updates()
-    for _ in range(2):
-        result_d, result_i = index.query(
-            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-        )
-        assert {1, 2, 3}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {1, 2, 3}, nprobe=partitions)
 
     index.delete_batch(external_ids=np.array([1, 3]))
-    for _ in range(2):
-        result_d, result_i = index.query(
-            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-        )
-        assert {0, 2, 4}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {0, 2, 4}, nprobe=partitions)
 
     index = index.consolidate_updates()
-    for _ in range(2):
-        result_d, result_i = index.query(
-            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-        )
-        assert {0, 2, 4}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {0, 2, 4}, nprobe=partitions)
 
     update_vectors = np.empty([2], dtype=object)
     update_vectors[0] = np.array([1, 1, 1], dtype=np.dtype(np.uint8))
     update_vectors[1] = np.array([3, 3, 3], dtype=np.dtype(np.uint8))
     index.update_batch(vectors=update_vectors, external_ids=np.array([1, 3]))
-    for _ in range(2):
-        result_d, result_i = index.query(
-            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-        )
-        assert {1, 2, 3}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {1, 2, 3}, nprobe=partitions)
 
     index = index.consolidate_updates()
-    for _ in range(2):
-        result_d, result_i = index.query(
-            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-        )
-        assert {1, 2, 3}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {1, 2, 3}, nprobe=partitions)
 
     index.delete_batch(external_ids=np.array([1, 3]))
-    for _ in range(2):
-        result_d, result_i = index.query(
-            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-        )
-        assert {0, 2, 4}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {0, 2, 4}, nprobe=partitions)
 
     index = index.consolidate_updates()
-    for _ in range(2):
-        result_d, result_i = index.query(
-            np.array([[2, 2, 2]], dtype=np.float32), k=3, nprobe=partitions
-        )
-        assert {0, 2, 4}.issubset(set(result_i[0]))
+    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {0, 2, 4}, nprobe=partitions)


### PR DESCRIPTION
### What
Adds tests for the idempotence of `query()` to address [https://app.shortcut.com/tiledb-inc/story/32367/add-tests-for-query-idempotence](https://app.shortcut.com/tiledb-inc/story/32367/add-tests-for-query-idempotence). There is not much of a speed difference from repeating `.query()` twice, though I'm very open to other suggestions on how to test this. Alternatives include:
1. New separate idempotence tests in `apis/python/test/test_index.py`, i.e. `test_flat_index_idempotence` and `test_ivf_flat_index_idempotence`
2. New separate idempotence tests in `apis/python/test/test_ingestion.py`, i.e. `test_flat_index_idempotence` and `test_ivf_flat_index_idempotence`
3. New separate idempotence tests in `apis/python/test/test_query.py`, i.e. `test_flat_index_idempotence` and `test_ivf_flat_index_idempotence`
4. Move this logic into `apis/python/test/test_ingestion.py` and run the loop on the `query()` calls in there

### Testing
Before:
```
(TileDB-Vector-Search) ~/repo/TileDB-Vector-Search/apis/python pytest test/test_index.py -s                                                  jparismorgan/query-idempotence 
============================================================================ test session starts ============================================================================
platform darwin -- Python 3.9.18, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/parismorgan/repo/TileDB-Vector-Search/apis/python
collected 2 items                                                                                                                                                           

test/test_index.py ..

============================================================================= 2 passed in 2.89s =============================================================================
```

After:
```
(TileDB-Vector-Search) ~/repo/TileDB-Vector-Search/apis/python pytest test/test_index.py -s                                                  jparismorgan/query-idempotence 
============================================================================ test session starts ============================================================================
platform darwin -- Python 3.9.18, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/parismorgan/repo/TileDB-Vector-Search/apis/python
collected 2 items                                                                                                                                                           

test/test_index.py ..

============================================================================= 2 passed in 3.07s =============================================================================
```