### PR TITLE
Save `training_source_uri` and `training_source_type` on `IVF_FLAT` metadata

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -401,6 +401,8 @@ def ingest(
         logger: logging.Logger,
         storage_version: str,
     ) -> None:
+        print('[ingestion@create_arrays] index_type', index_type)
+        print('[ingestion@create_arrays] training_source_uri', training_source_uri, 'training_source_type', training_source_type)
         if index_type == "FLAT":
             if not arrays_created:
                 flat_index.create(
@@ -419,7 +421,9 @@ def ingest(
                     vector_type=vector_type,
                     group_exists=True,
                     config=config,
-                    storage_version=storage_version
+                    storage_version=storage_version,
+                    training_source_uri=training_source_uri,
+                    training_source_type=training_source_type,
                 )
             tile_size = int(
                 ivf_flat_index.TILE_SIZE_BYTES
@@ -809,6 +813,8 @@ def ingest(
             kmeans_fit,
         )
 
+        print('[ingestion@centralised_kmeans] training_sample_size', training_sample_size, 'training_source_uri', training_source_uri, 'training_source_type', training_source_type)
+
         with tiledb.scope_ctx(ctx_or_config=config):
             logger = setup(config, verbose)
             group = tiledb.Group(index_group_uri)
@@ -863,6 +869,7 @@ def ingest(
                 # raise ValueError(f"We have a training_sample_size of {training_sample_size} but {partitions} partitions - training_sample_size must be >= partitions")
                 centroids = np.random.rand(dimensions, partitions)
 
+            print('[ingestion@centralised_kmeans] sample_vectors', sample_vectors.shape, '\n', sample_vectors)
             logger.debug("Writing centroids to array %s", centroids_uri)
             with tiledb.open(centroids_uri, mode="w", timestamp=index_timestamp) as A:
                 A[0:dimensions, 0:partitions] = centroids

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -401,8 +401,6 @@ def ingest(
         logger: logging.Logger,
         storage_version: str,
     ) -> None:
-        print('[ingestion@create_arrays] index_type', index_type)
-        print('[ingestion@create_arrays] training_source_uri', training_source_uri, 'training_source_type', training_source_type)
         if index_type == "FLAT":
             if not arrays_created:
                 flat_index.create(
@@ -813,8 +811,6 @@ def ingest(
             kmeans_fit,
         )
 
-        print('[ingestion@centralised_kmeans] training_sample_size', training_sample_size, 'training_source_uri', training_source_uri, 'training_source_type', training_source_type)
-
         with tiledb.scope_ctx(ctx_or_config=config):
             logger = setup(config, verbose)
             group = tiledb.Group(index_group_uri)
@@ -869,7 +865,6 @@ def ingest(
                 # raise ValueError(f"We have a training_sample_size of {training_sample_size} but {partitions} partitions - training_sample_size must be >= partitions")
                 centroids = np.random.rand(dimensions, partitions)
 
-            print('[ingestion@centralised_kmeans] sample_vectors', sample_vectors.shape, '\n', sample_vectors)
             logger.debug("Writing centroids to array %s", centroids_uri)
             with tiledb.open(centroids_uri, mode="w", timestamp=index_timestamp) as A:
                 A[0:dimensions, 0:partitions] = centroids

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -400,6 +400,8 @@ def ingest(
         vector_type: np.dtype,
         logger: logging.Logger,
         storage_version: str,
+        training_source_uri: Optional[str],
+        training_source_type: Optional[str],
     ) -> None:
         if index_type == "FLAT":
             if not arrays_created:
@@ -2017,7 +2019,9 @@ def ingest(
             input_vectors_work_items=input_vectors_work_items,
             vector_type=vector_type,
             logger=logger,
-            storage_version=storage_version
+            storage_version=storage_version,
+            training_source_uri=training_source_uri,
+            training_source_type=training_source_type,
         )
         group.meta["temp_size"] = size
         group.close()

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -456,7 +456,6 @@ def create(
     storage_version: str = STORAGE_VERSION,
     **kwargs,
 ) -> IVFFlatIndex:
-    print('[ivf_flat_index@create] uri', uri, 'group_exists', group_exists, 'config', config, 'storage_version', storage_version, 'kwargs', kwargs)
     validate_storage_version(storage_version)
 
     index.create_metadata(

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -451,9 +451,12 @@ def create(
     vector_type: np.dtype,
     group_exists: bool = False,
     config: Optional[Mapping[str, Any]] = None,
+    training_source_uri: str = None,
+    training_source_type: str = None,
     storage_version: str = STORAGE_VERSION,
     **kwargs,
 ) -> IVFFlatIndex:
+    print('[ivf_flat_index@create] uri', uri, 'group_exists', group_exists, 'config', config, 'storage_version', storage_version, 'kwargs', kwargs)
     validate_storage_version(storage_version)
 
     index.create_metadata(
@@ -468,8 +471,12 @@ def create(
     # TODO(paris): Save training_source_uri as metadata so that we use it for re-ingestion's.
     with tiledb.scope_ctx(ctx_or_config=config):
         group = tiledb.Group(uri, "w")
-        tile_size = int(TILE_SIZE_BYTES / np.dtype(vector_type).itemsize / dimensions)
         group.meta["partition_history"] = json.dumps([0])
+        if training_source_uri is not None:
+            group.meta["training_source_uri"] = training_source_uri
+        if training_source_type is not None:
+            group.meta["training_source_type"] = training_source_type
+        tile_size = int(TILE_SIZE_BYTES / np.dtype(vector_type).itemsize / dimensions)
         centroids_array_name = storage_formats[storage_version]["CENTROIDS_ARRAY_NAME"]
         index_array_name = storage_formats[storage_version]["INDEX_ARRAY_NAME"]
         ids_array_name = storage_formats[storage_version]["IDS_ARRAY_NAME"]

--- a/apis/python/test/common.py
+++ b/apis/python/test/common.py
@@ -295,8 +295,8 @@ def check_equals(result_d, result_i, expected_result_d, expected_result_i):
     result_i_expected: int
         The expected indices
     """
-    assert result_i == expected_result_i
-    assert result_d == expected_result_d
+    assert result_i == expected_result_i, f"result_i: {result_i} != expected_result_i: {expected_result_i}"
+    assert result_d == expected_result_d, f"result_d: {result_d} != expected_result_d: {expected_result_d}"
 
 # Generate random names for test array uris
 def random_name(name: str) -> str:

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -856,7 +856,6 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
     ################################################################################################
     # Test we can ingest, query, update, and consolidate with a training_source_uri.
     ################################################################################################
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================')
     index_uri = os.path.join(tmp_path, "array")
     index = ingest(
         index_type="IVF_FLAT", 
@@ -865,35 +864,29 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
         training_source_uri=os.path.join(dataset_dir, "training_data.tdb")
     )
 
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================')
     query_vector_index = 1
     query_vectors = np.array([data.transpose()[query_vector_index]], dtype=np.float32)
     result_d, result_i = index.query(query_vectors, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] update_batch() ======================')
     update_vectors = np.empty([3], dtype=object)
     update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
     update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
     update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
     index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
     
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================')
     index = index.consolidate_updates()
 
     query_vectors = np.array([update_vectors[2]], dtype=np.float32)
     result_d, result_i = index.query(query_vectors, k=1)
-    print('result_d', result_d, 'result_i', result_i)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
 
     ################################################################################################
     # Test we can load the index again and query, update, and consolidate.
     ################################################################################################
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index_ram = IVFFlatIndex(uri=index_uri) ======================')
     index_ram = IVFFlatIndex(uri=index_uri)
 
     result_d, result_i = index.query(query_vectors, k=1)
-    print('result_d', result_d, 'result_i', result_i)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
     
     update_vectors = np.empty([2], dtype=object)
@@ -940,25 +933,21 @@ def test_ingest_with_training_source_uri_numpy(tmp_path):
     result_d, result_i = index.query(query_vectors, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] update_batch() ======================')
     update_vectors = np.empty([3], dtype=object)
     update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
     update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
     update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
     index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
     
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================')
     index = index.consolidate_updates()
 
     query_vectors = np.array([update_vectors[2]], dtype=np.float32)
     result_d, result_i = index.query(query_vectors, k=1)
-    print('result_d', result_d, 'result_i', result_i)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
 
     ################################################################################################
     # Test we can load the index again and query, update, and consolidate.
     ################################################################################################
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index_ram = IVFFlatIndex(uri=index_uri) ======================')
     index_ram = IVFFlatIndex(uri=index_uri)
 
     query_vectors = np.array([data[query_vector_index]], dtype=np.float32)

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -827,7 +827,7 @@ def test_ingest_with_training_source_uri_f32(tmp_path):
     result_d, result_i = index.query(query_vectors, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
-    index_ram = FlatIndex(uri=index_uri)
+    index_ram = IVFFlatIndex(uri=index_uri)
     result_d, result_i = index_ram.query(query_vectors, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
@@ -837,10 +837,13 @@ def test_ingest_with_training_source_uri_f32(tmp_path):
         index_uri=os.path.join(tmp_path, "array_2"), 
         source_uri=os.path.join(dataset_dir, "data.f32bin"),
         training_source_uri=os.path.join(dataset_dir, "training_data.f32bin"),
-        training_source_type="FVEC"
+        training_source_type="F32BIN"
     )
 
 def test_ingest_with_training_source_uri_tdb(tmp_path):
+    ################################################################################################
+    # First set up the data.
+    ################################################################################################
     dataset_dir = os.path.join(tmp_path, "dataset")
     os.mkdir(dataset_dir)
     # data.shape should give you (cols, rows). So we transpose this before using it.
@@ -850,6 +853,10 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
     training_data = data[1:3]
     create_array(path=os.path.join(dataset_dir, "training_data.tdb"), data=training_data)
 
+    ################################################################################################
+    # Test we can ingest, query, update, and consolidate with a training_source_uri.
+    ################################################################################################
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================')
     index_uri = os.path.join(tmp_path, "array")
     index = ingest(
         index_type="IVF_FLAT", 
@@ -858,16 +865,50 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
         training_source_uri=os.path.join(dataset_dir, "training_data.tdb")
     )
 
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================')
     query_vector_index = 1
     query_vectors = np.array([data.transpose()[query_vector_index]], dtype=np.float32)
     result_d, result_i = index.query(query_vectors, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
-    index_ram = IVFFlatIndex(uri=index_uri)
-    result_d, result_i = index_ram.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] update_batch() ======================')
+    update_vectors = np.empty([3], dtype=object)
+    update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
+    update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
+    
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================')
+    index = index.consolidate_updates()
 
-    # Also test that we can ingest with training_source_type.
+    query_vectors = np.array([update_vectors[2]], dtype=np.float32)
+    result_d, result_i = index.query(query_vectors, k=1)
+    print('result_d', result_d, 'result_i', result_i)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
+
+    ################################################################################################
+    # Test we can load the index again and query, update, and consolidate.
+    ################################################################################################
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index_ram = IVFFlatIndex(uri=index_uri) ======================')
+    index_ram = IVFFlatIndex(uri=index_uri)
+
+    result_d, result_i = index.query(query_vectors, k=1)
+    print('result_d', result_d, 'result_i', result_i)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
+    
+    update_vectors = np.empty([2], dtype=object)
+    update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+    index_ram = index_ram.consolidate_updates()
+    
+    query_vectors = np.array([update_vectors[0]], dtype=np.float32)
+    result_d, result_i = index_ram.query(query_vectors, k=1)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])
+
+    ################################################################################################
+    # Test that we can ingest with training_source_type.
+    ################################################################################################
     ingest(
         index_type="IVF_FLAT",
         index_uri=os.path.join(tmp_path, "array_2"), 
@@ -877,9 +918,15 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
     )
 
 def test_ingest_with_training_source_uri_numpy(tmp_path):
+    ################################################################################################
+    # First set up the data.
+    ################################################################################################
     data = np.array([[1.0, 1.1, 1.2, 1.3], [2.0, 2.1, 2.2, 2.3], [3.0, 3.1, 3.2, 3.3], [4.0, 4.1, 4.2, 4.3], [5.0, 5.1, 5.2, 5.3]], dtype=np.float32)
     training_data = data[1:3]
 
+    ################################################################################################
+    # Test we can ingest, query, update, and consolidate.
+    ################################################################################################
     index_uri = os.path.join(tmp_path, "array")
     index = ingest(
         index_type="IVF_FLAT", 
@@ -893,6 +940,37 @@ def test_ingest_with_training_source_uri_numpy(tmp_path):
     result_d, result_i = index.query(query_vectors, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] update_batch() ======================')
+    update_vectors = np.empty([3], dtype=object)
+    update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
+    update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
+    
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================')
+    index = index.consolidate_updates()
+
+    query_vectors = np.array([update_vectors[2]], dtype=np.float32)
+    result_d, result_i = index.query(query_vectors, k=1)
+    print('result_d', result_d, 'result_i', result_i)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
+
+    ################################################################################################
+    # Test we can load the index again and query, update, and consolidate.
+    ################################################################################################
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index_ram = IVFFlatIndex(uri=index_uri) ======================')
     index_ram = IVFFlatIndex(uri=index_uri)
-    result_d, result_i = index_ram.query(query_vectors, k=1)
+
+    query_vectors = np.array([data[query_vector_index]], dtype=np.float32)
+    result_d, result_i = index.query(query_vectors, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+
+    update_vectors = np.empty([2], dtype=object)
+    update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+    index_ram = index_ram.consolidate_updates()
+    
+    query_vectors = np.array([update_vectors[0]], dtype=np.float32)
+    result_d, result_i = index_ram.query(query_vectors, k=1)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])


### PR DESCRIPTION
### What
Before this change we wouldn't remember `training_source_uri` or `training_source_type`, so if you call `consolidate_updates()`, which calls `ingest()`, we would re-train the centroids on different data than the first time, i.e. we would lose training_source_uri and use first N vectors from the input data approach.

This PR adds code to store the training_source_uri in metadata so that we can use it in the `consolidate_updates()` call.

### TODO
It seems like we should be storing some other things in metadata as well, for example `training_input_vectors`, so that we can reconstruct the original index exactly when we call `consolidate_updates()`. I will look at that as a follow-up.

### Testing
I added consolidate / update to unit tests and also did manual testing.

Before this change if you ran:
```
index = ingest(
    index_type="IVF_FLAT", 
    index_uri=index_uri, 
    source_uri=os.path.join(dataset_dir, "data.tdb"),
    training_source_uri=os.path.join(dataset_dir, "training_data.tdb")
)

print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================')
query_vector_index = 1
query_vectors = np.array([data.transpose()[query_vector_index]], dtype=np.float32)
result_d, result_i = index.query(query_vectors, k=1)
check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])

print('[test_ingestion@test_ingest_with_training_source_uri_tdb] update_batch() ======================')
update_vectors = np.empty([3], dtype=object)
update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))

print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================')
index = index.consolidate_updates()

query_vectors = np.array([update_vectors[2]], dtype=np.float32)
result_d, result_i = index.query(query_vectors, k=1)
print('result_d', result_d, 'result_i', result_i)
check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])

################################################################################################
# Test we can load the index again and query, update, and consolidate.
################################################################################################
print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index_ram = FlatIndex(uri=index_uri) ======================')
index_ram = IVFFlatIndex(uri=index_uri)

update_vectors = np.empty([2], dtype=object)
update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
index_ram = index_ram.consolidate_updates()

query_vectors = np.array([update_vectors[0]], dtype=np.float32)
result_d, result_i = index_ram.query(query_vectors, k=1)
check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])

################################################################################################
# Test that we can ingest with training_source_type.
################################################################################################
ingest(
    index_type="IVF_FLAT",
    index_uri=os.path.join(tmp_path, "array_2"), 
    source_uri=os.path.join(dataset_dir, "data.tdb"),
    training_source_uri=os.path.join(dataset_dir, "training_data.tdb"),
    training_source_type="TILEDB_ARRAY"
)
```
you would see issues in the `[ingestion@centralised_kmeans] sample_vectors` line where in later calls to ingest the sample_vectors are different from the first ingest():
```
test/test_ingestion.py [test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================
[ingestion@create_arrays]
[ivf_flat_index@create] uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1014/test_ingest_with_training_sour0/array group_exists True config None storage_version 0.3 kwargs {}
[ingestion@centralised_kmeans] training_sample_size 5 training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1014/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type None
[ingestion@centralised_kmeans] training_in_size 5 training_dimensions 2 training_vector_type float32
[ingestion@centralised_kmeans] sample_vectors (5, 2) 
 [[1.1 1.2]
 [2.1 2.2]
 [3.1 3.2]
 [4.1 4.2]
 [5.1 5.2]]
[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================
[test_ingestion@test_ingest_with_training_source_uri_tdb] update_batch() ======================
[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================
[ingestion@create_arrays]
[ingestion@centralised_kmeans] training_sample_size 5 training_source_uri None training_source_type None
[ingestion@centralised_kmeans] sample_vectors (5, 4) 
 [[1.  1.1 1.2 1.3]
 [2.  2.1 2.2 2.3]
 [3.  3.1 3.2 3.3]
 [4.  4.1 4.2 4.3]
 [5.  5.1 5.2 5.3]]
result_d [[0.]] result_i [[1002]]
[test_ingestion@test_ingest_with_training_source_uri_tdb] index_ram = FlatIndex(uri=index_uri) ======================
[ingestion@create_arrays]
[ingestion@centralised_kmeans] training_sample_size 8 training_source_uri None training_source_type None
[ingestion@centralised_kmeans] sample_vectors (8, 4) 
 [[3.  3.1 3.2 3.3]
 [4.  4.1 4.2 4.3]
 [5.  5.1 5.2 5.3]
 [6.  6.1 6.2 6.3]
 [7.  7.1 7.2 7.3]
 [8.  8.1 8.2 8.3]
 [1.  1.1 1.2 1.3]
 [2.  2.1 2.2 2.3]]
[ingestion@create_arrays]
[ivf_flat_index@create] uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1014/test_ingest_with_training_sour0/array_2 group_exists True config None storage_version 0.3 kwargs {}
[ingestion@centralised_kmeans] training_sample_size 5 training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1014/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type TILEDB_ARRAY
[ingestion@centralised_kmeans] training_in_size 5 training_dimensions 2 training_vector_type float32
[ingestion@centralised_kmeans] sample_vectors (5, 2) 
 [[1.1 1.2]
 [2.1 2.2]
 [3.1 3.2]
 [4.1 4.2]
 [5.1 5.2]]
```
But after this change you get this, and you can see they are the same each time:
```
test/test_ingestion.py [test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================
[ingestion@create_arrays]
[ivf_flat_index@create] uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1015/test_ingest_with_training_sour0/array group_exists True config None storage_version 0.3 kwargs {}
[ingestion@centralised_kmeans] training_sample_size 5 training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1015/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type None
[ingestion@centralised_kmeans] training_in_size 5 training_dimensions 2 training_vector_type float32
[ingestion@centralised_kmeans] sample_vectors (5, 2) 
 [[1.1 1.2]
 [2.1 2.2]
 [3.1 3.2]
 [4.1 4.2]
 [5.1 5.2]]
[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================
[test_ingestion@test_ingest_with_training_source_uri_tdb] update_batch() ======================
[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================
[ingestion@create_arrays]
[ingestion@centralised_kmeans] training_sample_size 5 training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1015/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type None
[ingestion@centralised_kmeans] training_in_size 5 training_dimensions 2 training_vector_type float32
[ingestion@centralised_kmeans] sample_vectors (5, 2) 
 [[1.1 1.2]
 [2.1 2.2]
 [3.1 3.2]
 [4.1 4.2]
 [5.1 5.2]]
result_d [[0.]] result_i [[1002]]
[test_ingestion@test_ingest_with_training_source_uri_tdb] index_ram = FlatIndex(uri=index_uri) ======================
[ingestion@create_arrays]
[ingestion@centralised_kmeans] training_sample_size 8 training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1015/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type None
[ingestion@centralised_kmeans] training_in_size 5 training_dimensions 2 training_vector_type float32
[ingestion@centralised_kmeans] sample_vectors (5, 2) 
 [[1.1 1.2]
 [2.1 2.2]
 [3.1 3.2]
 [4.1 4.2]
 [5.1 5.2]]
[ingestion@create_arrays]
[ivf_flat_index@create] uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1015/test_ingest_with_training_sour0/array_2 group_exists True config None storage_version 0.3 kwargs {}
[ingestion@centralised_kmeans] training_sample_size 5 training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1015/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type TILEDB_ARRAY
[ingestion@centralised_kmeans] training_in_size 5 training_dimensions 2 training_vector_type float32
[ingestion@centralised_kmeans] sample_vectors (5, 2) 
 [[1.1 1.2]
 [2.1 2.2]
 [3.1 3.2]
 [4.1 4.2]
 [5.1 5.2]]
```

<img width="1300" alt="Screenshot 2023-12-18 at 5 28 07 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/47ea26f9-01d7-4977-bdfc-2082297fc272">

