### PR TITLE
Fix crash from passing `copy_centroids_uri` to `ingest()`

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -765,6 +765,8 @@ def ingest(
     def copy_centroids(
         index_group_uri: str,
         copy_centroids_uri: str,
+        partitions: int,
+        dimensions: int,
         config: Optional[Mapping[str, Any]] = None,
         verbose: bool = False,
         trace_id: Optional[str] = None,
@@ -777,8 +779,8 @@ def ingest(
         )
         src = tiledb.open(copy_centroids_uri, mode="r")
         dest = tiledb.open(centroids_uri, mode="w", timestamp=index_timestamp)
-        src_centroids = src[:, :]
-        dest[:, :] = src_centroids
+        src_centroids = src[0:dimensions, 0:partitions]
+        dest[0:dimensions, 0:partitions] = src_centroids
         logger.debug(src_centroids)
 
     # --------------------------------------------------------------------
@@ -1613,6 +1615,8 @@ def ingest(
                     copy_centroids,
                     index_group_uri=index_group_uri,
                     copy_centroids_uri=copy_centroids_uri,
+                    partitions=partitions,
+                    dimensions=dimensions,
                     config=config,
                     verbose=verbose,
                     trace_id=trace_id,

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -776,7 +776,7 @@ def test_copy_centroids_uri(tmp_path):
         copy_centroids_uri=centroids_uri
     )
 
-    # Query the index/
+    # Query the index.
     query_vector_index = 4
     query_vectors = np.array([data[query_vector_index]], dtype=np.float32)
     result_d, result_i = index.query(query_vectors, k=1)


### PR DESCRIPTION
### What
This fixes a crash from passing `copy_centroids_uri` to `ingest()`. From talking with Nikos:

> I think the problem is the domain of the centroids array
```
domain=tiledb.Domain(
            *[
                tiledb.Dim(name="rows", domain=(0, dimensions - 1), tile=dimensions, dtype=np.dtype(np.int32)),
                tiledb.Dim(name="cols", domain=(0, np.iinfo(np.dtype("int32")).max), tile=100000, dtype=np.dtype(np.int32)),
            ]
        ),
```
> The domain is [0:max_int32] with no indication of the actual size of centroids that you write to it. When reading with [:, :] it will try to read the entire domain filling with default values on missing data. This is why the process hangs as it tries to fill your memory with default values. I think we need to safeguard the copy operation by reading [0:partitions]  from the centroids array
> We used to have restrictive domains [0,size] in all arrays before implementing updates. This would allow reading with [:, :]. However now we should make sure that all reads are restricted when the array domains are not restricted

So here we  safeguard the copy operation in `copy_centroids_uri`.

### Note
It seems like we may have a flaky unit test, as I had one CI test failure: https://github.com/TileDB-Inc/TileDB-Vector-Search/actions/runs/7263516461/job/19788997097?pr=172

But I ran that code locally and it passed, and then I re-ran on GitHub and it passed. So I think we are okay to move forward with this.

### Testing
Before if you ran the newly added unit test, you would crash:
```
================================================= test session starts =================================================
platform darwin -- Python 3.9.18, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/parismorgan/repo/TileDB-Vector-Search/apis/python
collected 1 item                                                                                                      

test/test_ingestion.py [test_ingestion@test_copy_centroids_uri] ==========================================
[test_ingestion@test_copy_centroids_uri] in_size 2 dimensions 4 vector_type float32
[test_ingestion@test_copy_centroids_uri] centroids_uri ArraySchema(
  domain=Domain(*[
    Dim(name='rows', domain=(0, 3), tile=4, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
    Dim(name='cols', domain=(0, 2147483647), tile=100000, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
  ]),
  attrs=[
    Attr(name='centroids', dtype='float32', var=False, nullable=False, enum_label=None, filters=FilterList([ZstdFilter(level=-1), ])),
  ],
  cell_order='col-major',
  tile_order='col-major',
  sparse=False,
)

[test_ingestion@test_copy_centroids_uri] centroids_uri OrderedDict([('centroids', array([[1., 2.],
       [1., 2.],
       [1., 2.],
       [1., 2.]], dtype=float32))])
[test_ingestion@test_copy_centroids_uri@ingest] ==========================================
[ingestion@ingest] copy_centroids_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1182/test_copy_centroids_uri0/dataset/centroids.tdb training_sample_size -1 training_input_vectors None training_source_uri None training_source_type None
[ivf_flat_index.py@create] dimensions 4 vector_type float32
[ingestion@copy_centroids] partitions 2 dimensions 4
[ingest@copy_centroids] centroids_uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1182/test_copy_centroids_uri0/array/partition_centroids
Fatal Python error: Bus error

Thread 0xFatal Python error: Segmentation fault

0000000292013000 (most recent call first):
  File "/opt/homebrew/anaconda3/envs/TileDB-Vector-Search/lib/python3.9/site-packages/tiledb/vector_search/ingestion.py", line 808 in copy_centroids
  File "/opt/homebrew/anaconda3/envs/TileDB-Vector-Search/lib/python3.9/site-packages/tiledb/cloud/_results/results.py", line 
```
But now you don't:
```
(TileDB-Vector-Search) ~/repo/TileDB-Vector-Search/apis/python pytest test/test_ingestion.py -s          
================================================= test session starts =================================================
platform darwin -- Python 3.9.18, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/parismorgan/repo/TileDB-Vector-Search/apis/python
collected 1 item                                                                                                      

test/test_ingestion.py [test_ingestion@test_copy_centroids_uri] ==========================================
[test_ingestion@test_copy_centroids_uri] in_size 2 dimensions 4 vector_type float32
[test_ingestion@test_copy_centroids_uri] centroids_uri ArraySchema(
  domain=Domain(*[
    Dim(name='rows', domain=(0, 3), tile=4, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
    Dim(name='cols', domain=(0, 2147483647), tile=100000, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
  ]),
  attrs=[
    Attr(name='centroids', dtype='float32', var=False, nullable=False, enum_label=None, filters=FilterList([ZstdFilter(level=-1), ])),
  ],
  cell_order='col-major',
  tile_order='col-major',
  sparse=False,
)

[test_ingestion@test_copy_centroids_uri] centroids_uri OrderedDict([('centroids', array([[1., 2.],
       [1., 2.],
       [1., 2.],
       [1., 2.]], dtype=float32))])
[test_ingestion@test_copy_centroids_uri@ingest] ==========================================
[ingestion@ingest] copy_centroids_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1183/test_copy_centroids_uri0/dataset/centroids.tdb training_sample_size -1 training_input_vectors None training_source_uri None training_source_type None
[ivf_flat_index.py@create] dimensions 4 vector_type float32
[ingestion@copy_centroids] partitions 2 dimensions 4
[ingest@copy_centroids] centroids_uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1183/test_copy_centroids_uri0/array/partition_centroids
[ingest@copy_centroids] src_centroids OrderedDict([('centroids', array([[1., 2.],
       [1., 2.],
       [1., 2.],
       [1., 2.]], dtype=float32))])
[ingest@copy_centroids] dest DenseArray(uri='file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1183/test_copy_centroids_uri0/array/partition_centroids', mode=w, ndim=2)
[ingest@copy_centroids] dest after OrderedDict([('centroids', array([[1., 2.],
       [1., 2.],
       [1., 2.],
       [1., 2.]], dtype=float32))])
[ivf_flat_index.py] self._centroids
 ArraySchema(
  domain=Domain(*[
    Dim(name='rows', domain=(0, 3), tile=4, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
    Dim(name='cols', domain=(0, 2147483647), tile=100000, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
  ]),
  attrs=[
    Attr(name='centroids', dtype='float32', var=False, nullable=False, enum_label=None, filters=FilterList([ZstdFilter(level=-1), ])),
  ],
  cell_order='col-major',
  tile_order='col-major',
  sparse=False,
)

.
```

### Note
We also fix two issues in `test_ingest_with_training_source_uri_f32` and `test_ingest_with_training_source_uri_f32`. In a follow-up I'll look at whether we should throw if we load a `IVFFlatIndex` into a `FlatIndex`.
