### PR TITLE
Have `consolidate_updates()` reuse existing centroids by default with an option to re-compute them

### DIFF
--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -386,11 +386,11 @@ class Index:
         # We don't copy the centroids if self.partitions=0 because this means our index was previously empty.
         should_pass_copy_centroids_uri = self.index_type == "IVF_FLAT" and reuse_centroids and self.partitions > 0
         if should_pass_copy_centroids_uri:
+            # Make sure the user didn't pass an incorrect number of partitions.
             if 'partitions' in kwargs and self.partitions != kwargs['partitions']:
                 raise ValueError(f"The passed partitions={kwargs['partitions']} is different than the number of partitions ({self.partitions}) from when the index was created - this is an issue because with reuse_centroids=True, the partitions from the previous index will be used; to fix, set reuse_centroids=False, don't pass partitions, or pass the correct number of partitions.")
-            partitions = self.partitions
-        else:
-            partitions = kwargs.get('partitions', -1)
+            # We pass partitions through kwargs so that we don't pass it twice.
+            kwargs['partitions'] = self.partitions
 
         new_index = ingest(
             index_type=self.index_type,
@@ -403,7 +403,6 @@ class Index:
             index_timestamp=max_timestamp,
             storage_version=self.storage_version,
             copy_centroids_uri=self.centroids_uri if should_pass_copy_centroids_uri else None,
-            partitions=partitions,
             config=self.config,
             **kwargs,
         )

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -385,18 +385,12 @@ class Index:
 
         # We don't copy the centroids if self.partitions=0 because this means our index was previously empty.
         should_pass_copy_centroids_uri = self.index_type == "IVF_FLAT" and reuse_centroids and self.partitions > 0
-        print('should_pass_copy_centroids_uri', should_pass_copy_centroids_uri)
-        print('kwargs[partitions]', kwargs.get('partitions'))
-        print('partitions in kwargs', 'partitions' in kwargs)
-        print('self.centroids_uri', self.centroids_uri)
-        print('self.partitions', self.partitions)
         if should_pass_copy_centroids_uri:
             if 'partitions' in kwargs and self.partitions != kwargs['partitions']:
-                raise ValueError(f"The passed partitions={kwargs['partitions']} are different than the number of partitions ({self.partitions}) from when the index was created - this is an issue because with reuse_centroids=True, the partitions from the previous index will be used; to fix, set reuse_centroids=False, don't pass partitions, or pass the correct number of partitions.")
+                raise ValueError(f"The passed partitions={kwargs['partitions']} is different than the number of partitions ({self.partitions}) from when the index was created - this is an issue because with reuse_centroids=True, the partitions from the previous index will be used; to fix, set reuse_centroids=False, don't pass partitions, or pass the correct number of partitions.")
             partitions = self.partitions
         else:
             partitions = kwargs.get('partitions', -1)
-        print('partitions', partitions)
 
         new_index = ingest(
             index_type=self.index_type,

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -390,7 +390,6 @@ class Index:
             should only be provided when training_source_uri is provided
         """
         from tiledb.vector_search.ingestion import ingest
-        print(f'[index@consolidate_updates] self.partitions {self.partitions} self.size {self.size}')
         fragments_info = tiledb.array_fragments(
             self.updates_array_uri, ctx=tiledb.Ctx(self.config)
         )

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -404,7 +404,7 @@ class Index:
         tiledb.consolidate(self.updates_array_uri, config=conf)
         tiledb.vacuum(self.updates_array_uri, config=conf)
 
-        pass_copy_centroids_uri = self.index_type == "IVF_FLAT" and reuse_centroids
+        should_pass_copy_centroids_uri = self.index_type == "IVF_FLAT" and reuse_centroids
         new_index = ingest(
             index_type=self.index_type,
             index_uri=self.uri,
@@ -415,8 +415,8 @@ class Index:
             updates_uri=self.updates_array_uri,
             index_timestamp=max_timestamp,
             storage_version=self.storage_version,
-            copy_centroids_uri=self.centroids_uri if pass_copy_centroids_uri else None,
-            partitions=self.partitions if pass_copy_centroids_uri else -1,
+            copy_centroids_uri=self.centroids_uri if should_pass_copy_centroids_uri else None,
+            partitions=self.partitions if should_pass_copy_centroids_uri else -1,
             training_sample_size=training_sample_size,
             training_input_vectors=training_input_vectors,
             training_source_uri=training_source_uri,

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -158,6 +158,7 @@ def ingest(
     
     if training_sample_size < -1:
         raise ValueError("training_sample_size should either be positive or -1 (to auto-configure based on the dataset sizes)")
+
     if copy_centroids_uri is not None and training_sample_size != -1:
         raise ValueError("training_sample_size should either be positive or -1 (to auto-configure based on the dataset sizes)")
     if copy_centroids_uri is not None and partitions == -1:

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -134,6 +134,8 @@ def ingest(
     from tiledb.vector_search.index import Index
     from tiledb.vector_search.storage_formats import storage_formats
 
+    print('[ingestion@ingest]', 'copy_centroids_uri', copy_centroids_uri, 'training_sample_size', training_sample_size, 'training_input_vectors', training_input_vectors, 'training_source_uri', training_source_uri, 'training_source_type', training_source_type)
+
     validate_storage_version(storage_version)
 
     if source_type and not source_uri:
@@ -158,6 +160,10 @@ def ingest(
     
     if training_sample_size < -1:
         raise ValueError("training_sample_size should either be positive or -1 (to auto-configure based on the dataset sizes)")
+    if copy_centroids_uri is not None and training_sample_size != -1:
+        raise ValueError("training_sample_size should either be positive or -1 (to auto-configure based on the dataset sizes)")
+    if copy_centroids_uri is not None and partitions == -1:
+        raise ValueError("partitions must be explicitly set if copy_centroids_uri is provided (set it to the number of centroids in copy_centroids_uri)")
 
     if index_type != "IVF_FLAT" and training_sample_size != -1:
         raise ValueError("training_sample_size should only be provided with index_type IVF_FLAT")
@@ -783,9 +789,14 @@ def ingest(
         logger.debug(
             "Copying centroids from: %s, to: %s", copy_centroids_uri, centroids_uri
         )
+
+        dst_centroids = tiledb.open(centroids_uri, mode="r")
+        print('[ingest@copy_centroids] dst_centroids before write\n', dst_centroids[0:dimensions, 0:partitions]['centroids'])
+
         src = tiledb.open(copy_centroids_uri, mode="r")
         dest = tiledb.open(centroids_uri, mode="w", timestamp=index_timestamp)
         src_centroids = src[0:dimensions, 0:partitions]
+        print('[ingest@copy_centroids] src_centroids\n', src_centroids['centroids'])
         dest[0:dimensions, 0:partitions] = src_centroids
         logger.debug(src_centroids)
 
@@ -810,6 +821,7 @@ def ingest(
         trace_id: Optional[str] = None,
         use_sklearn: bool = False
     ):
+        print('[ingest@centralised_kmeans] training_sample_size', training_sample_size, 'training_source_uri', training_source_uri, 'training_source_type', training_source_type)
         from sklearn.cluster import KMeans
 
         from tiledb.vector_search.module import (
@@ -828,6 +840,7 @@ def ingest(
                     training_in_size, training_dimensions, training_vector_type = read_source_metadata(source_uri=training_source_uri, source_type=training_source_type)
                     if dimensions != training_dimensions:
                         raise ValueError(f"When training centroids, the index data dimensions ({dimensions}) != the training data dimensions ({training_dimensions})")
+                    print('[ingest@centralised_kmeans] reading from training_source_uri: training_source_uri', training_source_uri, 'training_source_type', training_source_type, 'training_in_size', training_in_size, 'training_dimensions', training_dimensions, 'training_vector_type', training_vector_type)
                     sample_vectors = read_input_vectors(
                         source_uri=training_source_uri,
                         source_type=training_source_type,
@@ -840,6 +853,7 @@ def ingest(
                         trace_id=trace_id,
                     ).astype(np.float32)
                 else:
+                    print('[ingest@centralised_kmeans] reading from source_uri: source_uri', source_uri, 'source_type', source_type, 'vector_type', vector_type, 'dimensions', dimensions, 'training_sample_size', training_sample_size)
                     sample_vectors = read_input_vectors(
                         source_uri=source_uri,
                         source_type=source_type,
@@ -872,6 +886,7 @@ def ingest(
                 # raise ValueError(f"We have a training_sample_size of {training_sample_size} but {partitions} partitions - training_sample_size must be >= partitions")
                 centroids = np.random.rand(dimensions, partitions)
 
+            print('[ingestion@centralized_kmeans] sample_vectors', sample_vectors.shape, '\n', sample_vectors, '\ncentroids', centroids.shape, '\n', centroids)
             logger.debug("Writing centroids to array %s", centroids_uri)
             with tiledb.open(centroids_uri, mode="w", timestamp=index_timestamp) as A:
                 A[0:dimensions, 0:partitions] = centroids
@@ -1617,6 +1632,7 @@ def ingest(
             )
             return d
         elif index_type == "IVF_FLAT":
+            print('[ingestion@create_ingestion_dag] partitions', partitions, 'dimensions', dimensions)
             if copy_centroids_uri is not None:
                 centroids_node = submit(
                     copy_centroids,
@@ -1890,6 +1906,7 @@ def ingest(
         partition_history = list(json.loads(group.meta.get("partition_history", "[]")))
         if partitions == -1:
             partitions = int(group.meta.get("partitions", "-1"))
+            print('[ingestion@ingest_vectors] partitions from meta', partitions)
 
         previous_ingestion_timestamp = 0
         if len(ingestion_timestamps) > 0:
@@ -1947,6 +1964,7 @@ def ingest(
         logger.debug("Vector dimension type %s", vector_type)
         if partitions == -1:
             partitions = max(1, int(math.sqrt(size)))
+            print(f"[ingestion@ingest_vectors] partitions calculated from size ({size}), partitions: ", partitions)
         if training_sample_size == -1:
             training_sample_size = min(size, 100 * partitions)
         if mode == Mode.BATCH:

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -98,6 +98,8 @@ class IVFFlatIndex(index.Index):
             config=config,
             timestamp=self.base_array_timestamp,
         )
+        # src = tiledb.open(self.centroids_uri, mode="r")
+        # print('[ivf_flat_index.py] self._centroids\n', tiledb.ArraySchema.load(self.centroids_uri, ctx=tiledb.Ctx(config))) #, '\n', src[0]
         self._index = read_vector_u64(
             self.ctx,
             self.index_array_uri,
@@ -455,7 +457,7 @@ def create(
     **kwargs,
 ) -> IVFFlatIndex:
     validate_storage_version(storage_version)
-
+    print('[ivf_flat_index.py@create] dimensions', dimensions, 'vector_type', vector_type)
     index.create_metadata(
         uri=uri,
         dimensions=dimensions,

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -98,8 +98,6 @@ class IVFFlatIndex(index.Index):
             config=config,
             timestamp=self.base_array_timestamp,
         )
-        # src = tiledb.open(self.centroids_uri, mode="r")
-        # print('[ivf_flat_index.py] self._centroids\n', tiledb.ArraySchema.load(self.centroids_uri, ctx=tiledb.Ctx(config))) #, '\n', src[0]
         self._index = read_vector_u64(
             self.ctx,
             self.index_array_uri,
@@ -457,7 +455,6 @@ def create(
     **kwargs,
 ) -> IVFFlatIndex:
     validate_storage_version(storage_version)
-    print('[ivf_flat_index.py@create] dimensions', dimensions, 'vector_type', vector_type)
     index.create_metadata(
         uri=uri,
         dimensions=dimensions,

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -455,6 +455,7 @@ def create(
     **kwargs,
 ) -> IVFFlatIndex:
     validate_storage_version(storage_version)
+
     index.create_metadata(
         uri=uri,
         dimensions=dimensions,

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -40,7 +40,7 @@ class CloudTests(unittest.TestCase):
         k = 100
         nqueries = 100
 
-        query_vectors = load_fvecs(queries_uri)
+        queries = load_fvecs(queries_uri)
         gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
         index = vs.ingest(
@@ -50,7 +50,7 @@ class CloudTests(unittest.TestCase):
             config=tiledb.cloud.Config().dict(),
             mode=Mode.BATCH,
         )
-        _, result_i = index.query(query_vectors, k=k)
+        _, result_i = index.query(queries, k=k)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
     def test_cloud_ivf_flat(self):
@@ -63,7 +63,7 @@ class CloudTests(unittest.TestCase):
         nqueries = 100
         nprobe = 20
 
-        query_vectors = load_fvecs(queries_uri)
+        queries = load_fvecs(queries_uri)
         gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
         index = vs.ingest(
@@ -79,16 +79,16 @@ class CloudTests(unittest.TestCase):
             # mode=Mode.BATCH,
         )
 
-        _, result_i = index.query(query_vectors, k=k, nprobe=nprobe)
+        _, result_i = index.query(queries, k=k, nprobe=nprobe)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
         _, result_i = index.query(
-            query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME, num_partitions=2, resource_class="standard"
+            queries, k=k, nprobe=nprobe, mode=Mode.REALTIME, num_partitions=2, resource_class="standard"
         )
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
         _, result_i = index.query(
-            query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL, num_partitions=2
+            queries, k=k, nprobe=nprobe, mode=Mode.LOCAL, num_partitions=2
         )
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
@@ -97,20 +97,20 @@ class CloudTests(unittest.TestCase):
 
         # Cannot pass resource_class or resources to LOCAL mode or to no mode.
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL, resource_class="large")
+            index.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL, resource_class="large")
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL, resources=resources)
+            index.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL, resources=resources)
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, resource_class="large")
+            index.query(queries, k=k, nprobe=nprobe, resource_class="large")
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, resources=resources)
+            index.query(queries, k=k, nprobe=nprobe, resources=resources)
 
         # Cannot pass resources to REALTIME.
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME, resources=resources)
+            index.query(queries, k=k, nprobe=nprobe, mode=Mode.REALTIME, resources=resources)
 
         # Cannot pass both resource_class and resources.
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.REALTIME, resource_class="large", resources=resources)
+            index.query(queries, k=k, nprobe=nprobe, mode=Mode.REALTIME, resource_class="large", resources=resources)
         with self.assertRaises(TypeError):
-            index.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.BATCH, resource_class="large", resources=resources)
+            index.query(queries, k=k, nprobe=nprobe, mode=Mode.BATCH, resource_class="large", resources=resources)

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -131,8 +131,8 @@ def test_index_with_incorrect_num_of_query_columns_simple(tmp_path):
             index.query(np.random.rand(*query_shape).astype(np.float32), k=10)
 
         # Okay otherwise.
-        query_vectors = load_fvecs(queries_uri)
-        index.query(query_vectors, k=10)
+        queries = load_fvecs(queries_uri)
+        index.query(queries, k=10)
 
 def test_index_with_incorrect_num_of_query_columns_complex(tmp_path):
     # Tests that we raise a TypeError if the number of columns in the query is not the same as the 

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -786,74 +786,74 @@ def test_copy_centroids_uri(tmp_path):
     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
 
-# def test_kmeans():
-#     k = 128
-#     d = 16
-#     n = k * k
-#     max_iter = 16
-#     n_init = 10
-#     verbose = False
+def test_kmeans():
+    k = 128
+    d = 16
+    n = k * k
+    max_iter = 16
+    n_init = 10
+    verbose = False
 
-#     import sklearn.model_selection
-#     from sklearn.datasets import make_blobs
-#     from sklearn.cluster import KMeans
+    import sklearn.model_selection
+    from sklearn.datasets import make_blobs
+    from sklearn.cluster import KMeans
 
-#     X, _, centers = make_blobs(n_samples=n, n_features=d, centers=k, return_centers=True, random_state=1)
-#     X = X.astype("float32")
+    X, _, centers = make_blobs(n_samples=n, n_features=d, centers=k, return_centers=True, random_state=1)
+    X = X.astype("float32")
 
-#     data, queries = sklearn.model_selection.train_test_split(
-#         X, test_size=0.1, random_state=1
-#     )
+    data, queries = sklearn.model_selection.train_test_split(
+        X, test_size=0.1, random_state=1
+    )
 
-#     data_x = np.array([[1.0573647,   5.082087],
-#                       [-6.229642,   -1.3590931],
-#                       [0.7446737,    6.3828287],
-#                       [-7.698864,   -3.0493321],
-#                       [2.1362762,   -4.4448104],
-#                       [1.04019,     -4.0389647],
-#                       [0.38996044,   5.7235265],
-#     [1.7470839,  -4.717076]]).astype("float32")
-#     queries_x = np.array([[-7.3712273, -1.1178735]]).astype("float32")
+    data_x = np.array([[1.0573647,   5.082087],
+                      [-6.229642,   -1.3590931],
+                      [0.7446737,    6.3828287],
+                      [-7.698864,   -3.0493321],
+                      [2.1362762,   -4.4448104],
+                      [1.04019,     -4.0389647],
+                      [0.38996044,   5.7235265],
+    [1.7470839,  -4.717076]]).astype("float32")
+    queries_x = np.array([[-7.3712273, -1.1178735]]).astype("float32")
 
-#     km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="random", random_state=1)
-#     km.fit(data)
-#     centroids_sk = km.cluster_centers_
-#     results_sk = km.predict(queries)
+    km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="random", random_state=1)
+    km.fit(data)
+    centroids_sk = km.cluster_centers_
+    results_sk = km.predict(queries)
 
-#     centroids_tdb = kmeans_fit(
-#         k, "random", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
-#     )
-#     centroids_tdb_np = np.transpose(np.array(centroids_tdb))
-#     results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
-#     results_tdb_np = np.transpose(np.array(results_tdb))
+    centroids_tdb = kmeans_fit(
+        k, "random", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
+    )
+    centroids_tdb_np = np.transpose(np.array(centroids_tdb))
+    results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
+    results_tdb_np = np.transpose(np.array(results_tdb))
 
-#     def get_score(centroids, results):
-#         x = []
-#         for i in range(len(queries)):
-#             x.append(np.linalg.norm(queries[i] - centroids[results[i]]))
-#         return np.mean(np.array(x))
+    def get_score(centroids, results):
+        x = []
+        for i in range(len(queries)):
+            x.append(np.linalg.norm(queries[i] - centroids[results[i]]))
+        return np.mean(np.array(x))
 
-#     sklearn_score = get_score(centroids_sk, results_sk)
-#     tdb_score = get_score(centroids_tdb_np, results_tdb_np)
+    sklearn_score = get_score(centroids_sk, results_sk)
+    tdb_score = get_score(centroids_tdb_np, results_tdb_np)
 
-#     km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="k-means++", random_state=1)
-#     km.fit(data)
-#     centroids_sk = km.cluster_centers_
-#     results_sk = km.predict(queries)
+    km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="k-means++", random_state=1)
+    km.fit(data)
+    centroids_sk = km.cluster_centers_
+    results_sk = km.predict(queries)
 
-#     assert tdb_score < 1.5 * sklearn_score
+    assert tdb_score < 1.5 * sklearn_score
 
-#     centroids_tdb = kmeans_fit(
-#         k, "k-means++", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
-#     )
-#     centroids_tdb_np = np.transpose(np.array(centroids_tdb))
-#     results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
-#     results_tdb_np = np.transpose(np.array(results_tdb))
+    centroids_tdb = kmeans_fit(
+        k, "k-means++", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
+    )
+    centroids_tdb_np = np.transpose(np.array(centroids_tdb))
+    results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
+    results_tdb_np = np.transpose(np.array(results_tdb))
 
-#     sklearn_score = get_score(centroids_sk, results_sk)
-#     tdb_score = get_score(centroids_tdb_np, results_tdb_np)
+    sklearn_score = get_score(centroids_sk, results_sk)
+    tdb_score = get_score(centroids_tdb_np, results_tdb_np)
 
-#     assert tdb_score < 1.5 * sklearn_score
+    assert tdb_score < 1.5 * sklearn_score
 
 def test_ingest_with_training_source_uri_f32(tmp_path):
     dataset_dir = os.path.join(tmp_path, "dataset")

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -776,7 +776,8 @@ def test_copy_centroids_uri(tmp_path):
         index_type="IVF_FLAT", 
         index_uri=index_uri, 
         input_vectors=data,
-        copy_centroids_uri=centroids_uri
+        copy_centroids_uri=centroids_uri,
+        partitions=centroids_in_size
     )
 
     # Query the index.
@@ -928,15 +929,74 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
         training_source_uri=os.path.join(dataset_dir, "training_data.tdb")
     )
 
-    queries = np.array([data.transpose()[1]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
+    query_vector_index = 1
+    query_vectors = np.array([data.transpose()[query_vector_index]], dtype=np.float32)
+    result_d, result_i = index.query(query_vectors, k=1)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
+    update_vectors = np.empty([3], dtype=object)
+    update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
+    update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
+    
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================================')
+    index = index.consolidate_updates()
+
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
+    query_vectors = np.array([update_vectors[2]], dtype=np.float32)
+    result_d, result_i = index.query(query_vectors, k=1)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
+
+    ################################################################################################
+    # Test we can load the index again and query, update, and consolidate.
+    ################################################################################################
+    # Load the index again and query.
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index = IVFFlatIndex(uri=index_uri) ======================================')
     index = IVFFlatIndex(uri=index_uri)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+    print('index._centroids', index._centroids)
+
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
+    result_d, result_i = index.query(query_vectors, k=1)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
+    
+    # Update the index and query.
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================================')
+    update_vectors = np.empty([2], dtype=object)
+    update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+    index = index.consolidate_updates()
+    
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
+    query_vectors = np.array([update_vectors[0]], dtype=np.float32)
+    result_d, result_i = index.query(query_vectors, k=1)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])
+
+    # print('[test_ingestion@test_ingest_with_training_source_uri_tdb] clear_history() ======================================')
+    # Clear the index history, update the index, and query.
+    # print('index.latest_ingestion_timestamp', index.latest_ingestion_timestamp)
+    Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
+
+    # print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index = IVFFlatIndex(uri=index_uri) ======================================')
+    index = IVFFlatIndex(uri=index_uri)
+
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] consolidate_updates(reuse_centroids=False) ======================================')
+    update_vectors = np.empty([2], dtype=object)
+    update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([12.0, 12.1, 12.2, 12.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+    index = index.consolidate_updates()
+
+    query_vectors = np.array([update_vectors[0]], dtype=np.float32)
+    result_d, result_i = index.query(query_vectors, k=1)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])
 
     ###############################################################################################
     # Also test that we can ingest with training_source_type.
     ###############################################################################################
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================================')
     ingest(
         index_type="IVF_FLAT",
         index_uri=os.path.join(tmp_path, "array_2"), 
@@ -984,5 +1044,44 @@ def test_ingest_with_training_source_uri_numpy(tmp_path):
     queries = np.array([data[1]], dtype=np.float32)
     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
 
-    index = IVFFlatIndex(uri=index_uri)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+    update_vectors = np.empty([3], dtype=object)
+    update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
+    update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
+    
+    index = index.consolidate_updates()
+
+    query_vectors = np.array([update_vectors[2]], dtype=np.float32)
+    result_d, result_i = index.query(query_vectors, k=1)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
+
+    ################################################################################################
+    # Test we can load the index again and query, update, and consolidate.
+    ################################################################################################
+    index_ram = IVFFlatIndex(uri=index_uri)
+
+    query_vectors = np.array([data[query_vector_index]], dtype=np.float32)
+    result_d, result_i = index.query(query_vectors, k=1)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+
+    update_vectors = np.empty([2], dtype=object)
+    update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+    index_ram = index_ram.consolidate_updates()
+
+    query_vectors = np.array([update_vectors[0]], dtype=np.float32)
+    result_d, result_i = index_ram.query(query_vectors, k=1)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])
+
+    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] consolidate_updates(reuse_centroids=False) ======================================')
+    update_vectors = np.empty([2], dtype=object)
+    update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([12.0, 12.1, 12.2, 12.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+    index_ram = index_ram.consolidate_updates(reuse_centroids=False, training_sample_size=3)
+
+    query_vectors = np.array([update_vectors[0]], dtype=np.float32)
+    result_d, result_i = index_ram.query(query_vectors, k=1)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -365,7 +365,7 @@ def test_ivf_flat_ingestion_with_updates(tmp_path):
     _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
-    index = index.consolidate_updates(partitions=20)
+    index = index.consolidate_updates(reuse_centroids=False, partitions=20)
     _, result = index.query(queries, k=k, nprobe=20)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
@@ -733,7 +733,7 @@ def test_storage_versions(tmp_path):
             _, result = index.query(queries, k=k)
             assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
 
-            index = index.consolidate_updates(partitions=20)
+            index = index.consolidate_updates(reuse_centroids=False, partitions=20)
             _, result = index.query(queries, k=k)
             assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
 

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -781,78 +781,79 @@ def test_copy_centroids_uri(tmp_path):
     )
 
     # Query the index.
-    queries = np.array([data[4]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[4]])
+    query_vector_index = 4
+    queries = np.array([data[query_vector_index]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
 
-def test_kmeans():
-    k = 128
-    d = 16
-    n = k * k
-    max_iter = 16
-    n_init = 10
-    verbose = False
+# def test_kmeans():
+#     k = 128
+#     d = 16
+#     n = k * k
+#     max_iter = 16
+#     n_init = 10
+#     verbose = False
 
-    import sklearn.model_selection
-    from sklearn.datasets import make_blobs
-    from sklearn.cluster import KMeans
+#     import sklearn.model_selection
+#     from sklearn.datasets import make_blobs
+#     from sklearn.cluster import KMeans
 
-    X, _, centers = make_blobs(n_samples=n, n_features=d, centers=k, return_centers=True, random_state=1)
-    X = X.astype("float32")
+#     X, _, centers = make_blobs(n_samples=n, n_features=d, centers=k, return_centers=True, random_state=1)
+#     X = X.astype("float32")
 
-    data, queries = sklearn.model_selection.train_test_split(
-        X, test_size=0.1, random_state=1
-    )
+#     data, queries = sklearn.model_selection.train_test_split(
+#         X, test_size=0.1, random_state=1
+#     )
 
-    data_x = np.array([[1.0573647,   5.082087],
-                      [-6.229642,   -1.3590931],
-                      [0.7446737,    6.3828287],
-                      [-7.698864,   -3.0493321],
-                      [2.1362762,   -4.4448104],
-                      [1.04019,     -4.0389647],
-                      [0.38996044,   5.7235265],
-    [1.7470839,  -4.717076]]).astype("float32")
-    queries_x = np.array([[-7.3712273, -1.1178735]]).astype("float32")
+#     data_x = np.array([[1.0573647,   5.082087],
+#                       [-6.229642,   -1.3590931],
+#                       [0.7446737,    6.3828287],
+#                       [-7.698864,   -3.0493321],
+#                       [2.1362762,   -4.4448104],
+#                       [1.04019,     -4.0389647],
+#                       [0.38996044,   5.7235265],
+#     [1.7470839,  -4.717076]]).astype("float32")
+#     queries_x = np.array([[-7.3712273, -1.1178735]]).astype("float32")
 
-    km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="random", random_state=1)
-    km.fit(data)
-    centroids_sk = km.cluster_centers_
-    results_sk = km.predict(queries)
+#     km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="random", random_state=1)
+#     km.fit(data)
+#     centroids_sk = km.cluster_centers_
+#     results_sk = km.predict(queries)
 
-    centroids_tdb = kmeans_fit(
-        k, "random", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
-    )
-    centroids_tdb_np = np.transpose(np.array(centroids_tdb))
-    results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
-    results_tdb_np = np.transpose(np.array(results_tdb))
+#     centroids_tdb = kmeans_fit(
+#         k, "random", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
+#     )
+#     centroids_tdb_np = np.transpose(np.array(centroids_tdb))
+#     results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
+#     results_tdb_np = np.transpose(np.array(results_tdb))
 
-    def get_score(centroids, results):
-        x = []
-        for i in range(len(queries)):
-            x.append(np.linalg.norm(queries[i] - centroids[results[i]]))
-        return np.mean(np.array(x))
+#     def get_score(centroids, results):
+#         x = []
+#         for i in range(len(queries)):
+#             x.append(np.linalg.norm(queries[i] - centroids[results[i]]))
+#         return np.mean(np.array(x))
 
-    sklearn_score = get_score(centroids_sk, results_sk)
-    tdb_score = get_score(centroids_tdb_np, results_tdb_np)
+#     sklearn_score = get_score(centroids_sk, results_sk)
+#     tdb_score = get_score(centroids_tdb_np, results_tdb_np)
 
-    km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="k-means++", random_state=1)
-    km.fit(data)
-    centroids_sk = km.cluster_centers_
-    results_sk = km.predict(queries)
+#     km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="k-means++", random_state=1)
+#     km.fit(data)
+#     centroids_sk = km.cluster_centers_
+#     results_sk = km.predict(queries)
 
-    assert tdb_score < 1.5 * sklearn_score
+#     assert tdb_score < 1.5 * sklearn_score
 
-    centroids_tdb = kmeans_fit(
-        k, "k-means++", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
-    )
-    centroids_tdb_np = np.transpose(np.array(centroids_tdb))
-    results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
-    results_tdb_np = np.transpose(np.array(results_tdb))
+#     centroids_tdb = kmeans_fit(
+#         k, "k-means++", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
+#     )
+#     centroids_tdb_np = np.transpose(np.array(centroids_tdb))
+#     results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
+#     results_tdb_np = np.transpose(np.array(results_tdb))
 
-    sklearn_score = get_score(centroids_sk, results_sk)
-    tdb_score = get_score(centroids_tdb_np, results_tdb_np)
+#     sklearn_score = get_score(centroids_sk, results_sk)
+#     tdb_score = get_score(centroids_tdb_np, results_tdb_np)
 
-    assert tdb_score < 1.5 * sklearn_score
+#     assert tdb_score < 1.5 * sklearn_score
 
 def test_ingest_with_training_source_uri_f32(tmp_path):
     dataset_dir = os.path.join(tmp_path, "dataset")
@@ -869,11 +870,12 @@ def test_ingest_with_training_source_uri_f32(tmp_path):
         training_source_uri=os.path.join(dataset_dir, "training_data.f32bin")
     )
 
-    queries = np.array([data[1]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+    query_vector_index = 1
+    queries = np.array([data[query_vector_index]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
     index = IVFFlatIndex(uri=index_uri)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
     # Also test that we can ingest with training_source_type.
     ingest(
@@ -930,9 +932,8 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
     )
 
     query_vector_index = 1
-    query_vectors = np.array([data.transpose()[query_vector_index]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    queries = np.array([data.transpose()[query_vector_index]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
     update_vectors = np.empty([3], dtype=object)
     update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
@@ -942,9 +943,8 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
     
     index = index.consolidate_updates()
 
-    query_vectors = np.array([update_vectors[2]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
+    queries = np.array([update_vectors[2]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
 
     ################################################################################################
     # Test we can load the index again and query, update, and consolidate.
@@ -952,8 +952,7 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
     # Load the index again and query.
     index = IVFFlatIndex(uri=index_uri)
 
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
     
     # Update the index and query.
     update_vectors = np.empty([2], dtype=object)
@@ -962,9 +961,8 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
     index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
     index = index.consolidate_updates()
     
-    query_vectors = np.array([update_vectors[0]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])
+    queries = np.array([update_vectors[0]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
 
     # Clear the index history, load, update, and query.
     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
@@ -977,9 +975,8 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
     index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
     index = index.consolidate_updates()
 
-    query_vectors = np.array([update_vectors[0]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])
+    queries = np.array([update_vectors[0]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
 
     ###############################################################################################
     # Also test that we can ingest with training_source_type.
@@ -1028,8 +1025,9 @@ def test_ingest_with_training_source_uri_numpy(tmp_path):
         training_input_vectors=training_data,
     )
 
-    queries = np.array([data[1]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+    query_vector_index = 1
+    queries = np.array([data[query_vector_index]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
     update_vectors = np.empty([3], dtype=object)
     update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
@@ -1039,18 +1037,16 @@ def test_ingest_with_training_source_uri_numpy(tmp_path):
     
     index = index.consolidate_updates()
 
-    query_vectors = np.array([update_vectors[2]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
+    queries = np.array([update_vectors[2]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
 
     ################################################################################################
     # Test we can load the index again and query, update, and consolidate.
     ################################################################################################
     index_ram = IVFFlatIndex(uri=index_uri)
 
-    query_vectors = np.array([data[query_vector_index]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    queries = np.array([data[query_vector_index]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
 
     update_vectors = np.empty([2], dtype=object)
     update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
@@ -1058,9 +1054,8 @@ def test_ingest_with_training_source_uri_numpy(tmp_path):
     index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
     index_ram = index_ram.consolidate_updates()
 
-    query_vectors = np.array([update_vectors[0]], dtype=np.float32)
-    result_d, result_i = index_ram.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])
+    queries = np.array([update_vectors[0]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
 
     update_vectors = np.empty([2], dtype=object)
     update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
@@ -1068,6 +1063,5 @@ def test_ingest_with_training_source_uri_numpy(tmp_path):
     index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
     index_ram = index_ram.consolidate_updates(reuse_centroids=False, training_sample_size=3)
 
-    query_vectors = np.array([update_vectors[0]], dtype=np.float32)
-    result_d, result_i = index_ram.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])
+    queries = np.array([update_vectors[0]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -929,7 +929,6 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
         training_source_uri=os.path.join(dataset_dir, "training_data.tdb")
     )
 
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
     query_vector_index = 1
     query_vectors = np.array([data.transpose()[query_vector_index]], dtype=np.float32)
     result_d, result_i = index.query(query_vectors, k=1)
@@ -941,10 +940,8 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
     update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
     index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
     
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================================')
     index = index.consolidate_updates()
 
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
     query_vectors = np.array([update_vectors[2]], dtype=np.float32)
     result_d, result_i = index.query(query_vectors, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
@@ -953,36 +950,27 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
     # Test we can load the index again and query, update, and consolidate.
     ################################################################################################
     # Load the index again and query.
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index = IVFFlatIndex(uri=index_uri) ======================================')
     index = IVFFlatIndex(uri=index_uri)
-    print('index._centroids', index._centroids)
 
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
     result_d, result_i = index.query(query_vectors, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
     
     # Update the index and query.
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================================')
     update_vectors = np.empty([2], dtype=object)
     update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
     update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
     index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
     index = index.consolidate_updates()
     
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
     query_vectors = np.array([update_vectors[0]], dtype=np.float32)
     result_d, result_i = index.query(query_vectors, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])
 
-    # print('[test_ingestion@test_ingest_with_training_source_uri_tdb] clear_history() ======================================')
-    # Clear the index history, update the index, and query.
-    # print('index.latest_ingestion_timestamp', index.latest_ingestion_timestamp)
+    # Clear the index history, load, update, and query.
     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
 
-    # print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index = IVFFlatIndex(uri=index_uri) ======================================')
     index = IVFFlatIndex(uri=index_uri)
 
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] consolidate_updates(reuse_centroids=False) ======================================')
     update_vectors = np.empty([2], dtype=object)
     update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
     update_vectors[1] = np.array([12.0, 12.1, 12.2, 12.3], dtype=np.dtype(np.float32))
@@ -996,7 +984,6 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
     ###############################################################################################
     # Also test that we can ingest with training_source_type.
     ###############################################################################################
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================================')
     ingest(
         index_type="IVF_FLAT",
         index_uri=os.path.join(tmp_path, "array_2"), 
@@ -1075,7 +1062,6 @@ def test_ingest_with_training_source_uri_numpy(tmp_path):
     result_d, result_i = index_ram.query(query_vectors, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])
 
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] consolidate_updates(reuse_centroids=False) ======================================')
     update_vectors = np.empty([2], dtype=object)
     update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
     update_vectors[1] = np.array([12.0, 12.1, 12.2, 12.3], dtype=np.dtype(np.float32))

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -14,6 +14,9 @@ from tiledb.vector_search.utils import load_fvecs
 MINIMUM_ACCURACY = 0.85
 MAX_UINT64 = np.iinfo(np.dtype("uint64")).max
 
+def query_and_check_equals(index, queries, expected_result_d, expected_result_i):
+    result_d, result_i = index.query(queries, k=1)
+    check_equals(result_d=result_d, result_i=result_i, expected_result_d=expected_result_d, expected_result_i=expected_result_i)
 
 def test_flat_ingestion_u8(tmp_path):
     dataset_dir = os.path.join(tmp_path, "dataset")
@@ -22,7 +25,7 @@ def test_flat_ingestion_u8(tmp_path):
     dtype = np.uint8
     k = 10
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
 
     index = ingest(
@@ -30,7 +33,7 @@ def test_flat_ingestion_u8(tmp_path):
         index_uri=index_uri,
         source_uri=os.path.join(dataset_dir, "data.u8bin"),
     )
-    _, result = index.query(query_vectors, k=k)
+    _, result = index.query(queries, k=k)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
@@ -41,7 +44,7 @@ def test_flat_ingestion_f32(tmp_path):
     dtype = np.float32
     k = 10
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
 
     index = ingest(
@@ -49,11 +52,11 @@ def test_flat_ingestion_f32(tmp_path):
         index_uri=index_uri,
         source_uri=os.path.join(dataset_dir, "data.f32bin"),
     )
-    _, result = index.query(query_vectors, k=k)
+    _, result = index.query(queries, k=k)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = FlatIndex(uri=index_uri)
-    _, result = index_ram.query(query_vectors, k=k)
+    _, result = index_ram.query(queries, k=k)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
@@ -66,7 +69,7 @@ def test_flat_ingestion_external_id_u8(tmp_path):
     k = 10
     external_ids_offset = 100
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
     external_ids = np.array(
         [range(external_ids_offset, size + external_ids_offset)], np.uint64
@@ -78,7 +81,7 @@ def test_flat_ingestion_external_id_u8(tmp_path):
         source_uri=os.path.join(dataset_dir, "data.u8bin"),
         external_ids=external_ids,
     )
-    _, result = index.query(query_vectors, k=k)
+    _, result = index.query(queries, k=k)
     assert (
         accuracy(result, gt_i, external_ids_offset=external_ids_offset)
         > MINIMUM_ACCURACY
@@ -97,7 +100,7 @@ def test_ivf_flat_ingestion_u8(tmp_path):
     create_random_dataset_u8(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
     dtype = np.uint8
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
     index = ingest(
         index_type="IVF_FLAT",
@@ -106,15 +109,15 @@ def test_ivf_flat_ingestion_u8(tmp_path):
         partitions=partitions,
         input_vectors_per_work_item=int(size / 10),
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = IVFFlatIndex(uri=index_uri, memory_budget=int(size / 10))
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     _, result = index_ram.query(
-        query_vectors,
+        queries,
         k=k,
         nprobe=nprobe,
         use_nuv_implementation=True,
@@ -122,7 +125,7 @@ def test_ivf_flat_ingestion_u8(tmp_path):
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     _, result = index_ram.query(
-        query_vectors,
+        queries,
         k=k,
         nprobe=nprobe,
         mode=Mode.LOCAL,
@@ -143,7 +146,7 @@ def test_ivf_flat_ingestion_f32(tmp_path):
     create_random_dataset_f32(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
     dtype = np.float32
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
 
     index = ingest(
@@ -154,26 +157,26 @@ def test_ivf_flat_ingestion_f32(tmp_path):
         input_vectors_per_work_item=int(size / 10),
     )
 
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = IVFFlatIndex(uri=index_uri)
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = IVFFlatIndex(uri=index_uri, memory_budget=int(size / 10))
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     _, result = index_ram.query(
-        query_vectors,
+        queries,
         k=k,
         nprobe=nprobe,
         use_nuv_implementation=True,
     )
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
@@ -187,7 +190,7 @@ def test_ivf_flat_ingestion_fvec(tmp_path):
     nqueries = 100
     nprobe = 20
 
-    query_vectors = load_fvecs(queries_uri)
+    queries = load_fvecs(queries_uri)
     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
     index = ingest(
@@ -196,15 +199,15 @@ def test_ivf_flat_ingestion_fvec(tmp_path):
         source_uri=source_uri,
         partitions=partitions,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = IVFFlatIndex(uri=index_uri)
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     _, result = index_ram.query(
-        query_vectors,
+        queries,
         k=k,
         nprobe=nprobe,
         use_nuv_implementation=True,
@@ -212,7 +215,7 @@ def test_ivf_flat_ingestion_fvec(tmp_path):
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     # NB: local mode currently does not return distances
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
@@ -228,7 +231,7 @@ def test_ivf_flat_ingestion_numpy(tmp_path):
 
     input_vectors = load_fvecs(source_uri)
 
-    query_vectors = load_fvecs(queries_uri)
+    queries = load_fvecs(queries_uri)
     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
     index = ingest(
@@ -237,22 +240,22 @@ def test_ivf_flat_ingestion_numpy(tmp_path):
         input_vectors=input_vectors,
         partitions=partitions,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = IVFFlatIndex(uri=index_uri)
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     _, result = index_ram.query(
-        query_vectors,
+        queries,
         k=k,
         nprobe=nprobe,
         use_nuv_implementation=True,
     )
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
@@ -266,7 +269,7 @@ def test_ivf_flat_ingestion_multiple_workers(tmp_path):
     nqueries = 100
     nprobe = 20
 
-    query_vectors = load_fvecs(queries_uri)
+    queries = load_fvecs(queries_uri)
     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
     index = ingest(
@@ -277,15 +280,15 @@ def test_ivf_flat_ingestion_multiple_workers(tmp_path):
         input_vectors_per_work_item=421,
         max_tasks_per_stage=4,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_ram = IVFFlatIndex(uri=index_uri)
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     _, result = index_ram.query(
-        query_vectors,
+        queries,
         k=k,
         nprobe=nprobe,
         use_nuv_implementation=True,
@@ -293,7 +296,7 @@ def test_ivf_flat_ingestion_multiple_workers(tmp_path):
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     # NB: local mode currently does not return distances
-    _, result = index_ram.query(query_vectors, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
@@ -311,7 +314,7 @@ def test_ivf_flat_ingestion_external_ids_numpy(tmp_path):
 
     input_vectors = load_fvecs(source_uri)
 
-    query_vectors = load_fvecs(queries_uri)
+    queries = load_fvecs(queries_uri)
     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
     external_ids = np.array(
         [range(external_ids_offset, size + external_ids_offset)], np.uint64
@@ -323,7 +326,7 @@ def test_ivf_flat_ingestion_external_ids_numpy(tmp_path):
         partitions=partitions,
         external_ids=external_ids,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i, external_ids_offset) > MINIMUM_ACCURACY
 
 
@@ -341,7 +344,7 @@ def test_ivf_flat_ingestion_with_updates(tmp_path):
     )
     dtype = np.uint8
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
     index = ingest(
         index_type="IVF_FLAT",
@@ -349,7 +352,7 @@ def test_ivf_flat_ingestion_with_updates(tmp_path):
         source_uri=os.path.join(dataset_dir, "data.u8bin"),
         partitions=partitions,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) == 1.0
 
     update_ids_offset = MAX_UINT64 - size
@@ -359,11 +362,11 @@ def test_ivf_flat_ingestion_with_updates(tmp_path):
         index.update(vector=data[i].astype(dtype), external_id=i + update_ids_offset)
         updated_ids[i] = i + update_ids_offset
 
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
     index = index.consolidate_updates(partitions=20)
-    _, result = index.query(query_vectors, k=k, nprobe=20)
+    _, result = index.query(queries, k=k, nprobe=20)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
 
@@ -381,7 +384,7 @@ def test_ivf_flat_ingestion_with_batch_updates(tmp_path):
     )
     dtype = np.uint8
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
     index = ingest(
         index_type="IVF_FLAT",
@@ -390,7 +393,7 @@ def test_ivf_flat_ingestion_with_batch_updates(tmp_path):
         partitions=partitions,
         input_vectors_per_work_item=int(size / 10),
     )
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > 0.99
 
     update_ids = {}
@@ -411,11 +414,11 @@ def test_ivf_flat_ingestion_with_batch_updates(tmp_path):
         id += 1
 
     index.update_batch(vectors=updates, external_ids=external_ids)
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i, updated_ids=updated_ids) > 0.99
 
     index = index.consolidate_updates()
-    _, result = index.query(query_vectors, k=k, nprobe=nprobe)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i, updated_ids=updated_ids) > 0.99
 
 
@@ -433,7 +436,7 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
     )
     dtype = np.uint8
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
     index = ingest(
         index_type="IVF_FLAT",
@@ -442,7 +445,7 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
         partitions=partitions,
         index_timestamp=1,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
 
     update_ids_offset = MAX_UINT64 - size
@@ -455,29 +458,29 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
         updated_ids[i] = i + update_ids_offset
 
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert (
         0.05
         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
         <= 0.15
     )
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert (
         0.05
         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
@@ -489,13 +492,13 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
     for i in range(2, 52):
         updated_ids_part[i] = i + update_ids_offset
     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert (
         0.02
         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
@@ -504,32 +507,32 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
 
     # Timetravel at previous ingestion timestamp
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
 
     # Consolidate updates
     index = index.consolidate_updates()
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert (
         0.05
         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
         <= 0.15
     )
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert (
         0.05
         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
@@ -541,13 +544,13 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
     for i in range(2, 52):
         updated_ids_part[i] = i + update_ids_offset
     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert (
         0.02
         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
@@ -556,76 +559,76 @@ def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
 
     # Timetravel at previous ingestion timestamp
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 1))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
 
     # Clear history before the latest ingestion
     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
     # Clear all history
     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp)
     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
 
 
@@ -642,7 +645,7 @@ def test_ivf_flat_ingestion_with_additions_and_timetravel(tmp_path):
     )
     dtype = np.uint8
 
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
     index = ingest(
         index_type="IVF_FLAT",
@@ -651,7 +654,7 @@ def test_ivf_flat_ingestion_with_additions_and_timetravel(tmp_path):
         partitions=partitions,
         index_timestamp=1,
     )
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert accuracy(result, gt_i) == 1.0
 
     update_ids_offset = MAX_UINT64 - size
@@ -665,11 +668,11 @@ def test_ivf_flat_ingestion_with_additions_and_timetravel(tmp_path):
         updated_ids[i] = i + update_ids_offset
 
     index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert 0.45 < accuracy(result, gt_i) < 0.55
 
     index = index.consolidate_updates()
-    _, result = index.query(query_vectors, k=k, nprobe=index.partitions)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
     assert 0.45 < accuracy(result, gt_i) < 0.55
 
 
@@ -684,7 +687,7 @@ def test_storage_versions(tmp_path):
     source_uri = os.path.join(dataset_dir, "data.u8bin")
 
     dtype = np.uint8
-    query_vectors = get_queries(dataset_dir, dtype=dtype)
+    queries = get_queries(dataset_dir, dtype=dtype)
     gt_i, _ = get_groundtruth(dataset_dir, k)
     
     indexes = ["FLAT", "IVF_FLAT"]
@@ -717,7 +720,7 @@ def test_storage_versions(tmp_path):
                 partitions=partitions,
                 storage_version=storage_version
             )
-            _, result = index.query(query_vectors, k=k)
+            _, result = index.query(queries, k=k)
             assert accuracy(result, gt_i) >= MINIMUM_ACCURACY
 
             update_ids_offset = MAX_UINT64 - size
@@ -727,15 +730,15 @@ def test_storage_versions(tmp_path):
                 index.update(vector=data[i].astype(dtype), external_id=i + update_ids_offset)
                 updated_ids[i] = i + update_ids_offset
 
-            _, result = index.query(query_vectors, k=k)
+            _, result = index.query(queries, k=k)
             assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
 
             index = index.consolidate_updates(partitions=20)
-            _, result = index.query(query_vectors, k=k)
+            _, result = index.query(queries, k=k)
             assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
 
             index_ram = index_class(uri=index_uri)
-            _, result = index_ram.query(query_vectors, k=k)
+            _, result = index_ram.query(queries, k=k)
             assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 def test_copy_centroids_uri(tmp_path):
@@ -777,10 +780,8 @@ def test_copy_centroids_uri(tmp_path):
     )
 
     # Query the index.
-    query_vector_index = 4
-    query_vectors = np.array([data[query_vector_index]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    queries = np.array([data[4]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[4]])
 
 
 def test_kmeans():
@@ -867,14 +868,11 @@ def test_ingest_with_training_source_uri_f32(tmp_path):
         training_source_uri=os.path.join(dataset_dir, "training_data.f32bin")
     )
 
-    query_vector_index = 1
-    query_vectors = np.array([data[query_vector_index]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    queries = np.array([data[1]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
 
-    index_ram = IVFFlatIndex(uri=index_uri)
-    result_d, result_i = index_ram.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    index = IVFFlatIndex(uri=index_uri)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
 
     # Also test that we can ingest with training_source_type.
     ingest(
@@ -920,9 +918,8 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
     assert "training data dimensions" in str(error.value)
 
     ################################################################################################
-    # Test we can ingest, query, update, and consolidate with a training_source_uri.
+    # Test we can ingest, query, update, and consolidate.
     ################################################################################################
-    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================================')
     index_uri = os.path.join(tmp_path, "array")
     index = ingest(
         index_type="IVF_FLAT", 
@@ -931,16 +928,15 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
         training_source_uri=os.path.join(dataset_dir, "training_data.tdb")
     )
 
-    query_vector_index = 1
-    query_vectors = np.array([data.transpose()[query_vector_index]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    queries = np.array([data.transpose()[1]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
 
-    index_ram = IVFFlatIndex(uri=index_uri)
-    result_d, result_i = index_ram.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    index = IVFFlatIndex(uri=index_uri)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
 
+    ###############################################################################################
     # Also test that we can ingest with training_source_type.
+    ###############################################################################################
     ingest(
         index_type="IVF_FLAT",
         index_uri=os.path.join(tmp_path, "array_2"), 
@@ -985,11 +981,8 @@ def test_ingest_with_training_source_uri_numpy(tmp_path):
         training_input_vectors=training_data,
     )
 
-    query_vector_index = 1
-    query_vectors = np.array([data[query_vector_index]], dtype=np.float32)
-    result_d, result_i = index.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    queries = np.array([data[1]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
 
-    index_ram = IVFFlatIndex(uri=index_uri)
-    result_d, result_i = index_ram.query(query_vectors, k=1)
-    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])
+    index = IVFFlatIndex(uri=index_uri)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])


### PR DESCRIPTION
### What
When a user provides information about how to create the centroids in `ingest()` and then later calls `consolidate_updates()`, we will not remember any of the information they provided and will instead revert back to the defaults on how to create centroids in `ingest()`.

Here we add a `reuse_centroids` parameter to `consolidate_updates()` which defaults to true. If true, we will re-use the already computed centroids even after new updates to data. If false, we will re-compute the centroids from scratch, either using the defaults or the user-provided information (i.e. we make all the options about how to compute centroids in `ingest()` also arguments to `consolidate_updates()`).

We also make `partitions` required along with `copy_centroids_uri`. This is because if we've updated the array and so the `size` is larger, we'll end up having `partitions` be larger and thus try to read from invalid parts of `copy_centroids_uri`, leading us to end up with `nan`'s. Example:
```
First round
[ingestion@ingest_vectors] partitions calculated from size (5), partitions:  2
[ingest@copy_centroids] src_centroids
 [[1.  5. ]
 [1.1 5.1]
 [1.2 5.2]
 [1.3 5.3]]

Then we add more data
[ingestion@ingest_vectors] partitions calculated from size (10), partitions:  3
[ingest@copy_centroids] src_centroids
 [[1.  5.  nan]
 [1.1 5.1 nan]
 [1.2 5.2 nan]
 [1.3 5.3 nan]]
```

Isaiah also suggested instead of having to pass `partitions` along with `copy_centroids_uri`, we could instead, under the hood, inspect the non-empty domain region of `copy_centroids_uri` and compute partitions from that. This PR goes with the explicit approach instead as it doesn't seem too cumbersome and is easier. But happy to switch over if we'd like / we hear it's cumbersome to use like this.

### Example
Here is the following unit test:
```
def test_ingest_with_training_source_uri_tdb(tmp_path):
    ################################################################################################
    # First set up the data.
    ################################################################################################
    dataset_dir = os.path.join(tmp_path, "dataset")
    os.mkdir(dataset_dir)
    # data.shape should give you (cols, rows). So we transpose this before using it.
    data = np.array([
        [1.0, 1.1, 1.2, 1.3], 
        [2.0, 2.1, 2.2, 2.3], 
        [3.0, 3.1, 3.2, 3.3], 
        [4.0, 4.1, 4.2, 4.3], 
        [5.0, 5.1, 5.2, 5.3]], dtype=np.float32).transpose()
    create_array(path=os.path.join(dataset_dir, "data.tdb"), data=data)

    training_data = np.array([
        [1.0, 1.1, 1.2, 1.3], 
        [5.0, 5.1, 5.2, 5.3]], dtype=np.float32).transpose()
    create_array(path=os.path.join(dataset_dir, "training_data.tdb"), data=training_data)

    # Run a quick test that if we set up training_data incorrectly, we will raise an exception.
    with pytest.raises(ValueError) as error:
        training_data_invalid = np.array([
            [1.0, 1.1, 1.2], 
            [5.0, 5.1, 5.2]], dtype=np.float32).transpose()
        create_array(path=os.path.join(dataset_dir, "training_data_invalid.tdb"), data=training_data_invalid)
        index = ingest(
            index_type="IVF_FLAT", 
            index_uri=os.path.join(tmp_path, f"array_invalid"), 
            source_uri=os.path.join(dataset_dir, "data.tdb"),
            training_source_uri=os.path.join(dataset_dir, "training_data_invalid.tdb")
        )
    assert "training data dimensions" in str(error.value)

    ################################################################################################
    # Test we can ingest, query, update, and consolidate with a training_source_uri.
    ################################################################################################
    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================================')
    index_uri = os.path.join(tmp_path, "array")
    index = ingest(
        index_type="IVF_FLAT", 
        index_uri=index_uri, 
        source_uri=os.path.join(dataset_dir, "data.tdb"),
        training_source_uri=os.path.join(dataset_dir, "training_data.tdb")
    )

    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
    query_vector_index = 1
    query_vectors = np.array([data.transpose()[query_vector_index]], dtype=np.float32)
    result_d, result_i = index.query(query_vectors, k=1)
    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[query_vector_index]])

    update_vectors = np.empty([3], dtype=object)
    update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
    update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
    update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
    index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
    
    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================================')
    index = index.consolidate_updates()

    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
    query_vectors = np.array([update_vectors[2]], dtype=np.float32)
    result_d, result_i = index.query(query_vectors, k=1)
    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])

    ################################################################################################
    # Test we can load the index again and query, update, and consolidate.
    ################################################################################################
    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index_ram = IVFFlatIndex(uri=index_uri) ======================================')
    index_ram = IVFFlatIndex(uri=index_uri)

    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
    result_d, result_i = index.query(query_vectors, k=1)
    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1002]])
    
    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================================')
    update_vectors = np.empty([2], dtype=object)
    update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
    update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
    index_ram = index_ram.consolidate_updates()
    
    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================')
    query_vectors = np.array([update_vectors[0]], dtype=np.float32)
    result_d, result_i = index_ram.query(query_vectors, k=1)
    check_equals(result_d=result_d, result_i=result_i, expected_result_d=[[0]], expected_result_i=[[1003]])

    print('[test_ingestion@test_ingest_with_training_source_uri_tdb] consolidate_updates(reuse_centroids=False) ======================================')
    update_vectors = np.empty([2], dtype=object)
    update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
    update_vectors[1] = np.array([12.0, 12.1, 12.2, 12.3], dtype=np.dtype(np.float32))
    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
    index_ram = index_ram.consolidate_updates(reuse_centroids=False, training_sample_size=3)
```
Before you can see `centroids (4, 2)` is different each time we call `consolidate_updates()`:
```
(TileDB-Vector-Search-2) ~/repo/TileDB-Vector-Search-2/apis/python pytest test/test_ingestion.py -s          ✹main 
=============================================== test session starts ================================================
platform darwin -- Python 3.9.18, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/parismorgan/repo/TileDB-Vector-Search-2/apis/python
collected 1 item                                                                                                   

test/test_ingestion.py [ingestion@ingest] copy_centroids_uri None training_sample_size -1 training_input_vectors None training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1245/test_ingest_with_training_sour0/dataset/training_data_invalid.tdb training_source_type None
[ivf_flat_index.py@create] dimensions 4 vector_type float32
[ingest@centralised_kmeans] training_sample_size 5 training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1245/test_ingest_with_training_sour0/dataset/training_data_invalid.tdb training_source_type None
[ingest@centralised_kmeans] reading from training_source_uri: training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1245/test_ingest_with_training_sour0/dataset/training_data_invalid.tdb training_source_type TILEDB_ARRAY training_in_size 2 training_dimensions 3 training_vector_type float32
[test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================================
[ingestion@ingest] copy_centroids_uri None training_sample_size -1 training_input_vectors None training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1245/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type None
[ivf_flat_index.py@create] dimensions 4 vector_type float32
[ingest@centralised_kmeans] training_sample_size 5 training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1245/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type None
[ingest@centralised_kmeans] reading from training_source_uri: training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1245/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type TILEDB_ARRAY training_in_size 2 training_dimensions 4 training_vector_type float32
[ingestion@centralized_kmeans] sample_vectors (2, 4) 
 [[1.  1.1 1.2 1.3]
 [5.  5.1 5.2 5.3]] 
centroids (4, 2) 
 [[1.  5. ]
 [1.1 5.1]
 [1.2 5.2]
 [1.3 5.3]]
[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================
[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================================
[ingestion@ingest] copy_centroids_uri None training_sample_size -1 training_input_vectors None training_source_uri None training_source_type None
[ingest@centralised_kmeans] training_sample_size 5 training_source_uri None training_source_type None
[ingest@centralised_kmeans] reading from source_uri: source_uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1245/test_ingest_with_training_sour0/array/shuffled_vectors source_type TILEDB_ARRAY vector_type float32 dimensions 4 training_sample_size 5
[ingestion@centralized_kmeans] sample_vectors (5, 4) 
 [[1.  1.1 1.2 1.3]
 [2.  2.1 2.2 2.3]
 [3.  3.1 3.2 3.3]
 [4.  4.1 4.2 4.3]
 [5.  5.1 5.2 5.3]] 
centroids (4, 2) 
 [[1.5       4.       ]
 [1.5999999 4.1      ]
 [1.7       4.2      ]
 [1.8       4.3      ]]
[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================
[test_ingestion@test_ingest_with_training_source_uri_tdb] index_ram = IVFFlatIndex(uri=index_uri) ======================================
[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================
[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================================
[ingestion@ingest] copy_centroids_uri None training_sample_size -1 training_input_vectors None training_source_uri None training_source_type None
[ingest@centralised_kmeans] training_sample_size 8 training_source_uri None training_source_type None
[ingest@centralised_kmeans] reading from source_uri: source_uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1245/test_ingest_with_training_sour0/array/shuffled_vectors source_type TILEDB_ARRAY vector_type float32 dimensions 4 training_sample_size 8
[ingestion@centralized_kmeans] sample_vectors (8, 4) 
 [[1.  1.1 1.2 1.3]
 [2.  2.1 2.2 2.3]
 [3.  3.1 3.2 3.3]
 [4.  4.1 4.2 4.3]
 [5.  5.1 5.2 5.3]
 [6.  6.1 6.2 6.3]
 [7.  7.1 7.2 7.3]
 [8.  8.1 8.2 8.3]] 
centroids (4, 2) 
 [[3.        7.       ]
 [3.1       7.1      ]
 [3.2       7.1999993]
 [3.3       7.3000007]]
[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================
[test_ingestion@test_ingest_with_training_source_uri_tdb] consolidate_updates(reuse_centroids=False) ======================================
[ingestion@ingest] copy_centroids_uri None training_sample_size -1 training_input_vectors None training_source_uri None training_source_type None
[ingest@centralised_kmeans] training_sample_size 10 training_source_uri None training_source_type None
[ingest@centralised_kmeans] reading from source_uri: source_uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1245/test_ingest_with_training_sour0/array/shuffled_vectors source_type TILEDB_ARRAY vector_type float32 dimensions 4 training_sample_size 10
[ingestion@centralized_kmeans] sample_vectors (10, 4) 
 [[ 1.   1.1  1.2  1.3]
 [ 2.   2.1  2.2  2.3]
 [ 3.   3.1  3.2  3.3]
 [ 4.   4.1  4.2  4.3]
 [ 5.   5.1  5.2  5.3]
 [ 6.   6.1  6.2  6.3]
 [ 7.   7.1  7.2  7.3]
 [ 8.   8.1  8.2  8.3]
 [ 9.   9.1  9.2  9.3]
 [10.  10.1 10.2 10.3]] 
centroids (4, 3) 
 [[4.5       8.5       1.5      ]
 [4.6       8.6       1.5999999]
 [4.7       8.7       1.7      ]
 [4.8       8.8       1.8      ]]
.
```
After these changes, you can see `centroids (4, 2)` is the same each time we call `consolidate_updates()`, except when we call `consolidate_updates(reuse_centroids=False)`:
```
(TileDB-Vector-Search-2) ~/repo/TileDB-Vector-Search-2/apis/python pytest test/test_ingestion.py -s          ✹main 
=============================================== test session starts ================================================
platform darwin -- Python 3.9.18, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/parismorgan/repo/TileDB-Vector-Search-2/apis/python
collected 1 item                                                                                                   

test/test_ingestion.py [ingestion@ingest] copy_centroids_uri None training_sample_size -1 training_input_vectors None training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1249/test_ingest_with_training_sour0/dataset/training_data_invalid.tdb training_source_type None
[ivf_flat_index.py@create] dimensions 4 vector_type float32
[ingest@centralised_kmeans] training_sample_size 5 training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1249/test_ingest_with_training_sour0/dataset/training_data_invalid.tdb training_source_type None
[ingest@centralised_kmeans] reading from training_source_uri: training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1249/test_ingest_with_training_sour0/dataset/training_data_invalid.tdb training_source_type TILEDB_ARRAY training_in_size 2 training_dimensions 3 training_vector_type float32
[test_ingestion@test_ingest_with_training_source_uri_tdb] ingest() ======================================
[ingestion@ingest] copy_centroids_uri None training_sample_size -1 training_input_vectors None training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1249/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type None
[ivf_flat_index.py@create] dimensions 4 vector_type float32
[ingest@centralised_kmeans] training_sample_size 5 training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1249/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type None
[ingest@centralised_kmeans] reading from training_source_uri: training_source_uri /private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1249/test_ingest_with_training_sour0/dataset/training_data.tdb training_source_type TILEDB_ARRAY training_in_size 2 training_dimensions 4 training_vector_type float32
[ingestion@centralized_kmeans] sample_vectors (2, 4) 
 [[1.  1.1 1.2 1.3]
 [5.  5.1 5.2 5.3]] 
centroids (4, 2) 
 [[1.  5. ]
 [1.1 5.1]
 [1.2 5.2]
 [1.3 5.3]]
[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================
[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================================
[ingestion@ingest] copy_centroids_uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1249/test_ingest_with_training_sour0/array/partition_centroids training_sample_size -1 training_input_vectors None training_source_uri None training_source_type None
[ingestion@copy_centroids] partitions 2 dimensions 4
[ingest@copy_centroids] centroids_uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1249/test_ingest_with_training_sour0/array/partition_centroids
[ingest@copy_centroids] src_centroids OrderedDict([('centroids', array([[1. , 5. ],
       [1.1, 5.1],
       [1.2, 5.2],
       [1.3, 5.3]], dtype=float32))])
[ingest@copy_centroids] dst_centroids before write OrderedDict([('centroids', array([[1. , 5. ],
       [1.1, 5.1],
       [1.2, 5.2],
       [1.3, 5.3]], dtype=float32))])
[ingest@copy_centroids] dest DenseArray(uri='file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1249/test_ingest_with_training_sour0/array/partition_centroids', mode=w, ndim=2)
[ingest@copy_centroids] dest after OrderedDict([('centroids', array([[1. , 5. ],
       [1.1, 5.1],
       [1.2, 5.2],
       [1.3, 5.3]], dtype=float32))])
[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================
[test_ingestion@test_ingest_with_training_source_uri_tdb] index_ram = IVFFlatIndex(uri=index_uri) ======================================
[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================
[test_ingestion@test_ingest_with_training_source_uri_tdb] index.consolidate_updates() ======================================
[ingestion@ingest] copy_centroids_uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1249/test_ingest_with_training_sour0/array/partition_centroids training_sample_size -1 training_input_vectors None training_source_uri None training_source_type None
[ingestion@copy_centroids] partitions 2 dimensions 4
[ingest@copy_centroids] centroids_uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1249/test_ingest_with_training_sour0/array/partition_centroids
[ingest@copy_centroids] src_centroids OrderedDict([('centroids', array([[1. , 5. ],
       [1.1, 5.1],
       [1.2, 5.2],
       [1.3, 5.3]], dtype=float32))])
[ingest@copy_centroids] dst_centroids before write OrderedDict([('centroids', array([[1. , 5. ],
       [1.1, 5.1],
       [1.2, 5.2],
       [1.3, 5.3]], dtype=float32))])
[ingest@copy_centroids] dest DenseArray(uri='file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1249/test_ingest_with_training_sour0/array/partition_centroids', mode=w, ndim=2)
[ingest@copy_centroids] dest after OrderedDict([('centroids', array([[1. , 5. ],
       [1.1, 5.1],
       [1.2, 5.2],
       [1.3, 5.3]], dtype=float32))])
[test_ingestion@test_ingest_with_training_source_uri_tdb] query() ======================================
[test_ingestion@test_ingest_with_training_source_uri_tdb] consolidate_updates(reuse_centroids=False) ======================================
[ingestion@ingest] copy_centroids_uri None training_sample_size 3 training_input_vectors None training_source_uri None training_source_type None
[ingest@centralised_kmeans] training_sample_size 3 training_source_uri None training_source_type None
[ingest@centralised_kmeans] reading from source_uri: source_uri file:///private/var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/pytest-of-parismorgan/pytest-1249/test_ingest_with_training_sour0/array/shuffled_vectors source_type TILEDB_ARRAY vector_type float32 dimensions 4 training_sample_size 3
[ingestion@centralized_kmeans] sample_vectors (3, 4) 
 [[1.  1.1 1.2 1.3]
 [2.  2.1 2.2 2.3]
 [3.  3.1 3.2 3.3]] 
centroids (4, 3) 
 [[2.  0.  0. ]
 [2.1 0.  0. ]
 [2.2 0.  0. ]
 [2.3 0.  0. ]]
.
```

<img width="1828" alt="Screenshot 2023-12-20 at 5 57 14 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/b97eb73e-f5ce-46bd-8cde-03e8c1db419d">