### PR TITLE
Small refactor of unit tests to consolidate language and add a query and check helper to `test_ingestion.py`

### DIFF
--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -40,7 +40,7 @@ class CloudTests(unittest.TestCase):
         k = 100
         nqueries = 100
 
-        query_vectors = load_fvecs(queries_uri)
+        queries = load_fvecs(queries_uri)
         gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
         index = vs.ingest(
@@ -50,7 +50,7 @@ class CloudTests(unittest.TestCase):
             config=tiledb.cloud.Config().dict(),
             mode=Mode.BATCH,
         )
-        _, result_i = index.query(query_vectors, k=k)
+        _, result_i = index.query(queries, k=k)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
     def test_cloud_ivf_flat(self):
@@ -63,7 +63,7 @@ class CloudTests(unittest.TestCase):
         nqueries = 100
         nprobe = 20
 
-        query_vectors = load_fvecs(queries_uri)
+        queries = load_fvecs(queries_uri)
         gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
         index = vs.ingest(
@@ -79,16 +79,16 @@ class CloudTests(unittest.TestCase):
             # mode=Mode.BATCH,
         )
 
-        _, result_i = index.query(query_vectors, k=k, nprobe=nprobe)
+        _, result_i = index.query(queries, k=k, nprobe=nprobe)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
         _, result_i = index.query(
-            query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME, num_partitions=2, resource_class="standard"
+            queries, k=k, nprobe=nprobe, mode=Mode.REALTIME, num_partitions=2, resource_class="standard"
         )
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
         _, result_i = index.query(
-            query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL, num_partitions=2
+            queries, k=k, nprobe=nprobe, mode=Mode.LOCAL, num_partitions=2
         )
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
@@ -97,20 +97,20 @@ class CloudTests(unittest.TestCase):
 
         # Cannot pass resource_class or resources to LOCAL mode or to no mode.
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL, resource_class="large")
+            index.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL, resource_class="large")
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL, resources=resources)
+            index.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL, resources=resources)
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, resource_class="large")
+            index.query(queries, k=k, nprobe=nprobe, resource_class="large")
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, resources=resources)
+            index.query(queries, k=k, nprobe=nprobe, resources=resources)
 
         # Cannot pass resources to REALTIME.
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME, resources=resources)
+            index.query(queries, k=k, nprobe=nprobe, mode=Mode.REALTIME, resources=resources)
 
         # Cannot pass both resource_class and resources.
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME, resource_class="large", resources=resources)
+            index.query(queries, k=k, nprobe=nprobe, mode=Mode.REALTIME, resource_class="large", resources=resources)
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.BATCH, resource_class="large", resources=resources)
+            index.query(queries, k=k, nprobe=nprobe, mode=Mode.BATCH, resource_class="large", resources=resources)

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -131,8 +131,8 @@ def test_index_with_incorrect_num_of_query_columns_simple(tmp_path):
             index.query(np.random.rand(*query_shape).astype(np.float32), k=10)
 
         # Okay otherwise.
-        query_vectors = load_fvecs(queries_uri)
-        index.query(query_vectors, k=10)
+        queries = load_fvecs(queries_uri)
+        index.query(queries, k=10)
 
 def test_index_with_incorrect_num_of_query_columns_complex(tmp_path):
     # Tests that we raise a TypeError if the number of columns in the query is not the same as the 

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -14,6 +14,9 @@ from tiledb.vector_search.utils import load_fvecs
 MINIMUM_ACCURACY = 0.85
 MAX_UINT64 = np.iinfo(np.dtype("uint64")).max
 
+def query_and_check_equals(index, queries, expected_result_d, expected_result_i):
+    result_d, result_i = index.query(queries, k=1)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=expected_result_d, expected_result_i=expected_result_i)
 
 def test_flat_ingestion_u8(tmp_path):
     dataset_dir = os.path.join(tmp_path, "dataset")
@@ -22,7 +25,7 @@ def test_flat_ingestion_u8(tmp_path):
     dtype = np.uint8
     k = 10
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
 
     index = ingest(
@@ -30,7 +33,7 @@ def test_flat_ingestion_u8(tmp_path):
         index_uri=index_uri,
         source_uri=os.path.join(dataset_dir, "data.u8bin"),
     )
-    _, result = index.query(query_vectors, k=k)
+    _, result = index.query(queries, k=k)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
@@ -41,7 +44,7 @@ def test_flat_ingestion_f32(tmp_path):
     dtype = np.float32
     k = 10
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
 
     index = ingest(
@@ -49,11 +52,11 @@ def test_flat_ingestion_f32(tmp_path):
         index_uri=index_uri,
         source_uri=os.path.join(dataset_dir, "data.f32bin"),
     )
-    _, result = index.query(query_vectors, k=k)
+    _, result = index.query(queries, k=k)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = FlatIndex(uri=index_uri)
-    _, result = index_ram.query(query_vectors, k=k)
+    _, result = index_ram.query(queries, k=k)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
@@ -66,7 +69,7 @@ def test_flat_ingestion_external_id_u8(tmp_path):
     k = 10
     external_ids_offset = 100
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
     external_ids = np.array(
         [range(external_ids_offset, size + external_ids_offset)], np.uint64
@@ -78,7 +81,7 @@ def test_flat_ingestion_external_id_u8(tmp_path):
         source_uri=os.path.join(dataset_dir, "data.u8bin"),
         external_ids=external_ids,
     )
-    _, result = index.query(query_vectors, k=k)
+    _, result = index.query(queries, k=k)
     assert (
         accuracy(result, gt_i, external_ids_offset=external_ids_offset)
         > MINIMUM_ACCURACY
@@ -97,7 +100,7 @@ def test_ivf_flat_ingestion_u8(tmp_path):
     create_random_dataset_u8(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
     dtype = np.uint8
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
     index = ingest(
         index_type="IVF_FLAT",
@@ -106,15 +109,15 @@ def test_ivf_flat_ingestion_u8(tmp_path):
         partitions=partitions,
         input_vectors_per_work_item=int(size / 10),
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = IVFFlatIndex(uri=index_uri, memory_budget=int(size / 10))
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     _, result = index_ram.query(
-        query_vectors,
+        queries,
         k=k,
         nprobe=nprobe,
         use_nuv_implementation=True,
@@ -122,7 +125,7 @@ def test_ivf_flat_ingestion_u8(tmp_path):
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     _, result = index_ram.query(
-        query_vectors,
+        queries,
         k=k,
         nprobe=nprobe,
         mode=Mode.LOCAL,
@@ -143,7 +146,7 @@ def test_ivf_flat_ingestion_f32(tmp_path):
     create_random_dataset_f32(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
     dtype = np.float32
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
 
     index = ingest(
@@ -154,26 +157,26 @@ def test_ivf_flat_ingestion_f32(tmp_path):
         input_vectors_per_work_item=int(size / 10),
     )
 
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = IVFFlatIndex(uri=index_uri)
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = IVFFlatIndex(uri=index_uri, memory_budget=int(size / 10))
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     _, result = index_ram.query(
-        query_vectors,
+        queries,
         k=k,
         nprobe=nprobe,
         use_nuv_implementation=True,
     )
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
@@ -187,7 +190,7 @@ def test_ivf_flat_ingestion_fvec(tmp_path):
     nqueries = 100
     nprobe = 20
 
-    query_vectors = load_fvecs(queries_uri)
+    queries = load_fvecs(queries_uri)
     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
     index = ingest(
@@ -196,15 +199,15 @@ def test_ivf_flat_ingestion_fvec(tmp_path):
         source_uri=source_uri,
         partitions=partitions,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = IVFFlatIndex(uri=index_uri)
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     _, result = index_ram.query(
-        query_vectors,
+        queries,
         k=k,
         nprobe=nprobe,
         use_nuv_implementation=True,
@@ -212,7 +215,7 @@ def test_ivf_flat_ingestion_fvec(tmp_path):
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     # NB: local mode currently does not return distances
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
@@ -228,7 +231,7 @@ def test_ivf_flat_ingestion_numpy(tmp_path):
 
     input_vectors = load_fvecs(source_uri)
 
-    query_vectors = load_fvecs(queries_uri)
+    queries = load_fvecs(queries_uri)
     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
     index = ingest(
@@ -237,22 +240,22 @@ def test_ivf_flat_ingestion_numpy(tmp_path):
         input_vectors=input_vectors,
         partitions=partitions,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = IVFFlatIndex(uri=index_uri)
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     _, result = index_ram.query(
-        query_vectors,
+        queries,
         k=k,
         nprobe=nprobe,
         use_nuv_implementation=True,
     )
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
@@ -266,7 +269,7 @@ def test_ivf_flat_ingestion_multiple_workers(tmp_path):
     nqueries = 100
     nprobe = 20
 
-    query_vectors = load_fvecs(queries_uri)
+    queries = load_fvecs(queries_uri)
     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
     index = ingest(
@@ -277,15 +280,15 @@ def test_ivf_flat_ingestion_multiple_workers(tmp_path):
         input_vectors_per_work_item=421,
         max_tasks_per_stage=4,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = IVFFlatIndex(uri=index_uri)
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     _, result = index_ram.query(
-        query_vectors,
+        queries,
         k=k,
         nprobe=nprobe,
         use_nuv_implementation=True,
@@ -293,7 +296,7 @@ def test_ivf_flat_ingestion_multiple_workers(tmp_path):
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     # NB: local mode currently does not return distances
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
@@ -311,7 +314,7 @@ def test_ivf_flat_ingestion_external_ids_numpy(tmp_path):
 
     input_vectors = load_fvecs(source_uri)
 
-    query_vectors = load_fvecs(queries_uri)
+    queries = load_fvecs(queries_uri)
     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
     external_ids = np.array(
         [range(external_ids_offset, size + external_ids_offset)], np.uint64
@@ -323,7 +326,7 @@ def test_ivf_flat_ingestion_external_ids_numpy(tmp_path):
         partitions=partitions,
         external_ids=external_ids,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i, external_ids_offset) > MINIMUM_ACCURACY
 
 
@@ -341,7 +344,7 @@ def test_ivf_flat_ingestion_with_updates(tmp_path):
     )
     dtype = np.uint8
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
     index = ingest(
         index_type="IVF_FLAT",
@@ -349,7 +352,7 @@ def test_ivf_flat_ingestion_with_updates(tmp_path):
         source_uri=os.path.join(dataset_dir, "data.u8bin"),
         partitions=partitions,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) == 1.0
 
     update_ids_offset = MAX_UINT64 - size
@@ -359,11 +362,11 @@ def test_ivf_flat_ingestion_with_updates(tmp_path):
         index.update(vector=data[i].astype(dtype), external_id=i + update_ids_offset)
         updated_ids[i] = i + update_ids_offset
 
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
     index = index.consolidate_updates(partitions=20)
-    _, result = index.query(query_vectors, k=k, nprobe=20)
+    _, result = index.query(queries, k=k, nprobe=20)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
 
@@ -381,7 +384,7 @@ def test_ivf_flat_ingestion_with_batch_updates(tmp_path):
     )
     dtype = np.uint8
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
     index = ingest(
         index_type="IVF_FLAT",
@@ -390,7 +393,7 @@ def test_ivf_flat_ingestion_with_batch_updates(tmp_path):
         partitions=partitions,
         input_vectors_per_work_item=int(size / 10),
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > 0.99
 
     update_ids = {}
@@ -411,11 +414,11 @@ def test_ivf_flat_ingestion_with_batch_updates(tmp_path):
         id += 1
 
     index.update_batch(vectors=updates, external_ids=external_ids)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i, updated_ids=updated_ids) > 0.99
 
     index = index.consolidate_updates()
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i, updated_ids=updated_ids) > 0.99
 
 
@@ -433,7 +436,7 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
     )
     dtype = np.uint8
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
     index = ingest(
         index_type="IVF_FLAT",
@@ -442,7 +445,7 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
         partitions=partitions,
         index_timestamp=1,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
 
     update_ids_offset = MAX_UINT64 - size
@@ -455,29 +458,29 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
         updated_ids[i] = i + update_ids_offset
 
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert (
         0.05
         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
         <= 0.15
     )
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert (
         0.05
         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
@@ -489,13 +492,13 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
     for i in range(2, 52):
         updated_ids_part[i] = i + update_ids_offset
     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert (
         0.02
         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
@@ -504,32 +507,32 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
 
     # Timetravel at previous ingestion timestamp
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
 
     # Consolidate updates
     index = index.consolidate_updates()
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert (
         0.05
         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
         <= 0.15
     )
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert (
         0.05
         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
@@ -541,13 +544,13 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
     for i in range(2, 52):
         updated_ids_part[i] = i + update_ids_offset
     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert (
         0.02
         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
@@ -556,76 +559,76 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
 
     # Timetravel at previous ingestion timestamp
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 1))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
 
     # Clear history before the latest ingestion
     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
     # Clear all history
     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp)
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
 
 
@@ -642,7 +645,7 @@ def test_ivf_flat_ingestion_with_additions_and_timetravel(tmp_path):
     )
     dtype = np.uint8
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
     index = ingest(
         index_type="IVF_FLAT",
@@ -651,7 +654,7 @@ def test_ivf_flat_ingestion_with_additions_and_timetravel(tmp_path):
         partitions=partitions,
         index_timestamp=1,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
 
     update_ids_offset = MAX_UINT64 - size
@@ -665,11 +668,11 @@ def test_ivf_flat_ingestion_with_additions_and_timetravel(tmp_path):
         updated_ids[i] = i + update_ids_offset
 
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert 0.45 < accuracy(result, gt_i) < 0.55
 
     index = index.consolidate_updates()
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert 0.45 < accuracy(result, gt_i) < 0.55
 
 
@@ -684,7 +687,7 @@ def test_storage_versions(tmp_path):
     source_uri = os.path.join(dataset_dir, "data.u8bin")
 
     dtype = np.uint8
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, _ = get_groundtruth(dataset_dir, k)
     
     indexes = ["FLAT", "IVF_FLAT"]
@@ -717,7 +720,7 @@ def test_storage_versions(tmp_path):
                 partitions=partitions,
                 storage_version=storage_version
             )
-            _, result = index.query(query_vectors, k=k)
+            _, result = index.query(queries, k=k)
             assert accuracy(result, gt_i) >= MINIMUM_ACCURACY
 
             update_ids_offset = MAX_UINT64 - size
@@ -727,15 +730,15 @@ def test_storage_versions(tmp_path):
                 index.update(vector=data[i].astype(dtype), external_id=i + update_ids_offset)
                 updated_ids[i] = i + update_ids_offset
 
-            _, result = index.query(query_vectors, k=k)
+            _, result = index.query(queries, k=k)
             assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
 
             index = index.consolidate_updates(partitions=20)
-            _, result = index.query(query_vectors, k=k)
+            _, result = index.query(queries, k=k)
             assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
 
             index_ram = index_class(uri=index_uri)
-            _, result = index_ram.query(query_vectors, k=k)
+            _, result = index_ram.query(queries, k=k)
             assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 def test_copy_centroids_uri(tmp_path):
@@ -773,14 +776,13 @@ def test_copy_centroids_uri(tmp_path):
         index_type="IVF_FLAT", 
         index_uri=index_uri, 
         input_vectors=data,
-        copy_centroids_uri=centroids_uri
+        copy_centroids_uri=centroids_uri,
+        partitions=centroids_in_size
     )
 
     # Query the index.
-    query_vector_index = 4
-    query_vectors = np.array([data[query_vector_index]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    queries = np.array([data[4]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[4]])
 
 
 def test_kmeans():
@@ -867,14 +869,11 @@ def test_ingest_with_training_source_uri_f32(tmp_path):
         training_source_uri=os.path.join(dataset_dir, "training_data.f32bin")
     )
 
-    query_vector_index = 1
-    query_vectors = np.array([data[query_vector_index]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    queries = np.array([data[1]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
 
-    index_ram = IVFFlatIndex(uri=index_uri)
-    result_d, result_i = index_ram.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    index = IVFFlatIndex(uri=index_uri)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
 
     # Also test that we can ingest with training_source_type.
     ingest(
@@ -920,9 +919,8 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
     assert "training data dimensions" in str(error.value)
 
     ################################################################################################
-    # Test we can ingest, query, update, and consolidate with a training_source_uri.
+    # Test we can ingest, query, update, and consolidate.
     ################################################################################################
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================================')
     index_uri = os.path.join(tmp_path, "array")
     index = ingest(
         index_type="IVF_FLAT", 
@@ -931,16 +929,15 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
         training_source_uri=os.path.join(dataset_dir, "training_data.tdb")
     )
 
-    query_vector_index = 1
-    query_vectors = np.array([data.transpose()[query_vector_index]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    queries = np.array([data.transpose()[1]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
 
-    index_ram = IVFFlatIndex(uri=index_uri)
-    result_d, result_i = index_ram.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    index = IVFFlatIndex(uri=index_uri)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
 
+    ###############################################################################################
     # Also test that we can ingest with training_source_type.
+    ###############################################################################################
     ingest(
         index_type="IVF_FLAT",
         index_uri=os.path.join(tmp_path, "array_2"), 
@@ -985,11 +982,8 @@ def test_ingest_with_training_source_uri_numpy(tmp_path):
         training_input_vectors=training_data,
     )
 
-    query_vector_index = 1
-    query_vectors = np.array([data[query_vector_index]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    queries = np.array([data[1]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
 
-    index_ram = IVFFlatIndex(uri=index_uri)
-    result_d, result_i = index_ram.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    index = IVFFlatIndex(uri=index_uri)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -776,8 +776,7 @@ def test_copy_centroids_uri(tmp_path):
         index_type="IVF_FLAT", 
         index_uri=index_uri, 
         input_vectors=data,
-        copy_centroids_uri=centroids_uri,
-        partitions=centroids_in_size
+        copy_centroids_uri=centroids_uri
     )
 
     # Query the index.


### PR DESCRIPTION
### What
* Changes naming from `query_vectors` to `queries` to match what `ingest()` calls it
* Adds a helper to `test_ingestion.py` which queries and checks for equality

### Testing
* Unit tests pass

### Note
Let me know if you would like us to name everything `query_vectors` instead of `queries`, I don't mind either way, but seems nice to pick one for public facing code.

### TODO
Would be also nice to consolidate language (i.e. `query_vectors` vs `queries`) in the `.ipynb`'s - will ask offline about how to propagate those changes to cloud, and also will do those updates in a separate PR.