### PR TITLE
Fix bug for creating the updates array using a tiledb URI

### DIFF
--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -10,6 +10,7 @@ from tiledb.vector_search.storage_formats import (STORAGE_VERSION,
                                                   validate_storage_version)
 
 MAX_INT32 = np.iinfo(np.dtype("int32")).max
+MAX_UINT64 = np.iinfo(np.dtype("uint64")).max
 TILE_SIZE_BYTES = 128000000  # 128MB
 INDEX_TYPE = "FLAT"
 
@@ -139,8 +140,10 @@ def create(
         tile_size = TILE_SIZE_BYTES / np.dtype(vector_type).itemsize / dimensions
         ids_array_name = storage_formats[storage_version]["IDS_ARRAY_NAME"]
         parts_array_name = storage_formats[storage_version]["PARTS_ARRAY_NAME"]
+        updates_array_name = storage_formats[storage_version]["UPDATES_ARRAY_NAME"]
         ids_uri = f"{uri}/{ids_array_name}"
         parts_uri = f"{uri}/{parts_array_name}"
+        updates_array_uri = f"{uri}/{updates_array_name}"
 
         ids_array_rows_dim = tiledb.Dim(
             name="rows",
@@ -191,6 +194,22 @@ def create(
         )
         tiledb.Array.create(parts_uri, parts_schema)
         group.add(parts_uri, name=parts_array_name)
+
+        external_id_dim = tiledb.Dim(
+            name="external_id",
+            domain=(0, MAX_UINT64 - 1),
+            dtype=np.dtype(np.uint64),
+        )
+        dom = tiledb.Domain(external_id_dim)
+        vector_attr = tiledb.Attr(name="vector", dtype=vector_type, var=True)
+        updates_schema = tiledb.ArraySchema(
+            domain=dom,
+            sparse=True,
+            attrs=[vector_attr],
+            allows_duplicates=False,
+        )
+        tiledb.Array.create(updates_array_uri, updates_schema)
+        group.add(updates_array_uri, name=updates_array_name)
 
         group.close()
         return FlatIndex(uri=uri, config=config)

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -52,9 +52,7 @@ class Index:
             raise ValueError(
                 f"Time traveling is not supported for index storage_version={self.storage_version}"
             )
-
-        updates_array_name = storage_formats[self.storage_version]["UPDATES_ARRAY_NAME"]
-        self.updates_array_uri = f"{self.group.uri}/{updates_array_name}"
+        self.updates_array_uri = self.group[storage_formats[self.storage_version]["UPDATES_ARRAY_NAME"]].uri
         self.index_version = self.group.meta.get("index_version", "")
         self.ingestion_timestamps = [
             int(x)

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -52,7 +52,11 @@ class Index:
             raise ValueError(
                 f"Time traveling is not supported for index storage_version={self.storage_version}"
             )
-        self.updates_array_uri = self.group[storage_formats[self.storage_version]["UPDATES_ARRAY_NAME"]].uri
+        updates_array_name = storage_formats[self.storage_version]["UPDATES_ARRAY_NAME"]
+        if updates_array_name in self.group:
+            self.updates_array_uri = self.group[storage_formats[self.storage_version]["UPDATES_ARRAY_NAME"]].uri
+        else:
+            self.updates_array_uri = f"{self.group.uri}/{updates_array_name}"
         self.index_version = self.group.meta.get("index_version", "")
         self.ingestion_timestamps = [
             int(x)

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -136,7 +136,7 @@ class Index:
             raise TypeError(f"A query in queries has {query_dimensions} dimensions, but the indexed data had {self.dimensions} dimensions")
 
         with tiledb.scope_ctx(ctx_or_config=self.config):
-            if not self.has_updates():
+            if not tiledb.array_exists(self.updates_array_uri) or not self.has_updates():
                 if self.query_base_array:
                     return self.query_internal(queries, k, **kwargs)
                 else:
@@ -269,7 +269,10 @@ class Index:
         raise NotImplementedError
 
     def has_updates(self):
-        return self.group.meta["has_updates"]
+        if "has_updates" in self.group.meta:
+            return self.group.meta["has_updates"]
+        else:
+            return True
 
     def set_has_updates(self, has_updates: bool = True):
         if not self.group.meta["has_updates"]:

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -12,6 +12,7 @@ from tiledb.vector_search.storage_formats import (STORAGE_VERSION,
                                                   validate_storage_version)
 
 MAX_INT32 = np.iinfo(np.dtype("int32")).max
+MAX_UINT64 = np.iinfo(np.dtype("uint64")).max
 TILE_SIZE_BYTES = 64000000  # 64MB
 INDEX_TYPE = "IVF_FLAT"
 
@@ -436,12 +437,8 @@ class IVFFlatIndex(index.Index):
             tmp = sorted(tmp_results, key=lambda t: t[0])[0:k]
             for j in range(len(tmp), k):
                 tmp.append((float(0.0), int(0)))
-            results_per_query_d.append(
-                np.array(tmp, dtype=np.dtype("float,uint64"))["f0"]
-            )
-            results_per_query_i.append(
-                np.array(tmp, dtype=np.dtype("float,uint64"))["f1"]
-            )
+            results_per_query_d.append(np.array(tmp, dtype=np.float32)[:, 0])
+            results_per_query_i.append(np.array(tmp, dtype=np.uint64)[:, 1])
         return np.array(results_per_query_d), np.array(results_per_query_i)
 
 
@@ -473,10 +470,12 @@ def create(
         index_array_name = storage_formats[storage_version]["INDEX_ARRAY_NAME"]
         ids_array_name = storage_formats[storage_version]["IDS_ARRAY_NAME"]
         parts_array_name = storage_formats[storage_version]["PARTS_ARRAY_NAME"]
+        updates_array_name = storage_formats[storage_version]["UPDATES_ARRAY_NAME"]
         centroids_uri = f"{uri}/{centroids_array_name}"
         index_array_uri = f"{uri}/{index_array_name}"
         ids_uri = f"{uri}/{ids_array_name}"
         parts_uri = f"{uri}/{parts_array_name}"
+        updates_array_uri = f"{uri}/{updates_array_name}"
 
         centroids_array_rows_dim = tiledb.Dim(
             name="rows",
@@ -579,6 +578,22 @@ def create(
         )
         tiledb.Array.create(parts_uri, parts_schema)
         group.add(parts_uri, name=parts_array_name)
+
+        external_id_dim = tiledb.Dim(
+            name="external_id",
+            domain=(0, MAX_UINT64 - 1),
+            dtype=np.dtype(np.uint64),
+        )
+        dom = tiledb.Domain(external_id_dim)
+        vector_attr = tiledb.Attr(name="vector", dtype=vector_type, var=True)
+        updates_schema = tiledb.ArraySchema(
+            domain=dom,
+            sparse=True,
+            attrs=[vector_attr],
+            allows_duplicates=False,
+        )
+        tiledb.Array.create(updates_array_uri, updates_schema)
+        group.add(updates_array_uri, name=updates_array_name)
 
         group.close()
         return IVFFlatIndex(uri=uri, config=config, memory_budget=1000000)

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -50,8 +50,16 @@ class CloudTests(unittest.TestCase):
             config=tiledb.cloud.Config().dict(),
             mode=Mode.BATCH,
         )
+        tiledb_index_uri = groups.info(index_uri).tiledb_uri
+        index = vs.flat_index.FlatIndex(uri=tiledb_index_uri)
+
         _, result_i = index.query(query_vectors, k=k)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
+
+        index.delete(external_id=42)
+        _, result_i = index.query(query_vectors, k=k)
+        assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
+
 
     def test_cloud_ivf_flat(self):
         source_uri = "tiledb://TileDB-Inc/sift_10k"
@@ -78,6 +86,9 @@ class CloudTests(unittest.TestCase):
             #  UDF library releases.
             # mode=Mode.BATCH,
         )
+
+        tiledb_index_uri = groups.info(index_uri).tiledb_uri
+        index = vs.ivf_flat_index.IVFFlatIndex(uri=tiledb_index_uri)
 
         _, result_i = index.query(query_vectors, k=k, nprobe=nprobe)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
@@ -114,3 +125,7 @@ class CloudTests(unittest.TestCase):
             index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME, resource_class="large", resources=resources)
         with self.assertRaises(TypeError):
             index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.BATCH, resource_class="large", resources=resources)
+
+        index.delete(external_id=42)
+        _, result_i = index.query(query_vectors, k=k, nprobe=nprobe)
+        assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY


### PR DESCRIPTION
Statically create the updates array for Vector indices. This is done to avoid errors when adding updates in `tiledb://` arrays.

https://app.shortcut.com/tiledb-inc/story/38406/adding-documents-to-langchain-fails-for-cloud-arrays

This also fixes a bug of wrong result structure for `IVFFlatIndex.taskgraph_query`
