### PR TITLE
Validate the `queries` vector shape

### DIFF
--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -40,7 +40,7 @@ class FlatIndex(index.Index):
             + self.index_version
         ].uri
         schema = tiledb.ArraySchema.load(self.db_uri, ctx=tiledb.Ctx(self.config))
-        self.expected_query_dimensions = schema.shape[0]
+        self.dimensions = schema.shape[0]
         if self.base_size == -1:
             self.size = schema.domain.dim(1).domain[1] + 1
         else:
@@ -76,8 +76,8 @@ class FlatIndex(index.Index):
                     self.ctx, self.ids_uri, 0, self.size, self.base_array_timestamp
                 )
     
-    def get_expected_query_dimensions(self):
-        return self.expected_query_dimensions
+    def get_dimensions(self):
+        return self.dimensions
 
     def query_internal(
         self,

--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -40,7 +40,7 @@ class FlatIndex(index.Index):
             + self.index_version
         ].uri
         schema = tiledb.ArraySchema.load(self.db_uri, ctx=tiledb.Ctx(self.config))
-        self.expected_query_columns = schema.shape[0]
+        self.expected_query_dimensions = schema.shape[0]
         if self.base_size == -1:
             self.size = schema.domain.dim(1).domain[1] + 1
         else:
@@ -76,8 +76,8 @@ class FlatIndex(index.Index):
                     self.ctx, self.ids_uri, 0, self.size, self.base_array_timestamp
                 )
     
-    def get_expected_query_columns(self):
-        return self.expected_query_columns
+    def get_expected_query_dimensions(self):
+        return self.expected_query_dimensions
 
     def query_internal(
         self,

--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -40,6 +40,7 @@ class FlatIndex(index.Index):
             + self.index_version
         ].uri
         schema = tiledb.ArraySchema.load(self.db_uri, ctx=tiledb.Ctx(self.config))
+        self.expected_query_columns = schema.shape[0]
         if self.base_size == -1:
             self.size = schema.domain.dim(1).domain[1] + 1
         else:
@@ -74,6 +75,9 @@ class FlatIndex(index.Index):
                 self._ids = read_vector_u64(
                     self.ctx, self.ids_uri, 0, self.size, self.base_array_timestamp
                 )
+    
+    def get_expected_query_columns(self):
+        return self.expected_query_columns
 
     def query_internal(
         self,

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -126,6 +126,13 @@ class Index:
         self.thread_executor = futures.ThreadPoolExecutor()
 
     def query(self, queries: np.ndarray, k, **kwargs):
+        if queries.ndim != 1 and queries.ndim != 2:
+            raise TypeError(f"Expected queries to have either 1 or 2 dimensions (i.e. [...] or [[...], [...]]), but it had {queries.ndim} dimensions")
+        
+        query_columns = queries.shape[0] if queries.ndim == 1 else queries.shape[1]
+        if query_columns != self.get_expected_query_columns():
+            raise TypeError(f"A query in queries has {query_columns} columns, but the indexed data had {self.expected_query_columns} columns")
+
         with tiledb.scope_ctx(ctx_or_config=self.config):
             if not tiledb.array_exists(self.updates_array_uri):
                 if self.query_base_array:
@@ -252,6 +259,9 @@ class Index:
                 )
             else:
                 return None, None, updated_ids
+
+    def get_expected_query_columns(self):
+        raise NotImplementedError
 
     def query_internal(self, queries: np.ndarray, k, **kwargs):
         raise NotImplementedError

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -129,9 +129,9 @@ class Index:
         if queries.ndim != 1 and queries.ndim != 2:
             raise TypeError(f"Expected queries to have either 1 or 2 dimensions (i.e. [...] or [[...], [...]]), but it had {queries.ndim} dimensions")
         
-        query_columns = queries.shape[0] if queries.ndim == 1 else queries.shape[1]
-        if query_columns != self.get_expected_query_columns():
-            raise TypeError(f"A query in queries has {query_columns} columns, but the indexed data had {self.expected_query_columns} columns")
+        query_dimensions = queries.shape[0] if queries.ndim == 1 else queries.shape[1]
+        if query_dimensions != self.get_expected_query_dimensions():
+            raise TypeError(f"A query in queries has {query_dimensions} dimensions, but the indexed data had {self.expected_query_dimensions} dimensions")
 
         with tiledb.scope_ctx(ctx_or_config=self.config):
             if not tiledb.array_exists(self.updates_array_uri):
@@ -260,7 +260,7 @@ class Index:
             else:
                 return None, None, updated_ids
 
-    def get_expected_query_columns(self):
+    def get_expected_query_dimensions(self):
         raise NotImplementedError
 
     def query_internal(self, queries: np.ndarray, k, **kwargs):

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -130,8 +130,8 @@ class Index:
             raise TypeError(f"Expected queries to have either 1 or 2 dimensions (i.e. [...] or [[...], [...]]), but it had {queries.ndim} dimensions")
         
         query_dimensions = queries.shape[0] if queries.ndim == 1 else queries.shape[1]
-        if query_dimensions != self.get_expected_query_dimensions():
-            raise TypeError(f"A query in queries has {query_dimensions} dimensions, but the indexed data had {self.expected_query_dimensions} dimensions")
+        if query_dimensions != self.get_dimensions():
+            raise TypeError(f"A query in queries has {query_dimensions} dimensions, but the indexed data had {self.dimensions} dimensions")
 
         with tiledb.scope_ctx(ctx_or_config=self.config):
             if not tiledb.array_exists(self.updates_array_uri):
@@ -260,7 +260,7 @@ class Index:
             else:
                 return None, None, updated_ids
 
-    def get_expected_query_dimensions(self):
+    def get_dimensions(self):
         raise NotImplementedError
 
     def query_internal(self, queries: np.ndarray, k, **kwargs):

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -64,7 +64,7 @@ class IVFFlatIndex(index.Index):
         self.memory_budget = memory_budget
 
         schema = tiledb.ArraySchema.load(self.db_uri, ctx=tiledb.Ctx(self.config))
-        self.expected_query_columns = schema.shape[0]
+        self.expected_query_dimensions = schema.shape[0]
 
         self.dtype = self.group.meta.get("dtype", None)
         if self.dtype is None:
@@ -122,8 +122,8 @@ class IVFFlatIndex(index.Index):
                 self.ctx, self.ids_uri, 0, self.size, self.base_array_timestamp
             )
 
-    def get_expected_query_columns(self):
-        return self.expected_query_columns
+    def get_expected_query_dimensions(self):
+        return self.expected_query_dimensions
 
     def query_internal(
         self,

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -63,9 +63,11 @@ class IVFFlatIndex(index.Index):
         ].uri
         self.memory_budget = memory_budget
 
+        schema = tiledb.ArraySchema.load(self.db_uri, ctx=tiledb.Ctx(self.config))
+        self.expected_query_columns = schema.shape[0]
+
         self.dtype = self.group.meta.get("dtype", None)
         if self.dtype is None:
-            schema = tiledb.ArraySchema.load(self.db_uri, ctx=tiledb.Ctx(self.config))
             self.dtype = np.dtype(schema.attr("values").dtype)
         else:
             self.dtype = np.dtype(self.dtype)
@@ -119,6 +121,9 @@ class IVFFlatIndex(index.Index):
             self._ids = read_vector_u64(
                 self.ctx, self.ids_uri, 0, self.size, self.base_array_timestamp
             )
+
+    def get_expected_query_columns(self):
+        return self.expected_query_columns
 
     def query_internal(
         self,

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -64,7 +64,7 @@ class IVFFlatIndex(index.Index):
         self.memory_budget = memory_budget
 
         schema = tiledb.ArraySchema.load(self.db_uri, ctx=tiledb.Ctx(self.config))
-        self.expected_query_dimensions = schema.shape[0]
+        self.dimensions = schema.shape[0]
 
         self.dtype = self.group.meta.get("dtype", None)
         if self.dtype is None:
@@ -122,8 +122,8 @@ class IVFFlatIndex(index.Index):
                 self.ctx, self.ids_uri, 0, self.size, self.base_array_timestamp
             )
 
-    def get_expected_query_dimensions(self):
-        return self.expected_query_dimensions
+    def get_dimensions(self):
+        return self.dimensions
 
     def query_internal(
         self,

--- a/apis/python/test/common.py
+++ b/apis/python/test/common.py
@@ -70,8 +70,47 @@ def groundtruth_read(dataset_dir, nqueries=None):
     else:
         return I, D
 
+def create_random_dataset_f32_only_data(nb, d, centers, path):
+    """
+    Creates a random float32 dataset containing just a dataset and then writes it to disk.
+
+    Parameters
+    ----------
+    nb: int
+        Number of points in the dataset
+    d: int
+        Dimension of the dataset
+    nq: int
+        Number of centers
+    path: str
+        Path to write the dataset to
+    """
+    from sklearn.datasets import make_blobs
+
+    os.mkdir(path)
+    X, _ = make_blobs(n_samples=nb, n_features=d, centers=centers, random_state=1)
+
+    with open(os.path.join(path, "data.f32bin"), "wb") as f:
+        np.array([nb, d], dtype="uint32").tofile(f)
+        X.astype("float32").tofile(f)
 
 def create_random_dataset_f32(nb, d, nq, k, path):
+    """
+    Creates a random float32 dataset containing both a dataset and queries against it, and then writes those to disk.
+
+    Parameters
+    ----------
+    nb: int
+        Number of points in the dataset
+    d: int
+        Dimension of the dataset
+    nq: int
+        Number of queries
+    k: int
+        Number of nearest neighbors to return
+    path: str
+        Path to write the dataset to
+    """
     import sklearn.model_selection
     from sklearn.datasets import make_blobs
     from sklearn.neighbors import NearestNeighbors
@@ -104,6 +143,22 @@ def create_random_dataset_f32(nb, d, nq, k, path):
 
 
 def create_random_dataset_u8(nb, d, nq, k, path):
+    """
+    Creates a random uint8 dataset containing both a dataset and queries against it, and then writes those to disk.
+
+    Parameters
+    ----------
+    nb: int
+        Number of points in the dataset
+    d: int
+        Dimension of the dataset
+    nq: int
+        Number of queries
+    k: int
+        Number of nearest neighbors to return
+    path: str
+        Path to write the dataset to
+    """
     import sklearn.model_selection
     from sklearn.datasets import make_blobs
     from sklearn.neighbors import NearestNeighbors

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -97,19 +97,19 @@ def test_index_with_incorrect_dimensions(tmp_path):
     indexes = [flat_index, ivf_flat_index]
     for index_type in indexes:
         uri = os.path.join(tmp_path, f"array_{index_type.__name__}")
-        index = index_type.create(uri=uri, dimensions=1, vector_type=np.dtype(np.uint8))
+        index = index_type.create(uri=uri, dimensions=3, vector_type=np.dtype(np.uint8))
 
         # Wrong number of dimensions will raise a TypeError.
         with pytest.raises(TypeError):
             index.query(np.array(1, dtype=np.float32), k=3)
         with pytest.raises(TypeError):
-            index.query(np.array([[[1]]], dtype=np.float32), k=3)
+            index.query(np.array([[[1, 1, 1]]], dtype=np.float32), k=3)
         with pytest.raises(TypeError):
-            index.query(np.array([[[[1]]]], dtype=np.float32), k=3)
+            index.query(np.array([[[[1, 1, 1]]]], dtype=np.float32), k=3)
 
         # Okay otherwise.
-        index.query(np.array([1], dtype=np.float32), k=3)
-        index.query(np.array([[1]], dtype=np.float32), k=3)
+        index.query(np.array([1, 1, 1], dtype=np.float32), k=3)
+        index.query(np.array([[1, 1, 1]], dtype=np.float32), k=3)
 
 def test_index_with_incorrect_num_of_query_columns_simple(tmp_path):
     siftsmall_uri = "test/data/siftsmall/siftsmall_base.fvecs"

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -106,8 +106,8 @@ def test_index_with_incorrect_dimensions(tmp_path):
             index.query(np.array([[[1]]], dtype=np.float32), k=3)
         with pytest.raises(TypeError):
             index.query(np.array([[[[1]]]], dtype=np.float32), k=3)
-        
-        # But the correct number of dimensions will not.
+
+        # Okay otherwise.
         index.query(np.array([1], dtype=np.float32), k=3)
         index.query(np.array([[1]], dtype=np.float32), k=3)
 
@@ -124,12 +124,12 @@ def test_index_with_incorrect_num_of_query_columns_simple(tmp_path):
             source_type = "FVEC",
         )
 
-        # Throw with an incorrect number of columns.
+        # Wrong number of columns will raise a TypeError.
         query_shape = (1, 1)
         with pytest.raises(TypeError):
             index.query(np.random.rand(*query_shape).astype(np.float32), k=10)
 
-        # Okay ottherwise.
+        # Okay otherwise.
         query_vectors = load_fvecs(queries_uri)
         index.query(query_vectors, k=10)
 
@@ -157,6 +157,20 @@ def test_index_with_incorrect_num_of_query_columns_complex(tmp_path):
                     with pytest.raises(TypeError):
                         index.query(query, k=1)
 
+                # TODO(paris): This will throw with the following error. Fix and re-enable, then remove 
+                # test_index_with_incorrect_num_of_query_columns_in_single_vector_query:
+                #   def array_to_matrix(array: np.ndarray):
+                #           if array.dtype == np.float32:
+                #   >           return pyarray_copyto_matrix_f32(array)
+                #   E           RuntimeError: Number of dimensions must be two
+                # Here we test with a query which is just a vector, i.e. [1, 2, 3].
+                # query = query[0]
+                # if num_columns_for_query == num_columns:
+                #     index.query(query, k=1)
+                # else:
+                #     with pytest.raises(TypeError):
+                #         index.query(query, k=1)
+
 def test_index_with_incorrect_num_of_query_columns_in_single_vector_query(tmp_path):
     # Tests that we raise a TypeError if the number of columns in the query is not the same as the 
     # number of columns in the indexed data, specifically for a single vector query.
@@ -173,6 +187,6 @@ def test_index_with_incorrect_num_of_query_columns_in_single_vector_query(tmp_pa
             index.query(np.array([1, 1], dtype=np.float32), k=3)
         with pytest.raises(TypeError):
             index.query(np.array([1, 1, 1, 1], dtype=np.float32), k=3)
-        
-        # But the correct number of columns will not.
+
+        # Okay otherwise.
         index.query(np.array([1, 1, 1], dtype=np.float32), k=3)

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -293,6 +293,12 @@ class tdbPartitionedMatrix : public Matrix<T, LayoutPolicy, I> {
       std::get<1>(col_part_view_) = std::get<0>(col_part_view_);
       for (size_t i = std::get<0>(col_part_view_); i < total_num_parts_; ++i) {
         auto next_part_size = indices_[parts_[i] + 1] - indices_[parts_[i]];
+
+        // Continue if this partition is empty
+        if (next_part_size == 0) {
+          continue;
+        }
+
         if ((std::get<1>(col_view_) + next_part_size) >
             std::get<0>(col_view_) + max_cols_) {
           break;


### PR DESCRIPTION
### What
Here we validate the shape of the vector(s) in `queries` to make sure it matches the input data, addressing https://app.shortcut.com/tiledb-inc/story/31507/vs-validate-query-vectors-shape.

### Testing
* Adds a unit test for both `FLAT` and `IVF_FLAT` which tests a query against `siftsmall_base.fvecs `
* Adds a unit test for both `FLAT` and `IVF_FLAT` which tests creating index's with varying numbers of columns in their dataset vectors, and then for each of these index's we query against it with varying numbers of columns in the query vectors. We do this for both one and two dimensional query vectors.
* Adds tests to confirm the query vector is one or two dimensional.


Tests pass except cloud b/c I haven't logged in yet (I thought I had but it seems something happened)
```
(TileDB-Vector-Search) ~/repo/TileDB-Vector-Search/apis/python pytest             ✹ ✭jparismorgan/query-vectors-shape 
================================================= test session starts =================================================
platform darwin -- Python 3.9.18, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/parismorgan/repo/TileDB-Vector-Search/apis/python
collected 29 items                                                                                                    

test/test_api.py ....                                                                                           [ 13%]
test/test_cloud.py EE                                                                                           [ 20%]
test/test_index.py ......                                                                                       [ 41%]
test/test_ingestion.py ..............                                                                           [ 89%]
test/test_mod
```

### TODO
There is still a part of one test failing which I will look into as a follow-up. 

```
# TODO(paris): This will throw with the following error. Fix and re-enable, then remove 
# test_index_with_incorrect_num_of_query_columns_in_single_vector_query:
#   def array_to_matrix(array: np.ndarray):
#           if array.dtype == np.float32:
#   >           return pyarray_copyto_matrix_f32(array)
#   E           RuntimeError: Number of dimensions must be two
# Here we test with a query which is just a vector, i.e. [1, 2, 3].
# query = query[0]
# if num_columns_for_query == num_columns:
#     index.query(query, k=1)
# else:
#     with pytest.raises(TypeError):
#         index.query(query, k=1)
```