### PR TITLE
Updates the `.gitignore` to ignore all `*.egg-info`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,7 @@ apis/python/parts/
 apis/python/sdist/
 apis/python/var/
 apis/python/wheels/
-apis/python/*.egg-info/
-apis/python/src/*.egg-info
+apis/python/**/*.egg-info/
 apis/python/.installed.cfg
 apis/python/*.egg
 apis/python/MANIFEST


### PR DESCRIPTION
### What
I was getting these unstaged files, not I am not:

<img width="473" alt="Screenshot 2023-12-13 at 5 00 09 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/c770996e-6ca2-4b1a-bc94-93138340d13f">

