### PR TITLE
Enable setting `resource_class` or `resources` when calling `query()` on `IVFFlatIndex`

### DIFF
--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -18,8 +18,8 @@ INDEX_TYPE = "IVF_FLAT"
 def submit_local(d, func, *args, **kwargs):
     # Drop kwarg
     kwargs.pop("image_name", None)
-    kwargs.pop("resources", None)
     kwargs.pop("resource_class", None)
+    kwargs.pop("resources", None)
     return d.submit_local(func, *args, **kwargs)
 
 
@@ -184,6 +184,9 @@ class IVFFlatIndex(index.Index):
                 (queries.shape[0], k), index.MAX_UINT64
             )
 
+        if not (mode == Mode.REALTIME or mode == Mode.BATCH) and (resource_class or resources):
+            raise TypeError("Can only pass resource_class or resources in REALTIME or BATCH mode")
+
         assert queries.dtype == np.float32
 
         if queries.ndim == 1:
@@ -302,8 +305,6 @@ class IVFFlatIndex(index.Index):
 
         if resource_class and resources:
             raise TypeError("Cannot provide both resource_class and resources")
-        if mode == Mode.LOCAL and (resource_class or resources):
-            raise TypeError("Cannot provide resource_class or resources in LOCAL mode")
 
         def dist_qv_udf(
             dtype: np.dtype,

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -167,10 +167,7 @@ class IVFFlatIndex(index.Index):
         resources:
             A specification for the amount of resources to use when executing using TileDB cloud 
             taskgraphs, of the form: {"cpu": "6", "memory": "12Gi", "gpu": 1}. Can only be used 
-            in REALTIME or BATCH mode. Cannot be used alongside resource_class.
-        num_partitions: int
-            Only relevant for taskgraph based execution.
-            If provided, we split the query execution in that many partitions.
+            in BATCH mode. Cannot be used alongside resource_class.
         num_partitions: int
             Only relevant for taskgraph based execution.
             If provided, we split the query execution in that many partitions.
@@ -184,8 +181,10 @@ class IVFFlatIndex(index.Index):
                 (queries.shape[0], k), index.MAX_UINT64
             )
 
-        if not (mode == Mode.REALTIME or mode == Mode.BATCH) and (resource_class or resources):
-            raise TypeError("Can only pass resource_class or resources in REALTIME or BATCH mode")
+        if mode != Mode.BATCH and resources:
+            raise TypeError("Can only pass resources in BATCH mode")
+        if (mode != Mode.REALTIME and mode != Mode.BATCH) and resource_class:
+            raise TypeError("Can only pass resource_class in REALTIME or BATCH mode")
 
         assert queries.dtype == np.float32
 
@@ -283,7 +282,7 @@ class IVFFlatIndex(index.Index):
         resources:
             A specification for the amount of resources to use when executing using TileDB cloud 
             taskgraphs, of the form: {"cpu": "6", "memory": "12Gi", "gpu": 1}. Can only be used 
-            in REALTIME or BATCH mode. Cannot be used alongside resource_class.
+            in BATCH mode. Cannot be used alongside resource_class.
         num_partitions: int
             Only relevant for taskgraph based execution.
             If provided, we split the query execution in that many partitions.

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -19,6 +19,7 @@ def submit_local(d, func, *args, **kwargs):
     # Drop kwarg
     kwargs.pop("image_name", None)
     kwargs.pop("resources", None)
+    kwargs.pop("resource_class", None)
     return d.submit_local(func, *args, **kwargs)
 
 
@@ -133,6 +134,8 @@ class IVFFlatIndex(index.Index):
         nthreads: int = -1,
         use_nuv_implementation: bool = False,
         mode: Mode = None,
+        resource_class: Optional[str] = None,
+        resources: Optional[Mapping[str, Any]] = None,
         num_partitions: int = -1,
         num_workers: int = -1,
     ):
@@ -153,7 +156,21 @@ class IVFFlatIndex(index.Index):
             wether to use the nuv query implementation. Default: False
         mode: Mode
             If provided the query will be executed using TileDB cloud taskgraphs.
-            For distributed execution you can use REALTIME or BATCH mode
+            For distributed execution you can use REALTIME or BATCH mode. 
+            For local execution you can use LOCAL mode.
+        resource_class: 
+            The name of the resource class to use ("standard" or "large"). Resource classes define maximum
+            limits for cpu and memory usage. Can only be used in REALTIME or BATCH mode.
+            Cannot be used alongside resources.
+            In REALTIME or BATCH mode if neither resource_class nor resources are provided,
+            we default to the "large" resource class.
+        resources:
+            A specification for the amount of resources to use when executing using TileDB cloud 
+            taskgraphs, of the form: {"cpu": "6", "memory": "12Gi", "gpu": 1}. Can only be used 
+            in REALTIME or BATCH mode. Cannot be used alongside resource_class.
+        num_partitions: int
+            Only relevant for taskgraph based execution.
+            If provided, we split the query execution in that many partitions.
         num_partitions: int
             Only relevant for taskgraph based execution.
             If provided, we split the query execution in that many partitions.
@@ -217,6 +234,8 @@ class IVFFlatIndex(index.Index):
                 nthreads=nthreads,
                 nprobe=nprobe,
                 mode=mode,
+                resource_class=resource_class,
+                resources=resources,
                 num_partitions=num_partitions,
                 num_workers=num_workers,
                 config=self.config,
@@ -229,6 +248,8 @@ class IVFFlatIndex(index.Index):
         nprobe: int = 10,
         nthreads: int = -1,
         mode: Mode = None,
+        resource_class: Optional[str] = None,
+        resources: Optional[Mapping[str, Any]] = None,
         num_partitions: int = -1,
         num_workers: int = -1,
         config: Optional[Mapping[str, Any]] = None,
@@ -248,7 +269,18 @@ class IVFFlatIndex(index.Index):
             Number of threads to use for query
         mode: Mode
             If provided the query will be executed using TileDB cloud taskgraphs.
-            For distributed execution you can use REALTIME or BATCH mode
+            For distributed execution you can use REALTIME or BATCH mode. 
+            For local execution you can use LOCAL mode.
+        resource_class: 
+            The name of the resource class to use ("standard" or "large"). Resource classes define maximum
+            limits for cpu and memory usage. Can only be used in REALTIME or BATCH mode.
+            Cannot be used alongside resources.
+            In REALTIME or BATCH mode if neither resource_class nor resources are provided,
+            we default to the "large" resource class.
+        resources:
+            A specification for the amount of resources to use when executing using TileDB cloud 
+            taskgraphs, of the form: {"cpu": "6", "memory": "12Gi", "gpu": 1}. Can only be used 
+            in REALTIME or BATCH mode. Cannot be used alongside resource_class.
         num_partitions: int
             Only relevant for taskgraph based execution.
             If provided, we split the query execution in that many partitions.
@@ -267,6 +299,11 @@ class IVFFlatIndex(index.Index):
 
         from tiledb.vector_search.module import (array_to_matrix, dist_qv,
                                                  partition_ivf_index)
+
+        if resource_class and resources:
+            raise TypeError("Cannot provide both resource_class and resources")
+        if mode == Mode.LOCAL and (resource_class or resources):
+            raise TypeError("Cannot provide resource_class or resources in LOCAL mode")
 
         def dist_qv_udf(
             dtype: np.dtype,
@@ -373,7 +410,8 @@ class IVFFlatIndex(index.Index):
                     k_nn=k,
                     config=config,
                     timestamp=self.base_array_timestamp,
-                    resource_class="large" if mode == Mode.REALTIME else None,
+                    resource_class="large" if (not resources and not resource_class) else resource_class,
+                    resources=resources,
                     image_name="3.9-vectorsearch",
                 )
             )

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -106,7 +106,7 @@ class CloudTests(unittest.TestCase):
             index.query(query_vectors, k=k, nprobe=nprobe, resources=resources)
 
         # Cannot pass resources to REALTIME.
-        with self.assertRaises(tiledb_cloud_error.TileDBCloudError):
+        with self.assertRaises(TypeError):
             index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME, resources=resources)
 
         # Cannot pass both resource_class and resources.

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-import pytest
 
 from common import *
 from tiledb.cloud import groups, tiledb_cloud_error
@@ -8,7 +7,6 @@ from tiledb.cloud.dag import Mode
 
 import tiledb.vector_search as vs
 from tiledb.vector_search.utils import load_fvecs
-from tiledb.vector_search.ivf_flat_index import IVFFlatIndex
 
 MINIMUM_ACCURACY = 0.85
 
@@ -98,21 +96,21 @@ class CloudTests(unittest.TestCase):
         resources = {"cpu": "9", "memory": "12Gi", "gpu": 0}
 
         # Cannot pass resource_class or resources to LOCAL mode or to no mode.
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL, resource_class="large")
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL, resources=resources)
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             index.query(query_vectors, k=k, nprobe=nprobe, resource_class="large")
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             index.query(query_vectors, k=k, nprobe=nprobe, resources=resources)
 
         # Cannot pass resources to REALTIME.
-        with pytest.raises(tiledb_cloud_error.TileDBCloudError):
+        with self.assertRaises(tiledb_cloud_error.TileDBCloudError):
             index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME, resources=resources)
 
         # Cannot pass both resource_class and resources.
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME, resource_class="large", resources=resources)
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.BATCH, resource_class="large", resources=resources)

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -55,7 +55,6 @@ class CloudTests(unittest.TestCase):
         _, result_i = index.query(query_vectors, k=k)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
-
     def test_cloud_ivf_flat(self):
         source_uri = "tiledb://TileDB-Inc/sift_10k"
         queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"


### PR DESCRIPTION
### What
Adds `resource_class` and `resources` to `query()`. These are only valid for `Mode.REALTIME` and `Mode.BATCH`. If not provided, the default is `large`. You cannot pass both `resource_class` and `resources`.

### Testing
* Adds unit tests checking that we throw exceptions when we should and succeed otherwise.
* I manually looked at what machine we ran on for each scenario and things look okay, but I didn't see a nice path to testing this programmatically, though please do let me know if I just missed it :
```
index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME, resource_class="standard")
```
<img width="2032" alt="Screenshot 2023-12-13 at 3 15 36 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/de62738c-e6e6-4751-b773-1300e03da1db">

```
index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME)
```
<img width="2032" alt="Screenshot 2023-12-13 at 3 17 21 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/1301f394-fcba-4f9b-88cb-50647dbf6a06">

```
index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.BATCH, resource_class="standard")
```
<img width="2032" alt="Screenshot 2023-12-13 at 3 22 22 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/7e19ce9f-e564-459d-9720-dd4e2cb7fcdb">

```
index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.BATCH)
```
<img width="2032" alt="Screenshot 2023-12-13 at 3 28 15 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/1f3dfe65-2174-40c9-91b0-67090c704994">

```
resources = {"cpu": "9", "memory": "12Gi", "gpu": 0}
index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.BATCH, resources=resources)
```
<img width="2032" alt="Screenshot 2023-12-13 at 3 30 26 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/2ef2e483-7dc7-4993-9e2d-a4ecc6f89d8d">