### PR TITLE
Fix `training_data` bug in `test_ingest_with_training_source_uri_tdb` and validate training data dimensions in `ingest()`

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -134,8 +134,6 @@ def ingest(
     from tiledb.vector_search.index import Index
     from tiledb.vector_search.storage_formats import storage_formats
 
-    print('[ingestion@ingest]', 'copy_centroids_uri', copy_centroids_uri, 'training_sample_size', training_sample_size, 'training_input_vectors', training_input_vectors, 'training_source_uri', training_source_uri, 'training_source_type', training_source_type)
-
     validate_storage_version(storage_version)
 
     if source_type and not source_uri:
@@ -254,7 +252,6 @@ def ingest(
     ) -> Tuple[int, int, np.dtype]:
         if source_type == "TILEDB_ARRAY":
             schema = tiledb.ArraySchema.load(source_uri)
-            print('[ingest@read_source_metadata] schema', schema)
             size = schema.domain.dim(1).domain[1] + 1
             dimensions = schema.domain.dim(0).domain[1] + 1
             return size, dimensions, schema.attr("values").dtype
@@ -813,7 +810,6 @@ def ingest(
         trace_id: Optional[str] = None,
         use_sklearn: bool = False
     ):
-        print('[ingest@centralised_kmeans] training_sample_size', training_sample_size, 'training_source_uri', training_source_uri, 'training_source_type', training_source_type)
         from sklearn.cluster import KMeans
 
         from tiledb.vector_search.module import (
@@ -830,7 +826,6 @@ def ingest(
                     if training_source_type is None:
                         training_source_type = autodetect_source_type(source_uri=training_source_uri)
                     training_in_size, training_dimensions, training_vector_type = read_source_metadata(source_uri=training_source_uri, source_type=training_source_type)
-                    print('[ingest@centralised_kmeans] reading from training_source_uri: training_source_uri', training_source_uri, 'training_source_type', training_source_type, 'training_in_size', training_in_size, 'training_dimensions', training_dimensions, 'training_vector_type', training_vector_type)
                     if dimensions != training_dimensions:
                         raise ValueError(f"When training centroids, the index data dimensions ({dimensions}) != the training data dimensions ({training_dimensions})")
                     sample_vectors = read_input_vectors(
@@ -845,7 +840,6 @@ def ingest(
                         trace_id=trace_id,
                     ).astype(np.float32)
                 else:
-                    print('[ingest@centralised_kmeans] reading from source_uri: source_uri', source_uri, 'source_type', source_type, 'vector_type', vector_type, 'dimensions', dimensions, 'training_sample_size', training_sample_size)
                     sample_vectors = read_input_vectors(
                         source_uri=source_uri,
                         source_type=source_type,
@@ -878,13 +872,9 @@ def ingest(
                 # raise ValueError(f"We have a training_sample_size of {training_sample_size} but {partitions} partitions - training_sample_size must be >= partitions")
                 centroids = np.random.rand(dimensions, partitions)
 
-            print('[ingestion@centralized_kmeans] sample_vectors', sample_vectors.shape, '\n', sample_vectors, '\ncentroids', centroids.shape, '\n', centroids)
             logger.debug("Writing centroids to array %s", centroids_uri)
             with tiledb.open(centroids_uri, mode="w", timestamp=index_timestamp) as A:
                 A[0:dimensions, 0:partitions] = centroids
-
-            # with tiledb.open(centroids_uri, mode="r") as A:
-            #     print('[ingest@centralized_kmeans] centroids_uri', centroids_uri, A.shape, '\n', A[:])
 
     # --------------------------------------------------------------------
     # distributed kmeans UDFs

--- a/apis/python/test/common.py
+++ b/apis/python/test/common.py
@@ -295,8 +295,8 @@ def check_equals(result_d, result_i, expected_result_d, expected_result_i):
     result_i_expected: int
         The expected indices
     """
-    assert result_i == expected_result_i
-    assert result_d == expected_result_d
+    assert result_i == expected_result_i, f"result_i: {result_i} != expected_result_i: {expected_result_i}"
+    assert result_d == expected_result_d, f"result_d: {result_d} != expected_result_d: {expected_result_d}"
 
 # Generate random names for test array uris
 def random_name(name: str) -> str:

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -898,16 +898,14 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
         [3.0, 3.1, 3.2, 3.3], 
         [4.0, 4.1, 4.2, 4.3], 
         [5.0, 5.1, 5.2, 5.3]], dtype=np.float32).transpose()
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] data', data.shape, '\n', data)
     create_array(path=os.path.join(dataset_dir, "data.tdb"), data=data)
 
     training_data = np.array([
         [1.0, 1.1, 1.2, 1.3], 
         [5.0, 5.1, 5.2, 5.3]], dtype=np.float32).transpose()
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] training_data', training_data.shape, '\n', training_data)
     create_array(path=os.path.join(dataset_dir, "training_data.tdb"), data=training_data)
 
-    # Run a quick test that if we setup training_data incorrectly we will throw.
+    # Run a quick test that if we set up training_data incorrectly, we will raise an exception.
     with pytest.raises(ValueError) as error:
         training_data_invalid = np.array([
             [1.0, 1.1, 1.2], 
@@ -919,7 +917,6 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
             source_uri=os.path.join(dataset_dir, "data.tdb"),
             training_source_uri=os.path.join(dataset_dir, "training_data_invalid.tdb")
         )
-    print('error', error)
     assert "training data dimensions" in str(error.value)
 
     ################################################################################################
@@ -934,52 +931,16 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
         training_source_uri=os.path.join(dataset_dir, "training_data.tdb")
     )
 
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
     query_vector_index = 1
     query_vectors = np.array([data.transpose()[query_vector_index]], dtype=np.float32)
     result_d, result_i = index.query(query_vectors, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
-    update_vectors = np.empty([3], dtype=object)
-    update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
-    update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
-    update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
-    index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
-    
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================================')
-    index = index.consolidate_updates()
-
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
-    query_vectors = np.array([update_vectors[2]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
-
-    ################################################################################################
-    # Test we can load the index again and query, update, and consolidate.
-    ################################################################################################
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index_ram = IVFFlatIndex(uri=index_uri) ======================================')
     index_ram = IVFFlatIndex(uri=index_uri)
-
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
-    
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================================')
-    update_vectors = np.empty([2], dtype=object)
-    update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
-    update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
-    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
-    index_ram = index_ram.consolidate_updates()
-    
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
-    query_vectors = np.array([update_vectors[0]], dtype=np.float32)
     result_d, result_i = index_ram.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
-    ################################################################################################
-    # Test that we can ingest with training_source_type.
-    ################################################################################################
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================================')
+    # Also test that we can ingest with training_source_type.
     ingest(
         index_type="IVF_FLAT",
         index_uri=os.path.join(tmp_path, "array_2"), 
@@ -992,10 +953,26 @@ def test_ingest_with_training_source_uri_numpy(tmp_path):
     ################################################################################################
     # First set up the data.
     ################################################################################################
-    data = np.array([[1.0, 1.1, 1.2, 1.3], [2.0, 2.1, 2.2, 2.3], [3.0, 3.1, 3.2, 3.3], [4.0, 4.1, 4.2, 4.3], [5.0, 5.1, 5.2, 5.3]], dtype=np.float32)
-    print('data', data)
+    data = np.array([
+        [1.0, 1.1, 1.2, 1.3], 
+        [2.0, 2.1, 2.2, 2.3], 
+        [3.0, 3.1, 3.2, 3.3], 
+        [4.0, 4.1, 4.2, 4.3], 
+        [5.0, 5.1, 5.2, 5.3]], dtype=np.float32)
     training_data = data[1:3]
-    print('training_data', training_data)
+
+    # Run a quick test that if we set up training_data incorrectly, we will raise an exception.
+    with pytest.raises(ValueError) as error:
+        training_data_invalid = np.array([
+            [4.0, 4.1, 4.2], 
+            [5.0, 5.1, 5.2]], dtype=np.float32)
+        index = ingest(
+            index_type="IVF_FLAT", 
+            index_uri=os.path.join(tmp_path, "array_invalid"), 
+            input_vectors=data,
+            training_input_vectors=training_data_invalid,
+        )
+    assert "training data dimensions" in str(error.value)
 
     ################################################################################################
     # Test we can ingest, query, update, and consolidate.
@@ -1013,33 +990,6 @@ def test_ingest_with_training_source_uri_numpy(tmp_path):
     result_d, result_i = index.query(query_vectors, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
-    update_vectors = np.empty([3], dtype=object)
-    update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
-    update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
-    update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
-    index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
-    
-    index = index.consolidate_updates()
-
-    query_vectors = np.array([update_vectors[2]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
-
-    ################################################################################################
-    # Test we can load the index again and query, update, and consolidate.
-    ################################################################################################
     index_ram = IVFFlatIndex(uri=index_uri)
-
-    query_vectors = np.array([data[query_vector_index]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
-
-    update_vectors = np.empty([2], dtype=object)
-    update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
-    update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
-    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
-    index_ram = index_ram.consolidate_updates()
-    
-    query_vectors = np.array([update_vectors[0]], dtype=np.float32)
     result_d, result_i = index_ram.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])


### PR DESCRIPTION
### What
When I created `training_data` in the new `test_ingest_with_training_source_uri_tdb()` test, I accidentally did not slice the original data correctly, as it had already been transposed and so I couldn't just slice it. That was leading to us computing a 2x2 centroid instead of a 4x2 centroid, as you can see here:
```
(TileDB-Vector-Search) ~/repo/TileDB-Vector-Search/apis/python pytest test/test_ingestion.py -s            ✹main 
============================================== test session starts ===============================================
platform darwin -- Python 3.9.18, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/parismorgan/repo/TileDB-Vector-Search/apis/python
plugins: nbmake-1.4.6
collected 1 item                                                                                                 

test/test_ingestion.py [test_ingestion@test_ingest_with_training_source_uri_tdb] data (4, 5) 
 [[1.  2.  3.  4.  5. ]
 [1.1 2.1 3.1 4.1 5.1]
 [1.2 2.2 3.2 4.2 5.2]
 [1.3 2.3 3.3 4.3 5.3]]
[test_ingestion@test_ingest_with_training_source_uri_tdb] training_data (2, 4) 
 [[2.  2.1 2.2 2.3]
 [3.  3.1 3.2 3.3]]
[test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================================
[ingestion@ingest] copy_centroids_uri None training_sample_size -1 training_input_vectors None training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1217/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type None
[ingest@read_source_metadata] schema ArraySchema(
  domain=Domain(*[
    Dim(name='rows', domain=(0, 3), tile=3, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
    Dim(name='cols', domain=(0, 4), tile=3, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
  ]),
  attrs=[
    Attr(name='values', dtype='float32', var=False, nullable=False, enum_label=None),
  ],
  cell_order='col-major',
  tile_order='col-major',
  sparse=False,
)

[ivf_flat_index.py@create] dimensions 4 vector_type float32
[ingest@centralised_kmeans] training_sample_size 5 training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1217/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type None
[ingest@read_source_metadata] schema ArraySchema(
  domain=Domain(*[
    Dim(name='rows', domain=(0, 1), tile=1, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
    Dim(name='cols', domain=(0, 3), tile=3, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
  ]),
  attrs=[
    Attr(name='values', dtype='float32', var=False, nullable=False, enum_label=None),
  ],
  cell_order='col-major',
  tile_order='col-major',
  sparse=False,
)

[ingest@centralised_kmeans] reading from training_source_uri: training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1217/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type TILEDB_ARRAY training_in_size 4 training_dimensions 2 training_vector_type float32
[ingestion@centralized_kmeans] sample_vectors (4, 2) 
 [[2.  3. ]
 [2.1 3.1]
 [2.2 3.2]
 [2.3 3.3]] 
centroids (2, 2) 
 [[2.05 2.25]
 [3.05 3.25]]
```
This PR fixes this issue with `training_data` and also adds a check into the code so we raise an exception if this happens. Here is the same test now working correctly (you are looking for `centroids` at the bottom):
```
(TileDB-Vector-Search) ~/repo/TileDB-Vector-Search/apis/python pytest test/test_ingestion.py -s       2 ↵  ✹main 
============================================== test session starts ===============================================
platform darwin -- Python 3.9.18, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/parismorgan/repo/TileDB-Vector-Search/apis/python
plugins: nbmake-1.4.6
collected 1 item                                                                                                 

test/test_ingestion.py [test_ingestion@test_ingest_with_training_source_uri_tdb] data (4, 5) 
 [[1.  2.  3.  4.  5. ]
 [1.1 2.1 3.1 4.1 5.1]
 [1.2 2.2 3.2 4.2 5.2]
 [1.3 2.3 3.3 4.3 5.3]]
[test_ingestion@test_ingest_with_training_source_uri_tdb] training_data (4, 2) 
 [[1.  2. ]
 [1.1 2.1]
 [1.2 2.2]
 [1.3 2.3]]
[test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================================
[ingestion@ingest] copy_centroids_uri None training_sample_size -1 training_input_vectors None training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1218/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type None
[ingest@read_source_metadata] schema ArraySchema(
  domain=Domain(*[
    Dim(name='rows', domain=(0, 3), tile=3, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
    Dim(name='cols', domain=(0, 4), tile=3, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
  ]),
  attrs=[
    Attr(name='values', dtype='float32', var=False, nullable=False, enum_label=None),
  ],
  cell_order='col-major',
  tile_order='col-major',
  sparse=False,
)

[ivf_flat_index.py@create] dimensions 4 vector_type float32
[ingest@centralised_kmeans] training_sample_size 5 training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1218/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type None
[ingest@read_source_metadata] schema ArraySchema(
  domain=Domain(*[
    Dim(name='rows', domain=(0, 3), tile=3, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
    Dim(name='cols', domain=(0, 1), tile=1, dtype='int32', filters=FilterList([ZstdFilter(level=-1), ])),
  ]),
  attrs=[
    Attr(name='values', dtype='float32', var=False, nullable=False, enum_label=None),
  ],
  cell_order='col-major',
  tile_order='col-major',
  sparse=False,
)

[ingest@centralised_kmeans] reading from training_source_uri: training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1218/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type TILEDB_ARRAY training_in_size 2 training_dimensions 4 training_vector_type float32
[ingestion@centralized_kmeans] sample_vectors (2, 4) 
 [[1.  1.1 1.2 1.3]
 [2.  2.1 2.2 2.3]] 
centroids (4, 2) 
 [[1.5       0.       ]
 [1.5999999 0.       ]
 [1.7       0.       ]
 [1.8       0.       ]]
.
```

<img width="1784" alt="Screenshot 2023-12-20 at 12 19 25 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/b20dd7b4-ca9a-4d77-84bb-86929b8c2beb">

### Testing
* Manual test as shown above
* Adds checks to unit tests that we can hit this scenario

### Note
I also added a few checks to inputs to `ingest()` - they same safe and potentially useful.