### PR TITLE
Add support for randomly sampling the input data to compute centroids with

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -877,6 +877,7 @@ def ingest(
             array_to_matrix,
             kmeans_fit,
         )
+
         with tiledb.scope_ctx(ctx_or_config=config):
             logger = setup(config, verbose)
             group = tiledb.Group(index_group_uri)

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -873,7 +873,6 @@ def ingest(
             if training_sample_size >= partitions:
                 if sampled_vectors is not None:
                     sample_vectors = sampled_vectors
-                    print('[centralised_kmeans] Using sampled vectors', sample_vectors.shape, sample_vectors)
                 elif training_source_uri:
                     if training_source_type is None:
                         training_source_type = autodetect_source_type(source_uri=training_source_uri)
@@ -1686,40 +1685,20 @@ def ingest(
             else:
                 combine_vectors_node = None
                 if training_sampling_policy == TrainingSamplingPolicy.RANDOM:
+                    # The number of complete batches.
+                    num_batches = math.ceil(in_size / input_vectors_batch_size)
+                    # The number of data points to sample from each batch.
+                    samples_per_batch = 0 if num_batches == 0 else math.floor(training_sample_size / num_batches)
+                    # Calculate the remaining data points that need to be sampled (i.e. b/c the numbers were not perfectly divisible).
+                    remaining_samples = training_sample_size - (num_batches * samples_per_batch)
+                    # Calculate how many of the remaining data points to sample from each batch.
+                    extra_samples_per_batch = remaining_samples if num_batches == 0 else math.ceil(remaining_samples / num_batches)
+                    # Calculate at which index to stop sampling an extra_samples_per_batch from.
+                    idx_to_stop_adding_extra_samples = 0 if extra_samples_per_batch == 0 else remaining_samples / extra_samples_per_batch
+
                     sampled_vectors = []
-                    num_sampled = 0
                     idx = 0
-                    print(f"[ingestion@create_ingestion_dag] training_sample_size {training_sample_size}")
-                    print(f"[ingestion@create_ingestion_dag] in_size {in_size}")
-                    print(f"[ingestion@create_ingestion_dag] input_vectors_batch_size {input_vectors_batch_size}")
-
-                    # Calculate the number of complete chunks
-                    num_chunks = math.ceil(in_size / input_vectors_batch_size)
-                    # Calculate the number of data points to sample from each chunk
-                    samples_per_complete_chunk = 0 if num_chunks == 0 else math.floor(training_sample_size / num_chunks)
-
-                    # Calculate the remaining data points after the complete chunks are sampled
-                    remaining_data_points = training_sample_size - (num_chunks * samples_per_complete_chunk)
-                    # Calculate how many of the remaining data points to sample from each chunk.
-                    extra_samples_per_complete_chunk = remaining_data_points if num_chunks == 0 else math.ceil(remaining_data_points / num_chunks)
-                    # Calculate at which index to stop adding extra samples.
-                    idx_to_stop_adding_extra_samples = 0 if extra_samples_per_complete_chunk == 0 else remaining_data_points / extra_samples_per_complete_chunk
-                    
-                    # # Create a list to store the number of samples per chunk
-                    # chunk_sizes = [samples_per_complete_chunk] * num_chunks
-                    # # Fill out the remaining_data_points
-                    # chunk_sizes.append(samples_in_last_chunk)
-                    
-                    print(f"num_chunks {num_chunks}")
-                    print(f"samples_per_complete_chunk {samples_per_complete_chunk}")
-                    print(f"remaining_data_points {remaining_data_points}")
-                    print(f"extra_samples_per_complete_chunk {extra_samples_per_complete_chunk}")
-                    print(f"samples_to_stop_adding_extra {idx_to_stop_adding_extra_samples}")
-                    # print(f"samples_in_last_chunk {samples_in_last_chunk}")
-                    # print(f"chunk_sizes {chunk_sizes}")
-
                     num_sampled = 0
-
                     for i in range(0, in_size, input_vectors_batch_size):
                         # What vectors to read from the source_uri.
                         start = i
@@ -1727,26 +1706,11 @@ def ingest(
                         if end > size:
                             end = size
 
-                        # How many of those vectors to sample. We divide our random sample between
-                        # the batches, taking a percentage of the total sample size based on the
-                        # batch size.
-                        
-                        num_for_batch = samples_per_complete_chunk
+                        # How many of those vectors to sample in this batch.
+                        num_for_batch = samples_per_batch
                         if idx < idx_to_stop_adding_extra_samples:
-                            num_for_batch += extra_samples_per_complete_chunk
+                            num_for_batch += extra_samples_per_batch
                         num_sampled += num_for_batch
-                        print(f" [{idx}] start {start} -> end {end}, num_for_batch {num_for_batch}")
-                        # percent_of_data = (end - start) / in_size
-                        # num_for_batch = math.ceil(training_sample_size * percent_of_data)
-                        # num_sampled += num_for_batch
-                        # if num_sampled > training_sample_size:
-                        #     print(f"we'd go over by num_sampled ({num_sampled}) - training_sample_size ({training_sample_size}) {num_sampled - training_sample_size}")
-                        #     num_for_batch -= num_sampled - training_sample_size
-                        # print(f" [{task_id}] start {start} -> end {end}, percent_of_data {percent_of_data}, training_sample_size {training_sample_size}, num_for_batch {num_for_batch}")
-                        # # When training_sampling_policy is small we may skip the last batch(es).
-                        # if num_for_batch <= 0:
-                        #     print("   skip")
-                        #     continue
 
                         sampled_vectors.append(submit(
                             random_sample_from_input_vectors,
@@ -1764,7 +1728,6 @@ def ingest(
                             image_name=DEFAULT_IMG_NAME,
                         ))
                         idx += 1
-                    print(f"Done with random sampling, we sampled {num_sampled} points")
                     if num_sampled != training_sample_size:
                         raise ValueError(f"The random sampling ran into an issue: num_sampled ({num_sampled}) != training_sample_size ({training_sample_size})")
                     combine_vectors_node = submit(

--- a/apis/python/test/common.py
+++ b/apis/python/test/common.py
@@ -5,7 +5,7 @@ import string
 import numpy as np
 
 import tiledb
-
+from tiledb.vector_search.storage_formats import storage_formats, STORAGE_VERSION
 
 def xbin_mmap(fname, dtype):
     n, d = map(int, np.fromfile(fname, dtype="uint32", count=2))
@@ -302,3 +302,11 @@ def check_equals(result_d, result_i, expected_result_d, expected_result_i):
 def random_name(name: str) -> str:
     suffix = "".join(random.choices(string.ascii_letters, k=10))
     return f"zzz_unittest_{name}_{suffix}"
+
+def check_training_input_vectors(index_uri: str, expected_training_sample_size: int, expected_dimensions: int):
+    training_input_vectors_uri = f"{index_uri}/{storage_formats[STORAGE_VERSION]['TRAINING_INPUT_VECTORS_ARRAY_NAME']}"
+    with tiledb.open(training_input_vectors_uri, mode="r") as src_array:
+        training_input_vectors = np.transpose(src_array[:, :]["values"])
+        assert training_input_vectors.shape[0] == expected_training_sample_size
+        assert training_input_vectors.shape[1] == expected_dimensions
+        assert not np.isnan(training_input_vectors).any()

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -26,11 +26,13 @@ class CloudTests(unittest.TestCase):
         test_path = f"tiledb://{namespace}/{storage_path}/{rand_name}"
         cls.flat_index_uri = f"{test_path}/test_flat_array"
         cls.ivf_flat_index_uri = f"{test_path}/test_ivf_flat_array"
+        cls.ivf_flat_random_sampling_index_uri = f"{test_path}/test_ivf_flat_random_sampling_array"
 
     @classmethod
     def tearDownClass(cls):
         vs.Index.delete_index(uri=cls.flat_index_uri, config=tiledb.cloud.Config())
         vs.Index.delete_index(uri=cls.ivf_flat_index_uri, config=tiledb.cloud.Config())
+        vs.Index.delete_index(uri=cls.ivf_flat_random_sampling_index_uri, config=tiledb.cloud.Config())
 
     def test_cloud_flat(self):
         source_uri = "tiledb://TileDB-Inc/sift_10k"
@@ -119,15 +121,15 @@ class CloudTests(unittest.TestCase):
         # NOTE(paris): This was also tested with the following (and also with mode=Mode.BATCH):
         # source_uri = "tiledb://TileDB-Inc/ann_sift1b_raw_vectors_col_major"
         # training_sample_size = 1000000
-        source_uri = "tiledb://TileDB-Inc/ann_sift1b_raw_vectors_col_major"
+        source_uri = "tiledb://TileDB-Inc/sift_10k"
         queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
         gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
-        index_uri = CloudTests.ivf_flat_index_uri
+        index_uri = CloudTests.ivf_flat_random_sampling_index_uri
         k = 100
         nqueries = 100
         nprobe = 20
         max_sampling_tasks = 13
-        training_sample_size = 500123
+        training_sample_size = 1234
 
         queries = load_fvecs(queries_uri)
         gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -728,7 +728,7 @@ def test_ivf_flat_ingestion_fvec_random_sampling_policy(tmp_path):
         source_uri=source_uri,
         partitions=partitions,
         training_sampling_policy=TrainingSamplingPolicy.RANDOM,
-        input_vectors_per_work_item=5000,
+        input_vectors_per_work_item=1000,
     )
     _, result = index.query(queries, k=k, nprobe=nprobe)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -6,7 +6,7 @@ import pytest
 from tiledb.cloud.dag import Mode
 from tiledb.vector_search.flat_index import FlatIndex
 from tiledb.vector_search.index import Index
-from tiledb.vector_search.ingestion import ingest
+from tiledb.vector_search.ingestion import ingest, TrainingSamplingPolicy
 from tiledb.vector_search.ivf_flat_index import IVFFlatIndex
 from tiledb.vector_search.module import array_to_matrix, kmeans_fit, kmeans_predict
 from tiledb.vector_search.utils import load_fvecs
@@ -18,873 +18,1051 @@ def query_and_check_equals(index, queries, expected_result_d, expected_result_i)
     result_d, result_i = index.query(queries, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=expected_result_d, expected_result_i=expected_result_i)
 
-def test_flat_ingestion_u8(tmp_path):
-    dataset_dir = os.path.join(tmp_path, "dataset")
-    index_uri = os.path.join(tmp_path, "array")
-    create_random_dataset_u8(nb=10000, d=100, nq=100, k=10, path=dataset_dir)
-    dtype = np.uint8
-    k = 10
-
-    queries = get_queries(dataset_dir, dtype=dtype)
-    gt_i, gt_d = get_groundtruth(dataset_dir, k)
-
-    index = ingest(
-        index_type="FLAT",
-        index_uri=index_uri,
-        source_uri=os.path.join(dataset_dir, "data.u8bin"),
-    )
-    _, result = index.query(queries, k=k)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-def test_flat_ingestion_f32(tmp_path):
-    dataset_dir = os.path.join(tmp_path, "dataset")
-    index_uri = os.path.join(tmp_path, "array")
-    create_random_dataset_f32(nb=10000, d=100, nq=100, k=10, path=dataset_dir)
-    dtype = np.float32
-    k = 10
-
-    queries = get_queries(dataset_dir, dtype=dtype)
-    gt_i, gt_d = get_groundtruth(dataset_dir, k)
-
-    index = ingest(
-        index_type="FLAT",
-        index_uri=index_uri,
-        source_uri=os.path.join(dataset_dir, "data.f32bin"),
-    )
-    _, result = index.query(queries, k=k)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    index_ram = FlatIndex(uri=index_uri)
-    _, result = index_ram.query(queries, k=k)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-def test_flat_ingestion_external_id_u8(tmp_path):
-    dataset_dir = os.path.join(tmp_path, "dataset")
-    index_uri = os.path.join(tmp_path, "array")
-    size = 10000
-    dtype = np.uint8
-    create_random_dataset_u8(nb=size, d=100, nq=100, k=10, path=dataset_dir)
-    k = 10
-    external_ids_offset = 100
-
-    queries = get_queries(dataset_dir, dtype=dtype)
-    gt_i, gt_d = get_groundtruth(dataset_dir, k)
-    external_ids = np.array(
-        [range(external_ids_offset, size + external_ids_offset)], np.uint64
-    )
-
-    index = ingest(
-        index_type="FLAT",
-        index_uri=index_uri,
-        source_uri=os.path.join(dataset_dir, "data.u8bin"),
-        external_ids=external_ids,
-    )
-    _, result = index.query(queries, k=k)
-    assert (
-        accuracy(result, gt_i, external_ids_offset=external_ids_offset)
-        > MINIMUM_ACCURACY
-    )
-
-
-def test_ivf_flat_ingestion_u8(tmp_path):
-    dataset_dir = os.path.join(tmp_path, "dataset")
-    index_uri = os.path.join(tmp_path, "array")
-    k = 10
-    size = 100000
-    partitions = 100
-    dimensions = 128
-    nqueries = 100
-    nprobe = 20
-    create_random_dataset_u8(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
-    dtype = np.uint8
-
-    queries = get_queries(dataset_dir, dtype=dtype)
-    gt_i, gt_d = get_groundtruth(dataset_dir, k)
-    index = ingest(
-        index_type="IVF_FLAT",
-        index_uri=index_uri,
-        source_uri=os.path.join(dataset_dir, "data.u8bin"),
-        partitions=partitions,
-        input_vectors_per_work_item=int(size / 10),
-    )
-    _, result = index.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    index_ram = IVFFlatIndex(uri=index_uri, memory_budget=int(size / 10))
-    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    _, result = index_ram.query(
-        queries,
-        k=k,
-        nprobe=nprobe,
-        use_nuv_implementation=True,
-    )
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    _, result = index_ram.query(
-        queries,
-        k=k,
-        nprobe=nprobe,
-        mode=Mode.LOCAL,
-    )
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-def test_ivf_flat_ingestion_f32(tmp_path):
-    dataset_dir = os.path.join(tmp_path, "dataset")
-    index_uri = os.path.join(tmp_path, "array")
-    k = 10
-    size = 100000
-    dimensions = 128
-    partitions = 100
-    nqueries = 100
-    nprobe = 20
-
-    create_random_dataset_f32(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
-    dtype = np.float32
-
-    queries = get_queries(dataset_dir, dtype=dtype)
-    gt_i, gt_d = get_groundtruth(dataset_dir, k)
-
-    index = ingest(
-        index_type="IVF_FLAT",
-        index_uri=index_uri,
-        source_uri=os.path.join(dataset_dir, "data.f32bin"),
-        partitions=partitions,
-        input_vectors_per_work_item=int(size / 10),
-    )
-
-    _, result = index.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    index_ram = IVFFlatIndex(uri=index_uri)
-    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    index_ram = IVFFlatIndex(uri=index_uri, memory_budget=int(size / 10))
-    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    _, result = index_ram.query(
-        queries,
-        k=k,
-        nprobe=nprobe,
-        use_nuv_implementation=True,
-    )
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-def test_ivf_flat_ingestion_fvec(tmp_path):
-    source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
-    queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
-    gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
-    index_uri = os.path.join(tmp_path, "array")
-    k = 100
-    partitions = 100
-    nqueries = 100
-    nprobe = 20
-
-    queries = load_fvecs(queries_uri)
-    gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
-
-    index = ingest(
-        index_type="IVF_FLAT",
-        index_uri=index_uri,
-        source_uri=source_uri,
-        partitions=partitions,
-    )
-    _, result = index.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    index_ram = IVFFlatIndex(uri=index_uri)
-    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    _, result = index_ram.query(
-        queries,
-        k=k,
-        nprobe=nprobe,
-        use_nuv_implementation=True,
-    )
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    # NB: local mode currently does not return distances
-    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-def test_ivf_flat_ingestion_numpy(tmp_path):
-    source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
-    queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
-    gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
-    index_uri = os.path.join(tmp_path, "array")
-    k = 100
-    partitions = 100
-    nqueries = 100
-    nprobe = 20
-
-    input_vectors = load_fvecs(source_uri)
-
-    queries = load_fvecs(queries_uri)
-    gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
-
-    index = ingest(
-        index_type="IVF_FLAT",
-        index_uri=index_uri,
-        input_vectors=input_vectors,
-        partitions=partitions,
-    )
-    _, result = index.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    index_ram = IVFFlatIndex(uri=index_uri)
-    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    _, result = index_ram.query(
-        queries,
-        k=k,
-        nprobe=nprobe,
-        use_nuv_implementation=True,
-    )
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-def test_ivf_flat_ingestion_multiple_workers(tmp_path):
-    source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
-    queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
-    gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
-    index_uri = os.path.join(tmp_path, "array")
-    k = 100
-    partitions = 100
-    nqueries = 100
-    nprobe = 20
-
-    queries = load_fvecs(queries_uri)
-    gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
-
-    index = ingest(
-        index_type="IVF_FLAT",
-        index_uri=index_uri,
-        source_uri=source_uri,
-        partitions=partitions,
-        input_vectors_per_work_item=421,
-        max_tasks_per_stage=4,
-    )
-    _, result = index.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    index_ram = IVFFlatIndex(uri=index_uri)
-    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    _, result = index_ram.query(
-        queries,
-        k=k,
-        nprobe=nprobe,
-        use_nuv_implementation=True,
-    )
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-    # NB: local mode currently does not return distances
-    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
-    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-def test_ivf_flat_ingestion_external_ids_numpy(tmp_path):
-    source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
-    queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
-    gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
-    index_uri = os.path.join(tmp_path, "array")
-    k = 100
-    partitions = 100
-    nqueries = 100
-    nprobe = 20
-    size = 10000
-    external_ids_offset = 100
-
-    input_vectors = load_fvecs(source_uri)
-
-    queries = load_fvecs(queries_uri)
-    gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
-    external_ids = np.array(
-        [range(external_ids_offset, size + external_ids_offset)], np.uint64
-    )
-    index = ingest(
-        index_type="IVF_FLAT",
-        index_uri=index_uri,
-        input_vectors=input_vectors,
-        partitions=partitions,
-        external_ids=external_ids,
-    )
-    _, result = index.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i, external_ids_offset) > MINIMUM_ACCURACY
-
-
-def test_ivf_flat_ingestion_with_updates(tmp_path):
-    dataset_dir = os.path.join(tmp_path, "dataset")
-    index_uri = os.path.join(tmp_path, "array")
-    k = 10
-    size = 1000
-    partitions = 10
-    dimensions = 128
-    nqueries = 100
-    nprobe = 10
-    data = create_random_dataset_u8(
-        nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
-    )
-    dtype = np.uint8
-
-    queries = get_queries(dataset_dir, dtype=dtype)
-    gt_i, gt_d = get_groundtruth(dataset_dir, k)
-    index = ingest(
-        index_type="IVF_FLAT",
-        index_uri=index_uri,
-        source_uri=os.path.join(dataset_dir, "data.u8bin"),
-        partitions=partitions,
-    )
-    _, result = index.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i) == 1.0
-
-    update_ids_offset = MAX_UINT64 - size
-    updated_ids = {}
-    for i in range(100):
-        index.delete(external_id=i)
-        index.update(vector=data[i].astype(dtype), external_id=i + update_ids_offset)
-        updated_ids[i] = i + update_ids_offset
-
-    _, result = index.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-
-    index = index.consolidate_updates(retrain_index=True, partitions=20)
-    _, result = index.query(queries, k=k, nprobe=20)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-
-
-def test_ivf_flat_ingestion_with_batch_updates(tmp_path):
-    dataset_dir = os.path.join(tmp_path, "dataset")
-    index_uri = os.path.join(tmp_path, "array")
-    k = 10
-    size = 100000
-    partitions = 100
-    dimensions = 128
-    nqueries = 100
-    nprobe = 100
-    data = create_random_dataset_u8(
-        nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
-    )
-    dtype = np.uint8
-
-    queries = get_queries(dataset_dir, dtype=dtype)
-    gt_i, gt_d = get_groundtruth(dataset_dir, k)
-    index = ingest(
-        index_type="IVF_FLAT",
-        index_uri=index_uri,
-        source_uri=os.path.join(dataset_dir, "data.u8bin"),
-        partitions=partitions,
-        input_vectors_per_work_item=int(size / 10),
-    )
-    _, result = index.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i) > 0.99
-
-    update_ids = {}
-    updated_ids = {}
-    update_ids_offset = MAX_UINT64 - size
-    for i in range(0, 100000, 2):
-        updated_ids[i] = i + update_ids_offset
-        update_ids[i + update_ids_offset] = i
-    external_ids = np.zeros((len(updated_ids) * 2), dtype=np.uint64)
-    updates = np.empty((len(updated_ids) * 2), dtype="O")
-    id = 0
-    for prev_id, new_id in updated_ids.items():
-        external_ids[id] = prev_id
-        updates[id] = np.array([], dtype=dtype)
-        id += 1
-        external_ids[id] = new_id
-        updates[id] = data[prev_id].astype(dtype)
-        id += 1
-
-    index.update_batch(vectors=updates, external_ids=external_ids)
-    _, result = index.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) > 0.99
-
-    index = index.consolidate_updates()
-    _, result = index.query(queries, k=k, nprobe=nprobe)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) > 0.99
-
-
-def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
-    dataset_dir = os.path.join(tmp_path, "dataset")
-    index_uri = os.path.join(tmp_path, "array")
-    k = 10
-    size = 1000
-    partitions = 10
-    dimensions = 128
-    nqueries = 100
-    nprobe = 10
-    data = create_random_dataset_u8(
-        nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
-    )
-    dtype = np.uint8
-
-    queries = get_queries(dataset_dir, dtype=dtype)
-    gt_i, gt_d = get_groundtruth(dataset_dir, k)
-    index = ingest(
-        index_type="IVF_FLAT",
-        index_uri=index_uri,
-        source_uri=os.path.join(dataset_dir, "data.u8bin"),
-        partitions=partitions,
-        index_timestamp=1,
-    )
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i) == 1.0
-
-    update_ids_offset = MAX_UINT64 - size
-    updated_ids = {}
-    for i in range(2, 102):
-        index.delete(external_id=i, timestamp=i)
-        index.update(
-            vector=data[i].astype(dtype), external_id=i + update_ids_offset, timestamp=i
-        )
-        updated_ids[i] = i + update_ids_offset
-
-    index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert (
-        0.05
-        <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
-        <= 0.15
-    )
-    index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert (
-        0.05
-        <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
-        <= 0.15
-    )
-
-    # Timetravel with partial read from updates table
-    updated_ids_part = {}
-    for i in range(2, 52):
-        updated_ids_part[i] = i + update_ids_offset
-    index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert (
-        0.02
-        <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
-        <= 0.07
-    )
-
-    # Timetravel at previous ingestion timestamp
-    index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i) == 1.0
-
-    # Consolidate updates
-    index = index.consolidate_updates()
-    index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert (
-        0.05
-        <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
-        <= 0.15
-    )
-    index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert (
-        0.05
-        <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
-        <= 0.15
-    )
-
-    # Timetravel with partial read from updates table
-    updated_ids_part = {}
-    for i in range(2, 52):
-        updated_ids_part[i] = i + update_ids_offset
-    index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert (
-        0.02
-        <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
-        <= 0.07
-    )
-
-    # Timetravel at previous ingestion timestamp
-    index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 1))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i) == 1.0
-
-    # Clear history before the latest ingestion
-    Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
-    index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-
-    # Clear all history
-    Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp)
-    index = IVFFlatIndex(uri=index_uri, timestamp=1)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=51)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=101)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-    index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-    index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-
-
-def test_ivf_flat_ingestion_with_additions_and_timetravel(tmp_path):
-    dataset_dir = os.path.join(tmp_path, "dataset")
-    index_uri = os.path.join(tmp_path, "array")
-    k = 100
-    size = 100
-    partitions = 10
-    dimensions = 128
-    nqueries = 1
-    data = create_random_dataset_u8(
-        nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
-    )
-    dtype = np.uint8
-
-    queries = get_queries(dataset_dir, dtype=dtype)
-    gt_i, gt_d = get_groundtruth(dataset_dir, k)
-    index = ingest(
-        index_type="IVF_FLAT",
-        index_uri=index_uri,
-        source_uri=os.path.join(dataset_dir, "data.u8bin"),
-        partitions=partitions,
-        index_timestamp=1,
-    )
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert accuracy(result, gt_i) == 1.0
-
-    update_ids_offset = MAX_UINT64 - size
-    updated_ids = {}
-    for i in range(100):
-        index.update(
-            vector=data[i].astype(dtype),
-            external_id=i + update_ids_offset,
-            timestamp=i + 2,
-        )
-        updated_ids[i] = i + update_ids_offset
-
-    index = IVFFlatIndex(uri=index_uri)
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert 0.45 < accuracy(result, gt_i) < 0.55
-
-    index = index.consolidate_updates()
-    _, result = index.query(queries, k=k, nprobe=index.partitions)
-    assert 0.45 < accuracy(result, gt_i) < 0.55
-
-
-def test_storage_versions(tmp_path):
-    dataset_dir = os.path.join(tmp_path, "dataset")
-    k = 10
-    size = 1000
-    partitions = 10
-    dimensions = 128
-    nqueries = 100
-    data = create_random_dataset_u8(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
-    source_uri = os.path.join(dataset_dir, "data.u8bin")
-
-    dtype = np.uint8
-    queries = get_queries(dataset_dir, dtype=dtype)
-    gt_i, _ = get_groundtruth(dataset_dir, k)
+# def test_flat_ingestion_u8(tmp_path):
+#     dataset_dir = os.path.join(tmp_path, "dataset")
+#     index_uri = os.path.join(tmp_path, "array")
+#     create_random_dataset_u8(nb=10000, d=100, nq=100, k=10, path=dataset_dir)
+#     dtype = np.uint8
+#     k = 10
+
+#     queries = get_queries(dataset_dir, dtype=dtype)
+#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
+
+#     index = ingest(
+#         index_type="FLAT",
+#         index_uri=index_uri,
+#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
+#     )
+#     _, result = index.query(queries, k=k)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+# def test_flat_ingestion_f32(tmp_path):
+#     dataset_dir = os.path.join(tmp_path, "dataset")
+#     index_uri = os.path.join(tmp_path, "array")
+#     create_random_dataset_f32(nb=10000, d=100, nq=100, k=10, path=dataset_dir)
+#     dtype = np.float32
+#     k = 10
+
+#     queries = get_queries(dataset_dir, dtype=dtype)
+#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
+
+#     index = ingest(
+#         index_type="FLAT",
+#         index_uri=index_uri,
+#         source_uri=os.path.join(dataset_dir, "data.f32bin"),
+#     )
+#     _, result = index.query(queries, k=k)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     index_ram = FlatIndex(uri=index_uri)
+#     _, result = index_ram.query(queries, k=k)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+# def test_flat_ingestion_external_id_u8(tmp_path):
+#     dataset_dir = os.path.join(tmp_path, "dataset")
+#     index_uri = os.path.join(tmp_path, "array")
+#     size = 10000
+#     dtype = np.uint8
+#     create_random_dataset_u8(nb=size, d=100, nq=100, k=10, path=dataset_dir)
+#     k = 10
+#     external_ids_offset = 100
+
+#     queries = get_queries(dataset_dir, dtype=dtype)
+#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
+#     external_ids = np.array(
+#         [range(external_ids_offset, size + external_ids_offset)], np.uint64
+#     )
+
+#     index = ingest(
+#         index_type="FLAT",
+#         index_uri=index_uri,
+#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
+#         external_ids=external_ids,
+#     )
+#     _, result = index.query(queries, k=k)
+#     assert (
+#         accuracy(result, gt_i, external_ids_offset=external_ids_offset)
+#         > MINIMUM_ACCURACY
+#     )
+
+
+# def test_ivf_flat_ingestion_u8(tmp_path):
+#     dataset_dir = os.path.join(tmp_path, "dataset")
+#     index_uri = os.path.join(tmp_path, "array")
+#     k = 10
+#     size = 100000
+#     partitions = 100
+#     dimensions = 128
+#     nqueries = 100
+#     nprobe = 20
+#     create_random_dataset_u8(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
+#     dtype = np.uint8
+
+#     queries = get_queries(dataset_dir, dtype=dtype)
+#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
+#     index = ingest(
+#         index_type="IVF_FLAT",
+#         index_uri=index_uri,
+#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
+#         partitions=partitions,
+#         input_vectors_per_work_item=int(size / 10),
+#     )
+#     _, result = index.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     index_ram = IVFFlatIndex(uri=index_uri, memory_budget=int(size / 10))
+#     _, result = index_ram.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     _, result = index_ram.query(
+#         queries,
+#         k=k,
+#         nprobe=nprobe,
+#         use_nuv_implementation=True,
+#     )
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     _, result = index_ram.query(
+#         queries,
+#         k=k,
+#         nprobe=nprobe,
+#         mode=Mode.LOCAL,
+#     )
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+# def test_ivf_flat_ingestion_f32(tmp_path):
+#     dataset_dir = os.path.join(tmp_path, "dataset")
+#     index_uri = os.path.join(tmp_path, "array")
+#     k = 10
+#     size = 100000
+#     dimensions = 128
+#     partitions = 100
+#     nqueries = 100
+#     nprobe = 20
+
+#     create_random_dataset_f32(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
+#     dtype = np.float32
+
+#     queries = get_queries(dataset_dir, dtype=dtype)
+#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
+
+#     index = ingest(
+#         index_type="IVF_FLAT",
+#         index_uri=index_uri,
+#         source_uri=os.path.join(dataset_dir, "data.f32bin"),
+#         partitions=partitions,
+#         input_vectors_per_work_item=int(size / 10),
+#     )
+
+#     _, result = index.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     index_ram = IVFFlatIndex(uri=index_uri)
+#     _, result = index_ram.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     index_ram = IVFFlatIndex(uri=index_uri, memory_budget=int(size / 10))
+#     _, result = index_ram.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     _, result = index_ram.query(
+#         queries,
+#         k=k,
+#         nprobe=nprobe,
+#         use_nuv_implementation=True,
+#     )
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+# def test_ivf_flat_ingestion_fvec(tmp_path):
+#     source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
+#     queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
+#     gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
+#     index_uri = os.path.join(tmp_path, "array")
+#     k = 100
+#     partitions = 100
+#     nqueries = 100
+#     nprobe = 20
+
+#     queries = load_fvecs(queries_uri)
+#     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
+
+#     index = ingest(
+#         index_type="IVF_FLAT",
+#         index_uri=index_uri,
+#         source_uri=source_uri,
+#         partitions=partitions,
+#     )
+#     _, result = index.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     index_ram = IVFFlatIndex(uri=index_uri)
+#     _, result = index_ram.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     _, result = index_ram.query(
+#         queries,
+#         k=k,
+#         nprobe=nprobe,
+#         use_nuv_implementation=True,
+#     )
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     # NB: local mode currently does not return distances
+#     _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+# def test_ivf_flat_ingestion_numpy(tmp_path):
+#     source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
+#     queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
+#     gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
+#     index_uri = os.path.join(tmp_path, "array")
+#     k = 100
+#     partitions = 100
+#     nqueries = 100
+#     nprobe = 20
+
+#     input_vectors = load_fvecs(source_uri)
+
+#     queries = load_fvecs(queries_uri)
+#     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
+
+#     index = ingest(
+#         index_type="IVF_FLAT",
+#         index_uri=index_uri,
+#         input_vectors=input_vectors,
+#         partitions=partitions,
+#     )
+#     _, result = index.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     index_ram = IVFFlatIndex(uri=index_uri)
+#     _, result = index_ram.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     _, result = index_ram.query(
+#         queries,
+#         k=k,
+#         nprobe=nprobe,
+#         use_nuv_implementation=True,
+#     )
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+# def test_ivf_flat_ingestion_multiple_workers(tmp_path):
+#     source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
+#     queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
+#     gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
+#     index_uri = os.path.join(tmp_path, "array")
+#     k = 100
+#     partitions = 100
+#     nqueries = 100
+#     nprobe = 20
+
+#     queries = load_fvecs(queries_uri)
+#     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
+
+#     index = ingest(
+#         index_type="IVF_FLAT",
+#         index_uri=index_uri,
+#         source_uri=source_uri,
+#         partitions=partitions,
+#         input_vectors_per_work_item=421,
+#         max_tasks_per_stage=4,
+#     )
+#     _, result = index.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     index_ram = IVFFlatIndex(uri=index_uri)
+#     _, result = index_ram.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     _, result = index_ram.query(
+#         queries,
+#         k=k,
+#         nprobe=nprobe,
+#         use_nuv_implementation=True,
+#     )
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+#     # NB: local mode currently does not return distances
+#     _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+# def test_ivf_flat_ingestion_external_ids_numpy(tmp_path):
+#     source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
+#     queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
+#     gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
+#     index_uri = os.path.join(tmp_path, "array")
+#     k = 100
+#     partitions = 100
+#     nqueries = 100
+#     nprobe = 20
+#     size = 10000
+#     external_ids_offset = 100
+
+#     input_vectors = load_fvecs(source_uri)
+
+#     queries = load_fvecs(queries_uri)
+#     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
+#     external_ids = np.array(
+#         [range(external_ids_offset, size + external_ids_offset)], np.uint64
+#     )
+#     index = ingest(
+#         index_type="IVF_FLAT",
+#         index_uri=index_uri,
+#         input_vectors=input_vectors,
+#         partitions=partitions,
+#         external_ids=external_ids,
+#     )
+#     _, result = index.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i, external_ids_offset) > MINIMUM_ACCURACY
+
+
+# def test_ivf_flat_ingestion_with_updates(tmp_path):
+#     dataset_dir = os.path.join(tmp_path, "dataset")
+#     index_uri = os.path.join(tmp_path, "array")
+#     k = 10
+#     size = 1000
+#     partitions = 10
+#     dimensions = 128
+#     nqueries = 100
+#     nprobe = 10
+#     data = create_random_dataset_u8(
+#         nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
+#     )
+#     dtype = np.uint8
+
+#     queries = get_queries(dataset_dir, dtype=dtype)
+#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
+#     index = ingest(
+#         index_type="IVF_FLAT",
+#         index_uri=index_uri,
+#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
+#         partitions=partitions,
+#     )
+#     _, result = index.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i) == 1.0
+
+#     update_ids_offset = MAX_UINT64 - size
+#     updated_ids = {}
+#     for i in range(100):
+#         index.delete(external_id=i)
+#         index.update(vector=data[i].astype(dtype), external_id=i + update_ids_offset)
+#         updated_ids[i] = i + update_ids_offset
+
+#     _, result = index.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+
+#     index = index.consolidate_updates(retrain_index=True, partitions=20)
+#     _, result = index.query(queries, k=k, nprobe=20)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+
+
+# def test_ivf_flat_ingestion_with_batch_updates(tmp_path):
+#     dataset_dir = os.path.join(tmp_path, "dataset")
+#     index_uri = os.path.join(tmp_path, "array")
+#     k = 10
+#     size = 100000
+#     partitions = 100
+#     dimensions = 128
+#     nqueries = 100
+#     nprobe = 100
+#     data = create_random_dataset_u8(
+#         nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
+#     )
+#     dtype = np.uint8
+
+#     queries = get_queries(dataset_dir, dtype=dtype)
+#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
+#     index = ingest(
+#         index_type="IVF_FLAT",
+#         index_uri=index_uri,
+#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
+#         partitions=partitions,
+#         input_vectors_per_work_item=int(size / 10),
+#     )
+#     _, result = index.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i) > 0.99
+
+#     update_ids = {}
+#     updated_ids = {}
+#     update_ids_offset = MAX_UINT64 - size
+#     for i in range(0, 100000, 2):
+#         updated_ids[i] = i + update_ids_offset
+#         update_ids[i + update_ids_offset] = i
+#     external_ids = np.zeros((len(updated_ids) * 2), dtype=np.uint64)
+#     updates = np.empty((len(updated_ids) * 2), dtype="O")
+#     id = 0
+#     for prev_id, new_id in updated_ids.items():
+#         external_ids[id] = prev_id
+#         updates[id] = np.array([], dtype=dtype)
+#         id += 1
+#         external_ids[id] = new_id
+#         updates[id] = data[prev_id].astype(dtype)
+#         id += 1
+
+#     index.update_batch(vectors=updates, external_ids=external_ids)
+#     _, result = index.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) > 0.99
+
+#     index = index.consolidate_updates()
+#     _, result = index.query(queries, k=k, nprobe=nprobe)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) > 0.99
+
+
+# def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
+#     dataset_dir = os.path.join(tmp_path, "dataset")
+#     index_uri = os.path.join(tmp_path, "array")
+#     k = 10
+#     size = 1000
+#     partitions = 10
+#     dimensions = 128
+#     nqueries = 100
+#     nprobe = 10
+#     data = create_random_dataset_u8(
+#         nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
+#     )
+#     dtype = np.uint8
+
+#     queries = get_queries(dataset_dir, dtype=dtype)
+#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
+#     index = ingest(
+#         index_type="IVF_FLAT",
+#         index_uri=index_uri,
+#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
+#         partitions=partitions,
+#         index_timestamp=1,
+#     )
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i) == 1.0
+
+#     update_ids_offset = MAX_UINT64 - size
+#     updated_ids = {}
+#     for i in range(2, 102):
+#         index.delete(external_id=i, timestamp=i)
+#         index.update(
+#             vector=data[i].astype(dtype), external_id=i + update_ids_offset, timestamp=i
+#         )
+#         updated_ids[i] = i + update_ids_offset
+
+#     index = IVFFlatIndex(uri=index_uri)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=101)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert (
+#         0.05
+#         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
+#         <= 0.15
+#     )
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert (
+#         0.05
+#         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
+#         <= 0.15
+#     )
+
+#     # Timetravel with partial read from updates table
+#     updated_ids_part = {}
+#     for i in range(2, 52):
+#         updated_ids_part[i] = i + update_ids_offset
+#     index = IVFFlatIndex(uri=index_uri, timestamp=51)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert (
+#         0.02
+#         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
+#         <= 0.07
+#     )
+
+#     # Timetravel at previous ingestion timestamp
+#     index = IVFFlatIndex(uri=index_uri, timestamp=1)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i) == 1.0
+
+#     # Consolidate updates
+#     index = index.consolidate_updates()
+#     index = IVFFlatIndex(uri=index_uri)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=101)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert (
+#         0.05
+#         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
+#         <= 0.15
+#     )
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert (
+#         0.05
+#         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
+#         <= 0.15
+#     )
+
+#     # Timetravel with partial read from updates table
+#     updated_ids_part = {}
+#     for i in range(2, 52):
+#         updated_ids_part[i] = i + update_ids_offset
+#     index = IVFFlatIndex(uri=index_uri, timestamp=51)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert (
+#         0.02
+#         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
+#         <= 0.07
+#     )
+
+#     # Timetravel at previous ingestion timestamp
+#     index = IVFFlatIndex(uri=index_uri, timestamp=1)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 1))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i) == 1.0
+
+#     # Clear history before the latest ingestion
+#     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
+#     index = IVFFlatIndex(uri=index_uri, timestamp=1)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=51)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=101)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+
+#     # Clear all history
+#     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp)
+#     index = IVFFlatIndex(uri=index_uri, timestamp=1)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=51)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=101)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+#     index = IVFFlatIndex(uri=index_uri)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+
+
+# def test_ivf_flat_ingestion_with_additions_and_timetravel(tmp_path):
+#     dataset_dir = os.path.join(tmp_path, "dataset")
+#     index_uri = os.path.join(tmp_path, "array")
+#     k = 100
+#     size = 100
+#     partitions = 10
+#     dimensions = 128
+#     nqueries = 1
+#     data = create_random_dataset_u8(
+#         nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
+#     )
+#     dtype = np.uint8
+
+#     queries = get_queries(dataset_dir, dtype=dtype)
+#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
+#     index = ingest(
+#         index_type="IVF_FLAT",
+#         index_uri=index_uri,
+#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
+#         partitions=partitions,
+#         index_timestamp=1,
+#     )
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert accuracy(result, gt_i) == 1.0
+
+#     update_ids_offset = MAX_UINT64 - size
+#     updated_ids = {}
+#     for i in range(100):
+#         index.update(
+#             vector=data[i].astype(dtype),
+#             external_id=i + update_ids_offset,
+#             timestamp=i + 2,
+#         )
+#         updated_ids[i] = i + update_ids_offset
+
+#     index = IVFFlatIndex(uri=index_uri)
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert 0.45 < accuracy(result, gt_i) < 0.55
+
+#     index = index.consolidate_updates()
+#     _, result = index.query(queries, k=k, nprobe=index.partitions)
+#     assert 0.45 < accuracy(result, gt_i) < 0.55
+
+
+# def test_storage_versions(tmp_path):
+#     dataset_dir = os.path.join(tmp_path, "dataset")
+#     k = 10
+#     size = 1000
+#     partitions = 10
+#     dimensions = 128
+#     nqueries = 100
+#     data = create_random_dataset_u8(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
+#     source_uri = os.path.join(dataset_dir, "data.u8bin")
+
+#     dtype = np.uint8
+#     queries = get_queries(dataset_dir, dtype=dtype)
+#     gt_i, _ = get_groundtruth(dataset_dir, k)
     
-    indexes = ["FLAT", "IVF_FLAT"]
-    index_classes = [FlatIndex, IVFFlatIndex]
-    index_files = [tiledb.vector_search.flat_index, tiledb.vector_search.ivf_flat_index]
-    for index_type, index_class, index_file in zip(indexes, index_classes, index_files):
-        # First we test with an invalid storage version.
-        with pytest.raises(ValueError) as error:
-            index_uri = os.path.join(tmp_path, f"array_{index_type}_invalid")
-            ingest(
-                index_type=index_type,
-                index_uri=index_uri,
-                source_uri=source_uri,
-                partitions=partitions,
-                storage_version="Foo"
-            )
-        assert "Invalid storage version" in str(error.value)
+#     indexes = ["FLAT", "IVF_FLAT"]
+#     index_classes = [FlatIndex, IVFFlatIndex]
+#     index_files = [tiledb.vector_search.flat_index, tiledb.vector_search.ivf_flat_index]
+#     for index_type, index_class, index_file in zip(indexes, index_classes, index_files):
+#         # First we test with an invalid storage version.
+#         with pytest.raises(ValueError) as error:
+#             index_uri = os.path.join(tmp_path, f"array_{index_type}_invalid")
+#             ingest(
+#                 index_type=index_type,
+#                 index_uri=index_uri,
+#                 source_uri=source_uri,
+#                 partitions=partitions,
+#                 storage_version="Foo"
+#             )
+#         assert "Invalid storage version" in str(error.value)
 
-        with pytest.raises(ValueError) as error:
-            index_file.create(uri=index_uri, dimensions=3, vector_type=np.dtype(dtype), storage_version="Foo")
-        assert "Invalid storage version" in str(error.value)
+#         with pytest.raises(ValueError) as error:
+#             index_file.create(uri=index_uri, dimensions=3, vector_type=np.dtype(dtype), storage_version="Foo")
+#         assert "Invalid storage version" in str(error.value)
 
-        # Then we test with valid storage versions.
-        for storage_version, _ in tiledb.vector_search.storage_formats.items():
-            index_uri = os.path.join(tmp_path, f"array_{index_type}_{storage_version}")
-            index = ingest(
-                index_type=index_type,
-                index_uri=index_uri,
-                source_uri=source_uri,
-                partitions=partitions,
-                storage_version=storage_version
-            )
-            _, result = index.query(queries, k=k)
-            assert accuracy(result, gt_i) >= MINIMUM_ACCURACY
+#         # Then we test with valid storage versions.
+#         for storage_version, _ in tiledb.vector_search.storage_formats.items():
+#             index_uri = os.path.join(tmp_path, f"array_{index_type}_{storage_version}")
+#             index = ingest(
+#                 index_type=index_type,
+#                 index_uri=index_uri,
+#                 source_uri=source_uri,
+#                 partitions=partitions,
+#                 storage_version=storage_version
+#             )
+#             _, result = index.query(queries, k=k)
+#             assert accuracy(result, gt_i) >= MINIMUM_ACCURACY
 
-            update_ids_offset = MAX_UINT64 - size
-            updated_ids = {}
-            for i in range(10):
-                index.delete(external_id=i)
-                index.update(vector=data[i].astype(dtype), external_id=i + update_ids_offset)
-                updated_ids[i] = i + update_ids_offset
+#             update_ids_offset = MAX_UINT64 - size
+#             updated_ids = {}
+#             for i in range(10):
+#                 index.delete(external_id=i)
+#                 index.update(vector=data[i].astype(dtype), external_id=i + update_ids_offset)
+#                 updated_ids[i] = i + update_ids_offset
 
-            _, result = index.query(queries, k=k)
-            assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
+#             _, result = index.query(queries, k=k)
+#             assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
 
-            index = index.consolidate_updates(retrain_index=True, partitions=20)
-            _, result = index.query(queries, k=k)
-            assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
+#             index = index.consolidate_updates(retrain_index=True, partitions=20)
+#             _, result = index.query(queries, k=k)
+#             assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
 
-            index_ram = index_class(uri=index_uri)
-            _, result = index_ram.query(queries, k=k)
-            assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+#             index_ram = index_class(uri=index_uri)
+#             _, result = index_ram.query(queries, k=k)
+#             assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
-def test_copy_centroids_uri(tmp_path):
-    dataset_dir = os.path.join(tmp_path, "dataset")
-    os.mkdir(dataset_dir)
+# def test_copy_centroids_uri(tmp_path):
+#     dataset_dir = os.path.join(tmp_path, "dataset")
+#     os.mkdir(dataset_dir)
 
-    # Create the index data.
-    data = np.array([[1, 1, 1, 1], [1, 1, 1, 1], [2, 2, 2, 2], [2, 2, 2, 2], [3, 3, 3, 3]], dtype=np.float32)
+#     # Create the index data.
+#     data = np.array([[1, 1, 1, 1], [1, 1, 1, 1], [2, 2, 2, 2], [2, 2, 2, 2], [3, 3, 3, 3]], dtype=np.float32)
 
-    # Create the centroids - this is based on ivf_flat_index.py.
-    centroids = np.array([[1, 1, 1, 1], [2, 2, 2, 2]], dtype=np.float32)
-    centroids_in_size = centroids.shape[0]
-    dimensions = centroids.shape[1]
-    schema = tiledb.ArraySchema(
-        domain=tiledb.Domain(
-            *[
-                tiledb.Dim(name="rows", domain=(0, dimensions - 1), tile=dimensions, dtype=np.dtype(np.int32)),
-                tiledb.Dim(name="cols", domain=(0, np.iinfo(np.dtype("int32")).max), tile=100000, dtype=np.dtype(np.int32)),
-            ]
-        ),
-        sparse=False,
-        attrs=[tiledb.Attr(name="centroids", dtype="float32", filters=tiledb.FilterList([tiledb.ZstdFilter()]))],
-        cell_order="col-major",
-        tile_order="col-major",
-    )
-    centroids_uri = os.path.join(dataset_dir, "centroids.tdb")
-    tiledb.Array.create(centroids_uri, schema)
-    index_timestamp = int(time.time() * 1000)
-    with tiledb.open(centroids_uri, mode="w", timestamp=index_timestamp) as A:
-        A[0:dimensions, 0:centroids_in_size] = centroids.transpose()
+#     # Create the centroids - this is based on ivf_flat_index.py.
+#     centroids = np.array([[1, 1, 1, 1], [2, 2, 2, 2]], dtype=np.float32)
+#     centroids_in_size = centroids.shape[0]
+#     dimensions = centroids.shape[1]
+#     schema = tiledb.ArraySchema(
+#         domain=tiledb.Domain(
+#             *[
+#                 tiledb.Dim(name="rows", domain=(0, dimensions - 1), tile=dimensions, dtype=np.dtype(np.int32)),
+#                 tiledb.Dim(name="cols", domain=(0, np.iinfo(np.dtype("int32")).max), tile=100000, dtype=np.dtype(np.int32)),
+#             ]
+#         ),
+#         sparse=False,
+#         attrs=[tiledb.Attr(name="centroids", dtype="float32", filters=tiledb.FilterList([tiledb.ZstdFilter()]))],
+#         cell_order="col-major",
+#         tile_order="col-major",
+#     )
+#     centroids_uri = os.path.join(dataset_dir, "centroids.tdb")
+#     tiledb.Array.create(centroids_uri, schema)
+#     index_timestamp = int(time.time() * 1000)
+#     with tiledb.open(centroids_uri, mode="w", timestamp=index_timestamp) as A:
+#         A[0:dimensions, 0:centroids_in_size] = centroids.transpose()
 
-    # Create the index.
-    index_uri = os.path.join(tmp_path, "array")
-    index = ingest(
-        index_type="IVF_FLAT", 
-        index_uri=index_uri, 
-        input_vectors=data,
-        copy_centroids_uri=centroids_uri,
-        partitions=centroids_in_size
-    )
+#     # Create the index.
+#     index_uri = os.path.join(tmp_path, "array")
+#     index = ingest(
+#         index_type="IVF_FLAT", 
+#         index_uri=index_uri, 
+#         input_vectors=data,
+#         copy_centroids_uri=centroids_uri,
+#         partitions=centroids_in_size
+#     )
 
-    # Query the index.
-    queries = np.array([data[4]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[4]])
+#     # Query the index.
+#     queries = np.array([data[4]], dtype=np.float32)
+#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[4]])
 
 
-def test_kmeans():
-    k = 128
-    d = 16
-    n = k * k
-    max_iter = 16
-    n_init = 10
-    verbose = False
+# def test_kmeans():
+#     k = 128
+#     d = 16
+#     n = k * k
+#     max_iter = 16
+#     n_init = 10
+#     verbose = False
 
-    import sklearn.model_selection
-    from sklearn.datasets import make_blobs
-    from sklearn.cluster import KMeans
+#     import sklearn.model_selection
+#     from sklearn.datasets import make_blobs
+#     from sklearn.cluster import KMeans
 
-    X, _, centers = make_blobs(n_samples=n, n_features=d, centers=k, return_centers=True, random_state=1)
-    X = X.astype("float32")
+#     X, _, centers = make_blobs(n_samples=n, n_features=d, centers=k, return_centers=True, random_state=1)
+#     X = X.astype("float32")
 
-    data, queries = sklearn.model_selection.train_test_split(
-        X, test_size=0.1, random_state=1
-    )
+#     data, queries = sklearn.model_selection.train_test_split(
+#         X, test_size=0.1, random_state=1
+#     )
 
-    data_x = np.array([[1.0573647,   5.082087],
-                      [-6.229642,   -1.3590931],
-                      [0.7446737,    6.3828287],
-                      [-7.698864,   -3.0493321],
-                      [2.1362762,   -4.4448104],
-                      [1.04019,     -4.0389647],
-                      [0.38996044,   5.7235265],
-    [1.7470839,  -4.717076]]).astype("float32")
-    queries_x = np.array([[-7.3712273, -1.1178735]]).astype("float32")
+#     data_x = np.array([[1.0573647,   5.082087],
+#                       [-6.229642,   -1.3590931],
+#                       [0.7446737,    6.3828287],
+#                       [-7.698864,   -3.0493321],
+#                       [2.1362762,   -4.4448104],
+#                       [1.04019,     -4.0389647],
+#                       [0.38996044,   5.7235265],
+#     [1.7470839,  -4.717076]]).astype("float32")
+#     queries_x = np.array([[-7.3712273, -1.1178735]]).astype("float32")
 
-    km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="random", random_state=1)
-    km.fit(data)
-    centroids_sk = km.cluster_centers_
-    results_sk = km.predict(queries)
+#     km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="random", random_state=1)
+#     km.fit(data)
+#     centroids_sk = km.cluster_centers_
+#     results_sk = km.predict(queries)
 
-    centroids_tdb = kmeans_fit(
-        k, "random", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
-    )
-    centroids_tdb_np = np.transpose(np.array(centroids_tdb))
-    results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
-    results_tdb_np = np.transpose(np.array(results_tdb))
+#     centroids_tdb = kmeans_fit(
+#         k, "random", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
+#     )
+#     centroids_tdb_np = np.transpose(np.array(centroids_tdb))
+#     results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
+#     results_tdb_np = np.transpose(np.array(results_tdb))
 
-    def get_score(centroids, results):
-        x = []
-        for i in range(len(queries)):
-            x.append(np.linalg.norm(queries[i] - centroids[results[i]]))
-        return np.mean(np.array(x))
+#     def get_score(centroids, results):
+#         x = []
+#         for i in range(len(queries)):
+#             x.append(np.linalg.norm(queries[i] - centroids[results[i]]))
+#         return np.mean(np.array(x))
 
-    sklearn_score = get_score(centroids_sk, results_sk)
-    tdb_score = get_score(centroids_tdb_np, results_tdb_np)
+#     sklearn_score = get_score(centroids_sk, results_sk)
+#     tdb_score = get_score(centroids_tdb_np, results_tdb_np)
 
-    km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="k-means++", random_state=1)
-    km.fit(data)
-    centroids_sk = km.cluster_centers_
-    results_sk = km.predict(queries)
+#     km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="k-means++", random_state=1)
+#     km.fit(data)
+#     centroids_sk = km.cluster_centers_
+#     results_sk = km.predict(queries)
 
-    assert tdb_score < 1.5 * sklearn_score
+#     assert tdb_score < 1.5 * sklearn_score
 
-    centroids_tdb = kmeans_fit(
-        k, "k-means++", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
-    )
-    centroids_tdb_np = np.transpose(np.array(centroids_tdb))
-    results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
-    results_tdb_np = np.transpose(np.array(results_tdb))
+#     centroids_tdb = kmeans_fit(
+#         k, "k-means++", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
+#     )
+#     centroids_tdb_np = np.transpose(np.array(centroids_tdb))
+#     results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
+#     results_tdb_np = np.transpose(np.array(results_tdb))
 
-    sklearn_score = get_score(centroids_sk, results_sk)
-    tdb_score = get_score(centroids_tdb_np, results_tdb_np)
+#     sklearn_score = get_score(centroids_sk, results_sk)
+#     tdb_score = get_score(centroids_tdb_np, results_tdb_np)
 
-    assert tdb_score < 1.5 * sklearn_score
+#     assert tdb_score < 1.5 * sklearn_score
 
-def test_ingest_with_training_source_uri_f32(tmp_path):
-    dataset_dir = os.path.join(tmp_path, "dataset")
-    data = np.array([[1.0, 1.1, 1.2, 1.3], [2.0, 2.1, 2.2, 2.3], [3.0, 3.1, 3.2, 3.3], [4.0, 4.1, 4.2, 4.3], [5.0, 5.1, 5.2, 5.3]], dtype=np.float32)
-    create_manual_dataset_f32_only_data(data=data, path=dataset_dir)
+# def test_ingest_with_training_source_uri_f32(tmp_path):
+#     dataset_dir = os.path.join(tmp_path, "dataset")
+#     data = np.array([[1.0, 1.1, 1.2, 1.3], [2.0, 2.1, 2.2, 2.3], [3.0, 3.1, 3.2, 3.3], [4.0, 4.1, 4.2, 4.3], [5.0, 5.1, 5.2, 5.3]], dtype=np.float32)
+#     create_manual_dataset_f32_only_data(data=data, path=dataset_dir)
 
-    training_data = np.array([data[0], data[1], data[2]], dtype=np.float32)
-    create_manual_dataset_f32_only_data(data=training_data, path=dataset_dir, dataset_name="training_data.f32bin")
-    index_uri = os.path.join(tmp_path, "array")
-    index = ingest(
-        index_type="IVF_FLAT", 
-        index_uri=index_uri, 
-        source_uri=os.path.join(dataset_dir, "data.f32bin"),
-        training_source_uri=os.path.join(dataset_dir, "training_data.f32bin")
-    )
+#     training_data = np.array([data[0], data[1], data[2]], dtype=np.float32)
+#     create_manual_dataset_f32_only_data(data=training_data, path=dataset_dir, dataset_name="training_data.f32bin")
+#     index_uri = os.path.join(tmp_path, "array")
+#     index = ingest(
+#         index_type="IVF_FLAT", 
+#         index_uri=index_uri, 
+#         source_uri=os.path.join(dataset_dir, "data.f32bin"),
+#         training_source_uri=os.path.join(dataset_dir, "training_data.f32bin")
+#     )
 
-    queries = np.array([data[1]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+#     queries = np.array([data[1]], dtype=np.float32)
+#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
 
-    index = IVFFlatIndex(uri=index_uri)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+#     index = IVFFlatIndex(uri=index_uri)
+#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
 
-    # Also test that we can ingest with training_source_type.
-    ingest(
-        index_type="IVF_FLAT",
-        index_uri=os.path.join(tmp_path, "array_2"), 
-        source_uri=os.path.join(dataset_dir, "data.f32bin"),
-        training_source_uri=os.path.join(dataset_dir, "training_data.f32bin"),
-        training_source_type="F32BIN"
-    )
+#     # Also test that we can ingest with training_source_type.
+#     ingest(
+#         index_type="IVF_FLAT",
+#         index_uri=os.path.join(tmp_path, "array_2"), 
+#         source_uri=os.path.join(dataset_dir, "data.f32bin"),
+#         training_source_uri=os.path.join(dataset_dir, "training_data.f32bin"),
+#         training_source_type="F32BIN"
+#     )
 
-def test_ingest_with_training_source_uri_tdb(tmp_path):
+# def test_ingest_with_training_source_uri_tdb(tmp_path):
+#     ################################################################################################
+#     # First set up the data.
+#     ################################################################################################
+#     dataset_dir = os.path.join(tmp_path, "dataset")
+#     os.mkdir(dataset_dir)
+#     # data.shape should give you (cols, rows). So we transpose this before using it.
+#     data = np.array([
+#         [1.0, 1.1, 1.2, 1.3], 
+#         [2.0, 2.1, 2.2, 2.3], 
+#         [3.0, 3.1, 3.2, 3.3], 
+#         [4.0, 4.1, 4.2, 4.3], 
+#         [5.0, 5.1, 5.2, 5.3]], dtype=np.float32).transpose()
+#     create_array(path=os.path.join(dataset_dir, "data.tdb"), data=data)
+
+#     training_data = np.array([
+#         [1.0, 1.1, 1.2, 1.3], 
+#         [5.0, 5.1, 5.2, 5.3]], dtype=np.float32).transpose()
+#     create_array(path=os.path.join(dataset_dir, "training_data.tdb"), data=training_data)
+
+#     # Run a quick test that if we set up training_data incorrectly, we will raise an exception.
+#     with pytest.raises(ValueError) as error:
+#         training_data_invalid = np.array([
+#             [1.0, 1.1, 1.2], 
+#             [5.0, 5.1, 5.2]], dtype=np.float32).transpose()
+#         create_array(path=os.path.join(dataset_dir, "training_data_invalid.tdb"), data=training_data_invalid)
+#         index = ingest(
+#             index_type="IVF_FLAT", 
+#             index_uri=os.path.join(tmp_path, f"array_invalid"), 
+#             source_uri=os.path.join(dataset_dir, "data.tdb"),
+#             training_source_uri=os.path.join(dataset_dir, "training_data_invalid.tdb")
+#         )
+#     assert "training data dimensions" in str(error.value)
+
+#     ################################################################################################
+#     # Test we can ingest, query, update, and consolidate.
+#     ################################################################################################
+#     index_uri = os.path.join(tmp_path, "array")
+#     index = ingest(
+#         index_type="IVF_FLAT", 
+#         index_uri=index_uri, 
+#         source_uri=os.path.join(dataset_dir, "data.tdb"),
+#         training_source_uri=os.path.join(dataset_dir, "training_data.tdb")
+#     )
+
+#     queries = np.array([data.transpose()[1]], dtype=np.float32)
+#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+
+#     update_vectors = np.empty([3], dtype=object)
+#     update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
+#     update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
+#     update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
+#     index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
+    
+#     index = index.consolidate_updates()
+
+#     queries = np.array([update_vectors[2]], dtype=np.float32)
+#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
+
+#     ################################################################################################
+#     # Test we can load the index again and query, update, and consolidate.
+#     ################################################################################################
+#     # Load the index again and query.
+#     index = IVFFlatIndex(uri=index_uri)
+
+#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
+    
+#     # Update the index and query.
+#     update_vectors = np.empty([2], dtype=object)
+#     update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
+#     update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
+#     index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+#     index = index.consolidate_updates()
+    
+#     queries = np.array([update_vectors[0]], dtype=np.float32)
+#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
+
+#     # Clear the index history, load, update, and query.
+#     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
+
+#     index = IVFFlatIndex(uri=index_uri)
+
+#     update_vectors = np.empty([2], dtype=object)
+#     update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
+#     update_vectors[1] = np.array([12.0, 12.1, 12.2, 12.3], dtype=np.dtype(np.float32))
+#     index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+#     index = index.consolidate_updates()
+
+#     queries = np.array([update_vectors[0]], dtype=np.float32)
+#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
+
+#     ###############################################################################################
+#     # Also test that we can ingest with training_source_type.
+#     ###############################################################################################
+#     ingest(
+#         index_type="IVF_FLAT",
+#         index_uri=os.path.join(tmp_path, "array_2"), 
+#         source_uri=os.path.join(dataset_dir, "data.tdb"),
+#         training_source_uri=os.path.join(dataset_dir, "training_data.tdb"),
+#         training_source_type="TILEDB_ARRAY"
+#     )
+
+# def test_ingest_with_training_source_uri_numpy(tmp_path):
+#     ################################################################################################
+#     # First set up the data.
+#     ################################################################################################
+#     data = np.array([
+#         [1.0, 1.1, 1.2, 1.3], 
+#         [2.0, 2.1, 2.2, 2.3], 
+#         [3.0, 3.1, 3.2, 3.3], 
+#         [4.0, 4.1, 4.2, 4.3], 
+#         [5.0, 5.1, 5.2, 5.3]], dtype=np.float32)
+#     training_data = data[1:3]
+
+#     # Run a quick test that if we set up training_data incorrectly, we will raise an exception.
+#     with pytest.raises(ValueError) as error:
+#         training_data_invalid = np.array([
+#             [4.0, 4.1, 4.2], 
+#             [5.0, 5.1, 5.2]], dtype=np.float32)
+#         index = ingest(
+#             index_type="IVF_FLAT", 
+#             index_uri=os.path.join(tmp_path, "array_invalid"), 
+#             input_vectors=data,
+#             training_input_vectors=training_data_invalid,
+#         )
+#     assert "training data dimensions" in str(error.value)
+
+#     ################################################################################################
+#     # Test we can ingest, query, update, and consolidate.
+#     ################################################################################################
+#     index_uri = os.path.join(tmp_path, "array")
+#     index = ingest(
+#         index_type="IVF_FLAT", 
+#         index_uri=index_uri, 
+#         input_vectors=data,
+#         training_input_vectors=training_data,
+#     )
+
+#     queries = np.array([data[1]], dtype=np.float32)
+#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+
+#     update_vectors = np.empty([3], dtype=object)
+#     update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
+#     update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
+#     update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
+#     index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
+    
+#     index = index.consolidate_updates()
+
+#     queries = np.array([update_vectors[2]], dtype=np.float32)
+#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
+
+#     ################################################################################################
+#     # Test we can load the index again and query, update, and consolidate.
+#     ################################################################################################
+#     index_ram = IVFFlatIndex(uri=index_uri)
+
+#     queries = np.array([data[1]], dtype=np.float32)
+#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+
+#     update_vectors = np.empty([2], dtype=object)
+#     update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
+#     update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
+#     index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+#     index_ram = index_ram.consolidate_updates()
+
+#     queries = np.array([update_vectors[0]], dtype=np.float32)
+#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
+
+#     update_vectors = np.empty([2], dtype=object)
+#     update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
+#     update_vectors[1] = np.array([12.0, 12.1, 12.2, 12.3], dtype=np.dtype(np.float32))
+#     index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+#     index_ram = index_ram.consolidate_updates(retrain_index=True, training_sample_size=3)
+
+#     queries = np.array([update_vectors[0]], dtype=np.float32)
+#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
+    
+def test_ivf_flat_ingestion_tdb_random_sampling_policy(tmp_path):
     ################################################################################################
     # First set up the data.
     ################################################################################################
@@ -896,7 +1074,11 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
         [2.0, 2.1, 2.2, 2.3], 
         [3.0, 3.1, 3.2, 3.3], 
         [4.0, 4.1, 4.2, 4.3], 
-        [5.0, 5.1, 5.2, 5.3]], dtype=np.float32).transpose()
+        [5.0, 5.1, 5.2, 5.3],
+        [6.0, 6.1, 6.2, 6.3],
+        [7.0, 7.1, 7.2, 7.3],
+        [8.0, 8.1, 8.2, 8.3],
+        [9.0, 9.1, 9.2, 9.3]], dtype=np.float32).transpose()
     create_array(path=os.path.join(dataset_dir, "data.tdb"), data=data)
 
     training_data = np.array([
@@ -904,20 +1086,6 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
         [5.0, 5.1, 5.2, 5.3]], dtype=np.float32).transpose()
     create_array(path=os.path.join(dataset_dir, "training_data.tdb"), data=training_data)
 
-    # Run a quick test that if we set up training_data incorrectly, we will raise an exception.
-    with pytest.raises(ValueError) as error:
-        training_data_invalid = np.array([
-            [1.0, 1.1, 1.2], 
-            [5.0, 5.1, 5.2]], dtype=np.float32).transpose()
-        create_array(path=os.path.join(dataset_dir, "training_data_invalid.tdb"), data=training_data_invalid)
-        index = ingest(
-            index_type="IVF_FLAT", 
-            index_uri=os.path.join(tmp_path, f"array_invalid"), 
-            source_uri=os.path.join(dataset_dir, "data.tdb"),
-            training_source_uri=os.path.join(dataset_dir, "training_data_invalid.tdb")
-        )
-    assert "training data dimensions" in str(error.value)
-
     ################################################################################################
     # Test we can ingest, query, update, and consolidate.
     ################################################################################################
@@ -926,138 +1094,8 @@ def test_ingest_with_training_source_uri_tdb(tmp_path):
         index_type="IVF_FLAT", 
         index_uri=index_uri, 
         source_uri=os.path.join(dataset_dir, "data.tdb"),
-        training_source_uri=os.path.join(dataset_dir, "training_data.tdb")
+        training_sampling_policy=TrainingSamplingPolicy.RANDOM,
+        training_sample_size=3,
+        input_vectors_per_work_item=4,
+        use_sklearn=True
     )
-
-    queries = np.array([data.transpose()[1]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
-
-    update_vectors = np.empty([3], dtype=object)
-    update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
-    update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
-    update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
-    index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
-    
-    index = index.consolidate_updates()
-
-    queries = np.array([update_vectors[2]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
-
-    ################################################################################################
-    # Test we can load the index again and query, update, and consolidate.
-    ################################################################################################
-    # Load the index again and query.
-    index = IVFFlatIndex(uri=index_uri)
-
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
-    
-    # Update the index and query.
-    update_vectors = np.empty([2], dtype=object)
-    update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
-    update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
-    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
-    index = index.consolidate_updates()
-    
-    queries = np.array([update_vectors[0]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
-
-    # Clear the index history, load, update, and query.
-    Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
-
-    index = IVFFlatIndex(uri=index_uri)
-
-    update_vectors = np.empty([2], dtype=object)
-    update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
-    update_vectors[1] = np.array([12.0, 12.1, 12.2, 12.3], dtype=np.dtype(np.float32))
-    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
-    index = index.consolidate_updates()
-
-    queries = np.array([update_vectors[0]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
-
-    ###############################################################################################
-    # Also test that we can ingest with training_source_type.
-    ###############################################################################################
-    ingest(
-        index_type="IVF_FLAT",
-        index_uri=os.path.join(tmp_path, "array_2"), 
-        source_uri=os.path.join(dataset_dir, "data.tdb"),
-        training_source_uri=os.path.join(dataset_dir, "training_data.tdb"),
-        training_source_type="TILEDB_ARRAY"
-    )
-
-def test_ingest_with_training_source_uri_numpy(tmp_path):
-    ################################################################################################
-    # First set up the data.
-    ################################################################################################
-    data = np.array([
-        [1.0, 1.1, 1.2, 1.3], 
-        [2.0, 2.1, 2.2, 2.3], 
-        [3.0, 3.1, 3.2, 3.3], 
-        [4.0, 4.1, 4.2, 4.3], 
-        [5.0, 5.1, 5.2, 5.3]], dtype=np.float32)
-    training_data = data[1:3]
-
-    # Run a quick test that if we set up training_data incorrectly, we will raise an exception.
-    with pytest.raises(ValueError) as error:
-        training_data_invalid = np.array([
-            [4.0, 4.1, 4.2], 
-            [5.0, 5.1, 5.2]], dtype=np.float32)
-        index = ingest(
-            index_type="IVF_FLAT", 
-            index_uri=os.path.join(tmp_path, "array_invalid"), 
-            input_vectors=data,
-            training_input_vectors=training_data_invalid,
-        )
-    assert "training data dimensions" in str(error.value)
-
-    ################################################################################################
-    # Test we can ingest, query, update, and consolidate.
-    ################################################################################################
-    index_uri = os.path.join(tmp_path, "array")
-    index = ingest(
-        index_type="IVF_FLAT", 
-        index_uri=index_uri, 
-        input_vectors=data,
-        training_input_vectors=training_data,
-    )
-
-    queries = np.array([data[1]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
-
-    update_vectors = np.empty([3], dtype=object)
-    update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
-    update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
-    update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
-    index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
-    
-    index = index.consolidate_updates()
-
-    queries = np.array([update_vectors[2]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
-
-    ################################################################################################
-    # Test we can load the index again and query, update, and consolidate.
-    ################################################################################################
-    index_ram = IVFFlatIndex(uri=index_uri)
-
-    queries = np.array([data[1]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
-
-    update_vectors = np.empty([2], dtype=object)
-    update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
-    update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
-    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
-    index_ram = index_ram.consolidate_updates()
-
-    queries = np.array([update_vectors[0]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
-
-    update_vectors = np.empty([2], dtype=object)
-    update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
-    update_vectors[1] = np.array([12.0, 12.1, 12.2, 12.3], dtype=np.dtype(np.float32))
-    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
-    index_ram = index_ram.consolidate_updates(retrain_index=True, training_sample_size=3)
-
-    queries = np.array([update_vectors[0]], dtype=np.float32)
-    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -715,7 +715,7 @@ def test_ivf_flat_ingestion_fvec_random_sampling_policy(tmp_path):
     gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
     index_uri = os.path.join(tmp_path, "array")
     k = 100
-    partitions = 100
+    partitions = 50
     nqueries = 100
     nprobe = 20
 
@@ -728,6 +728,7 @@ def test_ivf_flat_ingestion_fvec_random_sampling_policy(tmp_path):
         source_uri=source_uri,
         partitions=partitions,
         training_sampling_policy=TrainingSamplingPolicy.RANDOM,
+        training_sample_size=1239,
         input_vectors_per_work_item=1000,
     )
     _, result = index.query(queries, k=k, nprobe=nprobe)

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -18,1054 +18,665 @@ def query_and_check_equals(index, queries, expected_result_d, expected_result_i)
     result_d, result_i = index.query(queries, k=1)
     check_equals(result_d=result_d, result_i=result_i, expected_result_d=expected_result_d, expected_result_i=expected_result_i)
 
-# def test_flat_ingestion_u8(tmp_path):
-#     dataset_dir = os.path.join(tmp_path, "dataset")
-#     index_uri = os.path.join(tmp_path, "array")
-#     create_random_dataset_u8(nb=10000, d=100, nq=100, k=10, path=dataset_dir)
-#     dtype = np.uint8
-#     k = 10
-
-#     queries = get_queries(dataset_dir, dtype=dtype)
-#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
-
-#     index = ingest(
-#         index_type="FLAT",
-#         index_uri=index_uri,
-#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
-#     )
-#     _, result = index.query(queries, k=k)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-# def test_flat_ingestion_f32(tmp_path):
-#     dataset_dir = os.path.join(tmp_path, "dataset")
-#     index_uri = os.path.join(tmp_path, "array")
-#     create_random_dataset_f32(nb=10000, d=100, nq=100, k=10, path=dataset_dir)
-#     dtype = np.float32
-#     k = 10
-
-#     queries = get_queries(dataset_dir, dtype=dtype)
-#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
-
-#     index = ingest(
-#         index_type="FLAT",
-#         index_uri=index_uri,
-#         source_uri=os.path.join(dataset_dir, "data.f32bin"),
-#     )
-#     _, result = index.query(queries, k=k)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     index_ram = FlatIndex(uri=index_uri)
-#     _, result = index_ram.query(queries, k=k)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-# def test_flat_ingestion_external_id_u8(tmp_path):
-#     dataset_dir = os.path.join(tmp_path, "dataset")
-#     index_uri = os.path.join(tmp_path, "array")
-#     size = 10000
-#     dtype = np.uint8
-#     create_random_dataset_u8(nb=size, d=100, nq=100, k=10, path=dataset_dir)
-#     k = 10
-#     external_ids_offset = 100
-
-#     queries = get_queries(dataset_dir, dtype=dtype)
-#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
-#     external_ids = np.array(
-#         [range(external_ids_offset, size + external_ids_offset)], np.uint64
-#     )
-
-#     index = ingest(
-#         index_type="FLAT",
-#         index_uri=index_uri,
-#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
-#         external_ids=external_ids,
-#     )
-#     _, result = index.query(queries, k=k)
-#     assert (
-#         accuracy(result, gt_i, external_ids_offset=external_ids_offset)
-#         > MINIMUM_ACCURACY
-#     )
-
-
-# def test_ivf_flat_ingestion_u8(tmp_path):
-#     dataset_dir = os.path.join(tmp_path, "dataset")
-#     index_uri = os.path.join(tmp_path, "array")
-#     k = 10
-#     size = 100000
-#     partitions = 100
-#     dimensions = 128
-#     nqueries = 100
-#     nprobe = 20
-#     create_random_dataset_u8(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
-#     dtype = np.uint8
-
-#     queries = get_queries(dataset_dir, dtype=dtype)
-#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
-#     index = ingest(
-#         index_type="IVF_FLAT",
-#         index_uri=index_uri,
-#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
-#         partitions=partitions,
-#         input_vectors_per_work_item=int(size / 10),
-#     )
-#     _, result = index.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     index_ram = IVFFlatIndex(uri=index_uri, memory_budget=int(size / 10))
-#     _, result = index_ram.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     _, result = index_ram.query(
-#         queries,
-#         k=k,
-#         nprobe=nprobe,
-#         use_nuv_implementation=True,
-#     )
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     _, result = index_ram.query(
-#         queries,
-#         k=k,
-#         nprobe=nprobe,
-#         mode=Mode.LOCAL,
-#     )
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-# def test_ivf_flat_ingestion_f32(tmp_path):
-#     dataset_dir = os.path.join(tmp_path, "dataset")
-#     index_uri = os.path.join(tmp_path, "array")
-#     k = 10
-#     size = 100000
-#     dimensions = 128
-#     partitions = 100
-#     nqueries = 100
-#     nprobe = 20
-
-#     create_random_dataset_f32(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
-#     dtype = np.float32
-
-#     queries = get_queries(dataset_dir, dtype=dtype)
-#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
-
-#     index = ingest(
-#         index_type="IVF_FLAT",
-#         index_uri=index_uri,
-#         source_uri=os.path.join(dataset_dir, "data.f32bin"),
-#         partitions=partitions,
-#         input_vectors_per_work_item=int(size / 10),
-#     )
-
-#     _, result = index.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     index_ram = IVFFlatIndex(uri=index_uri)
-#     _, result = index_ram.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     index_ram = IVFFlatIndex(uri=index_uri, memory_budget=int(size / 10))
-#     _, result = index_ram.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     _, result = index_ram.query(
-#         queries,
-#         k=k,
-#         nprobe=nprobe,
-#         use_nuv_implementation=True,
-#     )
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-# def test_ivf_flat_ingestion_fvec(tmp_path):
-#     source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
-#     queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
-#     gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
-#     index_uri = os.path.join(tmp_path, "array")
-#     k = 100
-#     partitions = 100
-#     nqueries = 100
-#     nprobe = 20
-
-#     queries = load_fvecs(queries_uri)
-#     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
-
-#     index = ingest(
-#         index_type="IVF_FLAT",
-#         index_uri=index_uri,
-#         source_uri=source_uri,
-#         partitions=partitions,
-#     )
-#     _, result = index.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     index_ram = IVFFlatIndex(uri=index_uri)
-#     _, result = index_ram.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     _, result = index_ram.query(
-#         queries,
-#         k=k,
-#         nprobe=nprobe,
-#         use_nuv_implementation=True,
-#     )
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     # NB: local mode currently does not return distances
-#     _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-# def test_ivf_flat_ingestion_numpy(tmp_path):
-#     source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
-#     queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
-#     gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
-#     index_uri = os.path.join(tmp_path, "array")
-#     k = 100
-#     partitions = 100
-#     nqueries = 100
-#     nprobe = 20
-
-#     input_vectors = load_fvecs(source_uri)
-
-#     queries = load_fvecs(queries_uri)
-#     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
-
-#     index = ingest(
-#         index_type="IVF_FLAT",
-#         index_uri=index_uri,
-#         input_vectors=input_vectors,
-#         partitions=partitions,
-#     )
-#     _, result = index.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     index_ram = IVFFlatIndex(uri=index_uri)
-#     _, result = index_ram.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     _, result = index_ram.query(
-#         queries,
-#         k=k,
-#         nprobe=nprobe,
-#         use_nuv_implementation=True,
-#     )
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-# def test_ivf_flat_ingestion_multiple_workers(tmp_path):
-#     source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
-#     queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
-#     gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
-#     index_uri = os.path.join(tmp_path, "array")
-#     k = 100
-#     partitions = 100
-#     nqueries = 100
-#     nprobe = 20
-
-#     queries = load_fvecs(queries_uri)
-#     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
-
-#     index = ingest(
-#         index_type="IVF_FLAT",
-#         index_uri=index_uri,
-#         source_uri=source_uri,
-#         partitions=partitions,
-#         input_vectors_per_work_item=421,
-#         max_tasks_per_stage=4,
-#     )
-#     _, result = index.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     index_ram = IVFFlatIndex(uri=index_uri)
-#     _, result = index_ram.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     _, result = index_ram.query(
-#         queries,
-#         k=k,
-#         nprobe=nprobe,
-#         use_nuv_implementation=True,
-#     )
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-#     # NB: local mode currently does not return distances
-#     _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
-#     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-
-# def test_ivf_flat_ingestion_external_ids_numpy(tmp_path):
-#     source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
-#     queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
-#     gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
-#     index_uri = os.path.join(tmp_path, "array")
-#     k = 100
-#     partitions = 100
-#     nqueries = 100
-#     nprobe = 20
-#     size = 10000
-#     external_ids_offset = 100
-
-#     input_vectors = load_fvecs(source_uri)
-
-#     queries = load_fvecs(queries_uri)
-#     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
-#     external_ids = np.array(
-#         [range(external_ids_offset, size + external_ids_offset)], np.uint64
-#     )
-#     index = ingest(
-#         index_type="IVF_FLAT",
-#         index_uri=index_uri,
-#         input_vectors=input_vectors,
-#         partitions=partitions,
-#         external_ids=external_ids,
-#     )
-#     _, result = index.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i, external_ids_offset) > MINIMUM_ACCURACY
-
-
-# def test_ivf_flat_ingestion_with_updates(tmp_path):
-#     dataset_dir = os.path.join(tmp_path, "dataset")
-#     index_uri = os.path.join(tmp_path, "array")
-#     k = 10
-#     size = 1000
-#     partitions = 10
-#     dimensions = 128
-#     nqueries = 100
-#     nprobe = 10
-#     data = create_random_dataset_u8(
-#         nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
-#     )
-#     dtype = np.uint8
-
-#     queries = get_queries(dataset_dir, dtype=dtype)
-#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
-#     index = ingest(
-#         index_type="IVF_FLAT",
-#         index_uri=index_uri,
-#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
-#         partitions=partitions,
-#     )
-#     _, result = index.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i) == 1.0
-
-#     update_ids_offset = MAX_UINT64 - size
-#     updated_ids = {}
-#     for i in range(100):
-#         index.delete(external_id=i)
-#         index.update(vector=data[i].astype(dtype), external_id=i + update_ids_offset)
-#         updated_ids[i] = i + update_ids_offset
-
-#     _, result = index.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-
-#     index = index.consolidate_updates(retrain_index=True, partitions=20)
-#     _, result = index.query(queries, k=k, nprobe=20)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-
-
-# def test_ivf_flat_ingestion_with_batch_updates(tmp_path):
-#     dataset_dir = os.path.join(tmp_path, "dataset")
-#     index_uri = os.path.join(tmp_path, "array")
-#     k = 10
-#     size = 100000
-#     partitions = 100
-#     dimensions = 128
-#     nqueries = 100
-#     nprobe = 100
-#     data = create_random_dataset_u8(
-#         nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
-#     )
-#     dtype = np.uint8
-
-#     queries = get_queries(dataset_dir, dtype=dtype)
-#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
-#     index = ingest(
-#         index_type="IVF_FLAT",
-#         index_uri=index_uri,
-#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
-#         partitions=partitions,
-#         input_vectors_per_work_item=int(size / 10),
-#     )
-#     _, result = index.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i) > 0.99
-
-#     update_ids = {}
-#     updated_ids = {}
-#     update_ids_offset = MAX_UINT64 - size
-#     for i in range(0, 100000, 2):
-#         updated_ids[i] = i + update_ids_offset
-#         update_ids[i + update_ids_offset] = i
-#     external_ids = np.zeros((len(updated_ids) * 2), dtype=np.uint64)
-#     updates = np.empty((len(updated_ids) * 2), dtype="O")
-#     id = 0
-#     for prev_id, new_id in updated_ids.items():
-#         external_ids[id] = prev_id
-#         updates[id] = np.array([], dtype=dtype)
-#         id += 1
-#         external_ids[id] = new_id
-#         updates[id] = data[prev_id].astype(dtype)
-#         id += 1
-
-#     index.update_batch(vectors=updates, external_ids=external_ids)
-#     _, result = index.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) > 0.99
-
-#     index = index.consolidate_updates()
-#     _, result = index.query(queries, k=k, nprobe=nprobe)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) > 0.99
-
-
-# def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
-#     dataset_dir = os.path.join(tmp_path, "dataset")
-#     index_uri = os.path.join(tmp_path, "array")
-#     k = 10
-#     size = 1000
-#     partitions = 10
-#     dimensions = 128
-#     nqueries = 100
-#     nprobe = 10
-#     data = create_random_dataset_u8(
-#         nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
-#     )
-#     dtype = np.uint8
-
-#     queries = get_queries(dataset_dir, dtype=dtype)
-#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
-#     index = ingest(
-#         index_type="IVF_FLAT",
-#         index_uri=index_uri,
-#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
-#         partitions=partitions,
-#         index_timestamp=1,
-#     )
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i) == 1.0
-
-#     update_ids_offset = MAX_UINT64 - size
-#     updated_ids = {}
-#     for i in range(2, 102):
-#         index.delete(external_id=i, timestamp=i)
-#         index.update(
-#             vector=data[i].astype(dtype), external_id=i + update_ids_offset, timestamp=i
-#         )
-#         updated_ids[i] = i + update_ids_offset
-
-#     index = IVFFlatIndex(uri=index_uri)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert (
-#         0.05
-#         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
-#         <= 0.15
-#     )
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert (
-#         0.05
-#         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
-#         <= 0.15
-#     )
-
-#     # Timetravel with partial read from updates table
-#     updated_ids_part = {}
-#     for i in range(2, 52):
-#         updated_ids_part[i] = i + update_ids_offset
-#     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert (
-#         0.02
-#         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
-#         <= 0.07
-#     )
-
-#     # Timetravel at previous ingestion timestamp
-#     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i) == 1.0
-
-#     # Consolidate updates
-#     index = index.consolidate_updates()
-#     index = IVFFlatIndex(uri=index_uri)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert (
-#         0.05
-#         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
-#         <= 0.15
-#     )
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert (
-#         0.05
-#         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
-#         <= 0.15
-#     )
-
-#     # Timetravel with partial read from updates table
-#     updated_ids_part = {}
-#     for i in range(2, 52):
-#         updated_ids_part[i] = i + update_ids_offset
-#     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert (
-#         0.02
-#         <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
-#         <= 0.07
-#     )
-
-#     # Timetravel at previous ingestion timestamp
-#     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 1))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i) == 1.0
-
-#     # Clear history before the latest ingestion
-#     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
-#     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-
-#     # Clear all history
-#     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp)
-#     index = IVFFlatIndex(uri=index_uri, timestamp=1)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=51)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=101)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-#     index = IVFFlatIndex(uri=index_uri)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-#     index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
-
-
-# def test_ivf_flat_ingestion_with_additions_and_timetravel(tmp_path):
-#     dataset_dir = os.path.join(tmp_path, "dataset")
-#     index_uri = os.path.join(tmp_path, "array")
-#     k = 100
-#     size = 100
-#     partitions = 10
-#     dimensions = 128
-#     nqueries = 1
-#     data = create_random_dataset_u8(
-#         nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
-#     )
-#     dtype = np.uint8
-
-#     queries = get_queries(dataset_dir, dtype=dtype)
-#     gt_i, gt_d = get_groundtruth(dataset_dir, k)
-#     index = ingest(
-#         index_type="IVF_FLAT",
-#         index_uri=index_uri,
-#         source_uri=os.path.join(dataset_dir, "data.u8bin"),
-#         partitions=partitions,
-#         index_timestamp=1,
-#     )
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert accuracy(result, gt_i) == 1.0
-
-#     update_ids_offset = MAX_UINT64 - size
-#     updated_ids = {}
-#     for i in range(100):
-#         index.update(
-#             vector=data[i].astype(dtype),
-#             external_id=i + update_ids_offset,
-#             timestamp=i + 2,
-#         )
-#         updated_ids[i] = i + update_ids_offset
-
-#     index = IVFFlatIndex(uri=index_uri)
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert 0.45 < accuracy(result, gt_i) < 0.55
-
-#     index = index.consolidate_updates()
-#     _, result = index.query(queries, k=k, nprobe=index.partitions)
-#     assert 0.45 < accuracy(result, gt_i) < 0.55
-
-
-# def test_storage_versions(tmp_path):
-#     dataset_dir = os.path.join(tmp_path, "dataset")
-#     k = 10
-#     size = 1000
-#     partitions = 10
-#     dimensions = 128
-#     nqueries = 100
-#     data = create_random_dataset_u8(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
-#     source_uri = os.path.join(dataset_dir, "data.u8bin")
-
-#     dtype = np.uint8
-#     queries = get_queries(dataset_dir, dtype=dtype)
-#     gt_i, _ = get_groundtruth(dataset_dir, k)
-    
-#     indexes = ["FLAT", "IVF_FLAT"]
-#     index_classes = [FlatIndex, IVFFlatIndex]
-#     index_files = [tiledb.vector_search.flat_index, tiledb.vector_search.ivf_flat_index]
-#     for index_type, index_class, index_file in zip(indexes, index_classes, index_files):
-#         # First we test with an invalid storage version.
-#         with pytest.raises(ValueError) as error:
-#             index_uri = os.path.join(tmp_path, f"array_{index_type}_invalid")
-#             ingest(
-#                 index_type=index_type,
-#                 index_uri=index_uri,
-#                 source_uri=source_uri,
-#                 partitions=partitions,
-#                 storage_version="Foo"
-#             )
-#         assert "Invalid storage version" in str(error.value)
-
-#         with pytest.raises(ValueError) as error:
-#             index_file.create(uri=index_uri, dimensions=3, vector_type=np.dtype(dtype), storage_version="Foo")
-#         assert "Invalid storage version" in str(error.value)
-
-#         # Then we test with valid storage versions.
-#         for storage_version, _ in tiledb.vector_search.storage_formats.items():
-#             index_uri = os.path.join(tmp_path, f"array_{index_type}_{storage_version}")
-#             index = ingest(
-#                 index_type=index_type,
-#                 index_uri=index_uri,
-#                 source_uri=source_uri,
-#                 partitions=partitions,
-#                 storage_version=storage_version
-#             )
-#             _, result = index.query(queries, k=k)
-#             assert accuracy(result, gt_i) >= MINIMUM_ACCURACY
-
-#             update_ids_offset = MAX_UINT64 - size
-#             updated_ids = {}
-#             for i in range(10):
-#                 index.delete(external_id=i)
-#                 index.update(vector=data[i].astype(dtype), external_id=i + update_ids_offset)
-#                 updated_ids[i] = i + update_ids_offset
-
-#             _, result = index.query(queries, k=k)
-#             assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
-
-#             index = index.consolidate_updates(retrain_index=True, partitions=20)
-#             _, result = index.query(queries, k=k)
-#             assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
-
-#             index_ram = index_class(uri=index_uri)
-#             _, result = index_ram.query(queries, k=k)
-#             assert accuracy(result, gt_i) > MINIMUM_ACCURACY
-
-# def test_copy_centroids_uri(tmp_path):
-#     dataset_dir = os.path.join(tmp_path, "dataset")
-#     os.mkdir(dataset_dir)
-
-#     # Create the index data.
-#     data = np.array([[1, 1, 1, 1], [1, 1, 1, 1], [2, 2, 2, 2], [2, 2, 2, 2], [3, 3, 3, 3]], dtype=np.float32)
-
-#     # Create the centroids - this is based on ivf_flat_index.py.
-#     centroids = np.array([[1, 1, 1, 1], [2, 2, 2, 2]], dtype=np.float32)
-#     centroids_in_size = centroids.shape[0]
-#     dimensions = centroids.shape[1]
-#     schema = tiledb.ArraySchema(
-#         domain=tiledb.Domain(
-#             *[
-#                 tiledb.Dim(name="rows", domain=(0, dimensions - 1), tile=dimensions, dtype=np.dtype(np.int32)),
-#                 tiledb.Dim(name="cols", domain=(0, np.iinfo(np.dtype("int32")).max), tile=100000, dtype=np.dtype(np.int32)),
-#             ]
-#         ),
-#         sparse=False,
-#         attrs=[tiledb.Attr(name="centroids", dtype="float32", filters=tiledb.FilterList([tiledb.ZstdFilter()]))],
-#         cell_order="col-major",
-#         tile_order="col-major",
-#     )
-#     centroids_uri = os.path.join(dataset_dir, "centroids.tdb")
-#     tiledb.Array.create(centroids_uri, schema)
-#     index_timestamp = int(time.time() * 1000)
-#     with tiledb.open(centroids_uri, mode="w", timestamp=index_timestamp) as A:
-#         A[0:dimensions, 0:centroids_in_size] = centroids.transpose()
-
-#     # Create the index.
-#     index_uri = os.path.join(tmp_path, "array")
-#     index = ingest(
-#         index_type="IVF_FLAT", 
-#         index_uri=index_uri, 
-#         input_vectors=data,
-#         copy_centroids_uri=centroids_uri,
-#         partitions=centroids_in_size
-#     )
-
-#     # Query the index.
-#     queries = np.array([data[4]], dtype=np.float32)
-#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[4]])
-
-
-# def test_kmeans():
-#     k = 128
-#     d = 16
-#     n = k * k
-#     max_iter = 16
-#     n_init = 10
-#     verbose = False
-
-#     import sklearn.model_selection
-#     from sklearn.datasets import make_blobs
-#     from sklearn.cluster import KMeans
-
-#     X, _, centers = make_blobs(n_samples=n, n_features=d, centers=k, return_centers=True, random_state=1)
-#     X = X.astype("float32")
-
-#     data, queries = sklearn.model_selection.train_test_split(
-#         X, test_size=0.1, random_state=1
-#     )
-
-#     data_x = np.array([[1.0573647,   5.082087],
-#                       [-6.229642,   -1.3590931],
-#                       [0.7446737,    6.3828287],
-#                       [-7.698864,   -3.0493321],
-#                       [2.1362762,   -4.4448104],
-#                       [1.04019,     -4.0389647],
-#                       [0.38996044,   5.7235265],
-#     [1.7470839,  -4.717076]]).astype("float32")
-#     queries_x = np.array([[-7.3712273, -1.1178735]]).astype("float32")
-
-#     km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="random", random_state=1)
-#     km.fit(data)
-#     centroids_sk = km.cluster_centers_
-#     results_sk = km.predict(queries)
-
-#     centroids_tdb = kmeans_fit(
-#         k, "random", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
-#     )
-#     centroids_tdb_np = np.transpose(np.array(centroids_tdb))
-#     results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
-#     results_tdb_np = np.transpose(np.array(results_tdb))
-
-#     def get_score(centroids, results):
-#         x = []
-#         for i in range(len(queries)):
-#             x.append(np.linalg.norm(queries[i] - centroids[results[i]]))
-#         return np.mean(np.array(x))
-
-#     sklearn_score = get_score(centroids_sk, results_sk)
-#     tdb_score = get_score(centroids_tdb_np, results_tdb_np)
-
-#     km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="k-means++", random_state=1)
-#     km.fit(data)
-#     centroids_sk = km.cluster_centers_
-#     results_sk = km.predict(queries)
-
-#     assert tdb_score < 1.5 * sklearn_score
-
-#     centroids_tdb = kmeans_fit(
-#         k, "k-means++", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
-#     )
-#     centroids_tdb_np = np.transpose(np.array(centroids_tdb))
-#     results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
-#     results_tdb_np = np.transpose(np.array(results_tdb))
-
-#     sklearn_score = get_score(centroids_sk, results_sk)
-#     tdb_score = get_score(centroids_tdb_np, results_tdb_np)
-
-#     assert tdb_score < 1.5 * sklearn_score
-
-# def test_ingest_with_training_source_uri_f32(tmp_path):
-#     dataset_dir = os.path.join(tmp_path, "dataset")
-#     data = np.array([[1.0, 1.1, 1.2, 1.3], [2.0, 2.1, 2.2, 2.3], [3.0, 3.1, 3.2, 3.3], [4.0, 4.1, 4.2, 4.3], [5.0, 5.1, 5.2, 5.3]], dtype=np.float32)
-#     create_manual_dataset_f32_only_data(data=data, path=dataset_dir)
-
-#     training_data = np.array([data[0], data[1], data[2]], dtype=np.float32)
-#     create_manual_dataset_f32_only_data(data=training_data, path=dataset_dir, dataset_name="training_data.f32bin")
-#     index_uri = os.path.join(tmp_path, "array")
-#     index = ingest(
-#         index_type="IVF_FLAT", 
-#         index_uri=index_uri, 
-#         source_uri=os.path.join(dataset_dir, "data.f32bin"),
-#         training_source_uri=os.path.join(dataset_dir, "training_data.f32bin")
-#     )
-
-#     queries = np.array([data[1]], dtype=np.float32)
-#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
-
-#     index = IVFFlatIndex(uri=index_uri)
-#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
-
-#     # Also test that we can ingest with training_source_type.
-#     ingest(
-#         index_type="IVF_FLAT",
-#         index_uri=os.path.join(tmp_path, "array_2"), 
-#         source_uri=os.path.join(dataset_dir, "data.f32bin"),
-#         training_source_uri=os.path.join(dataset_dir, "training_data.f32bin"),
-#         training_source_type="F32BIN"
-#     )
-
-# def test_ingest_with_training_source_uri_tdb(tmp_path):
-#     ################################################################################################
-#     # First set up the data.
-#     ################################################################################################
-#     dataset_dir = os.path.join(tmp_path, "dataset")
-#     os.mkdir(dataset_dir)
-#     # data.shape should give you (cols, rows). So we transpose this before using it.
-#     data = np.array([
-#         [1.0, 1.1, 1.2, 1.3], 
-#         [2.0, 2.1, 2.2, 2.3], 
-#         [3.0, 3.1, 3.2, 3.3], 
-#         [4.0, 4.1, 4.2, 4.3], 
-#         [5.0, 5.1, 5.2, 5.3]], dtype=np.float32).transpose()
-#     create_array(path=os.path.join(dataset_dir, "data.tdb"), data=data)
-
-#     training_data = np.array([
-#         [1.0, 1.1, 1.2, 1.3], 
-#         [5.0, 5.1, 5.2, 5.3]], dtype=np.float32).transpose()
-#     create_array(path=os.path.join(dataset_dir, "training_data.tdb"), data=training_data)
-
-#     # Run a quick test that if we set up training_data incorrectly, we will raise an exception.
-#     with pytest.raises(ValueError) as error:
-#         training_data_invalid = np.array([
-#             [1.0, 1.1, 1.2], 
-#             [5.0, 5.1, 5.2]], dtype=np.float32).transpose()
-#         create_array(path=os.path.join(dataset_dir, "training_data_invalid.tdb"), data=training_data_invalid)
-#         index = ingest(
-#             index_type="IVF_FLAT", 
-#             index_uri=os.path.join(tmp_path, f"array_invalid"), 
-#             source_uri=os.path.join(dataset_dir, "data.tdb"),
-#             training_source_uri=os.path.join(dataset_dir, "training_data_invalid.tdb")
-#         )
-#     assert "training data dimensions" in str(error.value)
-
-#     ################################################################################################
-#     # Test we can ingest, query, update, and consolidate.
-#     ################################################################################################
-#     index_uri = os.path.join(tmp_path, "array")
-#     index = ingest(
-#         index_type="IVF_FLAT", 
-#         index_uri=index_uri, 
-#         source_uri=os.path.join(dataset_dir, "data.tdb"),
-#         training_source_uri=os.path.join(dataset_dir, "training_data.tdb")
-#     )
-
-#     queries = np.array([data.transpose()[1]], dtype=np.float32)
-#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
-
-#     update_vectors = np.empty([3], dtype=object)
-#     update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
-#     update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
-#     update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
-#     index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
-    
-#     index = index.consolidate_updates()
-
-#     queries = np.array([update_vectors[2]], dtype=np.float32)
-#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
-
-#     ################################################################################################
-#     # Test we can load the index again and query, update, and consolidate.
-#     ################################################################################################
-#     # Load the index again and query.
-#     index = IVFFlatIndex(uri=index_uri)
-
-#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
-    
-#     # Update the index and query.
-#     update_vectors = np.empty([2], dtype=object)
-#     update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
-#     update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
-#     index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
-#     index = index.consolidate_updates()
-    
-#     queries = np.array([update_vectors[0]], dtype=np.float32)
-#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
-
-#     # Clear the index history, load, update, and query.
-#     Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
-
-#     index = IVFFlatIndex(uri=index_uri)
-
-#     update_vectors = np.empty([2], dtype=object)
-#     update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
-#     update_vectors[1] = np.array([12.0, 12.1, 12.2, 12.3], dtype=np.dtype(np.float32))
-#     index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
-#     index = index.consolidate_updates()
-
-#     queries = np.array([update_vectors[0]], dtype=np.float32)
-#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
-
-#     ###############################################################################################
-#     # Also test that we can ingest with training_source_type.
-#     ###############################################################################################
-#     ingest(
-#         index_type="IVF_FLAT",
-#         index_uri=os.path.join(tmp_path, "array_2"), 
-#         source_uri=os.path.join(dataset_dir, "data.tdb"),
-#         training_source_uri=os.path.join(dataset_dir, "training_data.tdb"),
-#         training_source_type="TILEDB_ARRAY"
-#     )
-
-# def test_ingest_with_training_source_uri_numpy(tmp_path):
-#     ################################################################################################
-#     # First set up the data.
-#     ################################################################################################
-#     data = np.array([
-#         [1.0, 1.1, 1.2, 1.3], 
-#         [2.0, 2.1, 2.2, 2.3], 
-#         [3.0, 3.1, 3.2, 3.3], 
-#         [4.0, 4.1, 4.2, 4.3], 
-#         [5.0, 5.1, 5.2, 5.3]], dtype=np.float32)
-#     training_data = data[1:3]
-
-#     # Run a quick test that if we set up training_data incorrectly, we will raise an exception.
-#     with pytest.raises(ValueError) as error:
-#         training_data_invalid = np.array([
-#             [4.0, 4.1, 4.2], 
-#             [5.0, 5.1, 5.2]], dtype=np.float32)
-#         index = ingest(
-#             index_type="IVF_FLAT", 
-#             index_uri=os.path.join(tmp_path, "array_invalid"), 
-#             input_vectors=data,
-#             training_input_vectors=training_data_invalid,
-#         )
-#     assert "training data dimensions" in str(error.value)
-
-#     ################################################################################################
-#     # Test we can ingest, query, update, and consolidate.
-#     ################################################################################################
-#     index_uri = os.path.join(tmp_path, "array")
-#     index = ingest(
-#         index_type="IVF_FLAT", 
-#         index_uri=index_uri, 
-#         input_vectors=data,
-#         training_input_vectors=training_data,
-#     )
-
-#     queries = np.array([data[1]], dtype=np.float32)
-#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
-
-#     update_vectors = np.empty([3], dtype=object)
-#     update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
-#     update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
-#     update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
-#     index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
-    
-#     index = index.consolidate_updates()
-
-#     queries = np.array([update_vectors[2]], dtype=np.float32)
-#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
-
-#     ################################################################################################
-#     # Test we can load the index again and query, update, and consolidate.
-#     ################################################################################################
-#     index_ram = IVFFlatIndex(uri=index_uri)
-
-#     queries = np.array([data[1]], dtype=np.float32)
-#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
-
-#     update_vectors = np.empty([2], dtype=object)
-#     update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
-#     update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
-#     index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
-#     index_ram = index_ram.consolidate_updates()
-
-#     queries = np.array([update_vectors[0]], dtype=np.float32)
-#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
-
-#     update_vectors = np.empty([2], dtype=object)
-#     update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
-#     update_vectors[1] = np.array([12.0, 12.1, 12.2, 12.3], dtype=np.dtype(np.float32))
-#     index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
-#     index_ram = index_ram.consolidate_updates(retrain_index=True, training_sample_size=3)
-
-#     queries = np.array([update_vectors[0]], dtype=np.float32)
-#     query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
-    
+def test_flat_ingestion_u8(tmp_path):
+    dataset_dir = os.path.join(tmp_path, "dataset")
+    index_uri = os.path.join(tmp_path, "array")
+    create_random_dataset_u8(nb=10000, d=100, nq=100, k=10, path=dataset_dir)
+    dtype = np.uint8
+    k = 10
+
+    queries = get_queries(dataset_dir, dtype=dtype)
+    gt_i, gt_d = get_groundtruth(dataset_dir, k)
+
+    index = ingest(
+        index_type="FLAT",
+        index_uri=index_uri,
+        source_uri=os.path.join(dataset_dir, "data.u8bin"),
+    )
+    _, result = index.query(queries, k=k)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+def test_flat_ingestion_f32(tmp_path):
+    dataset_dir = os.path.join(tmp_path, "dataset")
+    index_uri = os.path.join(tmp_path, "array")
+    create_random_dataset_f32(nb=10000, d=100, nq=100, k=10, path=dataset_dir)
+    dtype = np.float32
+    k = 10
+
+    queries = get_queries(dataset_dir, dtype=dtype)
+    gt_i, gt_d = get_groundtruth(dataset_dir, k)
+
+    index = ingest(
+        index_type="FLAT",
+        index_uri=index_uri,
+        source_uri=os.path.join(dataset_dir, "data.f32bin"),
+    )
+    _, result = index.query(queries, k=k)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    index_ram = FlatIndex(uri=index_uri)
+    _, result = index_ram.query(queries, k=k)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+def test_flat_ingestion_external_id_u8(tmp_path):
+    dataset_dir = os.path.join(tmp_path, "dataset")
+    index_uri = os.path.join(tmp_path, "array")
+    size = 10000
+    dtype = np.uint8
+    create_random_dataset_u8(nb=size, d=100, nq=100, k=10, path=dataset_dir)
+    k = 10
+    external_ids_offset = 100
+
+    queries = get_queries(dataset_dir, dtype=dtype)
+    gt_i, gt_d = get_groundtruth(dataset_dir, k)
+    external_ids = np.array(
+        [range(external_ids_offset, size + external_ids_offset)], np.uint64
+    )
+
+    index = ingest(
+        index_type="FLAT",
+        index_uri=index_uri,
+        source_uri=os.path.join(dataset_dir, "data.u8bin"),
+        external_ids=external_ids,
+    )
+    _, result = index.query(queries, k=k)
+    assert (
+        accuracy(result, gt_i, external_ids_offset=external_ids_offset)
+        > MINIMUM_ACCURACY
+    )
+
+
+def test_ivf_flat_ingestion_u8(tmp_path):
+    dataset_dir = os.path.join(tmp_path, "dataset")
+    index_uri = os.path.join(tmp_path, "array")
+    k = 10
+    size = 100000
+    partitions = 100
+    dimensions = 128
+    nqueries = 100
+    nprobe = 20
+    create_random_dataset_u8(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
+    dtype = np.uint8
+
+    queries = get_queries(dataset_dir, dtype=dtype)
+    gt_i, gt_d = get_groundtruth(dataset_dir, k)
+    index = ingest(
+        index_type="IVF_FLAT",
+        index_uri=index_uri,
+        source_uri=os.path.join(dataset_dir, "data.u8bin"),
+        partitions=partitions,
+        input_vectors_per_work_item=int(size / 10),
+    )
+    _, result = index.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    index_ram = IVFFlatIndex(uri=index_uri, memory_budget=int(size / 10))
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    _, result = index_ram.query(
+        queries,
+        k=k,
+        nprobe=nprobe,
+        use_nuv_implementation=True,
+    )
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    _, result = index_ram.query(
+        queries,
+        k=k,
+        nprobe=nprobe,
+        mode=Mode.LOCAL,
+    )
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+def test_ivf_flat_ingestion_f32(tmp_path):
+    dataset_dir = os.path.join(tmp_path, "dataset")
+    index_uri = os.path.join(tmp_path, "array")
+    k = 10
+    size = 100000
+    dimensions = 128
+    partitions = 100
+    nqueries = 100
+    nprobe = 20
+
+    create_random_dataset_f32(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
+    dtype = np.float32
+
+    queries = get_queries(dataset_dir, dtype=dtype)
+    gt_i, gt_d = get_groundtruth(dataset_dir, k)
+
+    index = ingest(
+        index_type="IVF_FLAT",
+        index_uri=index_uri,
+        source_uri=os.path.join(dataset_dir, "data.f32bin"),
+        partitions=partitions,
+        input_vectors_per_work_item=int(size / 10),
+    )
+
+    _, result = index.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    index_ram = IVFFlatIndex(uri=index_uri)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    index_ram = IVFFlatIndex(uri=index_uri, memory_budget=int(size / 10))
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    _, result = index_ram.query(
+        queries,
+        k=k,
+        nprobe=nprobe,
+        use_nuv_implementation=True,
+    )
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+def test_ivf_flat_ingestion_fvec(tmp_path):
+    source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
+    queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
+    gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
+    index_uri = os.path.join(tmp_path, "array")
+    k = 100
+    partitions = 100
+    nqueries = 100
+    nprobe = 20
+
+    queries = load_fvecs(queries_uri)
+    gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
+
+    index = ingest(
+        index_type="IVF_FLAT",
+        index_uri=index_uri,
+        source_uri=source_uri,
+        partitions=partitions,
+    )
+    _, result = index.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    index_ram = IVFFlatIndex(uri=index_uri)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    _, result = index_ram.query(
+        queries,
+        k=k,
+        nprobe=nprobe,
+        use_nuv_implementation=True,
+    )
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    # NB: local mode currently does not return distances
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+def test_ivf_flat_ingestion_numpy(tmp_path):
+    source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
+    queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
+    gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
+    index_uri = os.path.join(tmp_path, "array")
+    k = 100
+    partitions = 100
+    nqueries = 100
+    nprobe = 20
+
+    input_vectors = load_fvecs(source_uri)
+
+    queries = load_fvecs(queries_uri)
+    gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
+
+    index = ingest(
+        index_type="IVF_FLAT",
+        index_uri=index_uri,
+        input_vectors=input_vectors,
+        partitions=partitions,
+    )
+    _, result = index.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    index_ram = IVFFlatIndex(uri=index_uri)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    _, result = index_ram.query(
+        queries,
+        k=k,
+        nprobe=nprobe,
+        use_nuv_implementation=True,
+    )
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+def test_ivf_flat_ingestion_multiple_workers(tmp_path):
+    source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
+    queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
+    gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
+    index_uri = os.path.join(tmp_path, "array")
+    k = 100
+    partitions = 100
+    nqueries = 100
+    nprobe = 20
+
+    queries = load_fvecs(queries_uri)
+    gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
+
+    index = ingest(
+        index_type="IVF_FLAT",
+        index_uri=index_uri,
+        source_uri=source_uri,
+        partitions=partitions,
+        input_vectors_per_work_item=421,
+        max_tasks_per_stage=4,
+    )
+    _, result = index.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    index_ram = IVFFlatIndex(uri=index_uri)
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    _, result = index_ram.query(
+        queries,
+        k=k,
+        nprobe=nprobe,
+        use_nuv_implementation=True,
+    )
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    # NB: local mode currently does not return distances
+    _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+
+def test_ivf_flat_ingestion_external_ids_numpy(tmp_path):
+    source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
+    queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
+    gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
+    index_uri = os.path.join(tmp_path, "array")
+    k = 100
+    partitions = 100
+    nqueries = 100
+    nprobe = 20
+    size = 10000
+    external_ids_offset = 100
+
+    input_vectors = load_fvecs(source_uri)
+
+    queries = load_fvecs(queries_uri)
+    gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
+    external_ids = np.array(
+        [range(external_ids_offset, size + external_ids_offset)], np.uint64
+    )
+    index = ingest(
+        index_type="IVF_FLAT",
+        index_uri=index_uri,
+        input_vectors=input_vectors,
+        partitions=partitions,
+        external_ids=external_ids,
+    )
+    _, result = index.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i, external_ids_offset) > MINIMUM_ACCURACY
+
+
+def test_ivf_flat_ingestion_with_updates(tmp_path):
+    dataset_dir = os.path.join(tmp_path, "dataset")
+    index_uri = os.path.join(tmp_path, "array")
+    k = 10
+    size = 1000
+    partitions = 10
+    dimensions = 128
+    nqueries = 100
+    nprobe = 10
+    data = create_random_dataset_u8(
+        nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
+    )
+    dtype = np.uint8
+
+    queries = get_queries(dataset_dir, dtype=dtype)
+    gt_i, gt_d = get_groundtruth(dataset_dir, k)
+    index = ingest(
+        index_type="IVF_FLAT",
+        index_uri=index_uri,
+        source_uri=os.path.join(dataset_dir, "data.u8bin"),
+        partitions=partitions,
+    )
+    _, result = index.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) == 1.0
+
+    update_ids_offset = MAX_UINT64 - size
+    updated_ids = {}
+    for i in range(100):
+        index.delete(external_id=i)
+        index.update(vector=data[i].astype(dtype), external_id=i + update_ids_offset)
+        updated_ids[i] = i + update_ids_offset
+
+    _, result = index.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+
+    index = index.consolidate_updates(retrain_index=True, partitions=20)
+    _, result = index.query(queries, k=k, nprobe=20)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+
+
+def test_ivf_flat_ingestion_with_batch_updates(tmp_path):
+    dataset_dir = os.path.join(tmp_path, "dataset")
+    index_uri = os.path.join(tmp_path, "array")
+    k = 10
+    size = 100000
+    partitions = 100
+    dimensions = 128
+    nqueries = 100
+    nprobe = 100
+    data = create_random_dataset_u8(
+        nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
+    )
+    dtype = np.uint8
+
+    queries = get_queries(dataset_dir, dtype=dtype)
+    gt_i, gt_d = get_groundtruth(dataset_dir, k)
+    index = ingest(
+        index_type="IVF_FLAT",
+        index_uri=index_uri,
+        source_uri=os.path.join(dataset_dir, "data.u8bin"),
+        partitions=partitions,
+        input_vectors_per_work_item=int(size / 10),
+    )
+    _, result = index.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) > 0.99
+
+    update_ids = {}
+    updated_ids = {}
+    update_ids_offset = MAX_UINT64 - size
+    for i in range(0, 100000, 2):
+        updated_ids[i] = i + update_ids_offset
+        update_ids[i + update_ids_offset] = i
+    external_ids = np.zeros((len(updated_ids) * 2), dtype=np.uint64)
+    updates = np.empty((len(updated_ids) * 2), dtype="O")
+    id = 0
+    for prev_id, new_id in updated_ids.items():
+        external_ids[id] = prev_id
+        updates[id] = np.array([], dtype=dtype)
+        id += 1
+        external_ids[id] = new_id
+        updates[id] = data[prev_id].astype(dtype)
+        id += 1
+
+    index.update_batch(vectors=updates, external_ids=external_ids)
+    _, result = index.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) > 0.99
+
+    index = index.consolidate_updates()
+    _, result = index.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) > 0.99
+
+
+def test_ivf_flat_ingestion_with_updates_and_timetravel(tmp_path):
+    dataset_dir = os.path.join(tmp_path, "dataset")
+    index_uri = os.path.join(tmp_path, "array")
+    k = 10
+    size = 1000
+    partitions = 10
+    dimensions = 128
+    nqueries = 100
+    nprobe = 10
+    data = create_random_dataset_u8(
+        nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
+    )
+    dtype = np.uint8
+
+    queries = get_queries(dataset_dir, dtype=dtype)
+    gt_i, gt_d = get_groundtruth(dataset_dir, k)
+    index = ingest(
+        index_type="IVF_FLAT",
+        index_uri=index_uri,
+        source_uri=os.path.join(dataset_dir, "data.u8bin"),
+        partitions=partitions,
+        index_timestamp=1,
+    )
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i) == 1.0
+
+    update_ids_offset = MAX_UINT64 - size
+    updated_ids = {}
+    for i in range(2, 102):
+        index.delete(external_id=i, timestamp=i)
+        index.update(
+            vector=data[i].astype(dtype), external_id=i + update_ids_offset, timestamp=i
+        )
+        updated_ids[i] = i + update_ids_offset
+
+    index = IVFFlatIndex(uri=index_uri)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=101)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert (
+        0.05
+        <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
+        <= 0.15
+    )
+    index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert (
+        0.05
+        <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
+        <= 0.15
+    )
+
+    # Timetravel with partial read from updates table
+    updated_ids_part = {}
+    for i in range(2, 52):
+        updated_ids_part[i] = i + update_ids_offset
+    index = IVFFlatIndex(uri=index_uri, timestamp=51)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert (
+        0.02
+        <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
+        <= 0.07
+    )
+
+    # Timetravel at previous ingestion timestamp
+    index = IVFFlatIndex(uri=index_uri, timestamp=1)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i) == 1.0
+
+    # Consolidate updates
+    index = index.consolidate_updates()
+    index = IVFFlatIndex(uri=index_uri)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=101)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert (
+        0.05
+        <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
+        <= 0.15
+    )
+    index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert (
+        0.05
+        <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
+        <= 0.15
+    )
+
+    # Timetravel with partial read from updates table
+    updated_ids_part = {}
+    for i in range(2, 52):
+        updated_ids_part[i] = i + update_ids_offset
+    index = IVFFlatIndex(uri=index_uri, timestamp=51)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids_part) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert (
+        0.02
+        <= accuracy(result, gt_i, updated_ids=updated_ids, only_updated_ids=True)
+        <= 0.07
+    )
+
+    # Timetravel at previous ingestion timestamp
+    index = IVFFlatIndex(uri=index_uri, timestamp=1)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 1))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i) == 1.0
+
+    # Clear history before the latest ingestion
+    Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
+    index = IVFFlatIndex(uri=index_uri, timestamp=1)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=51)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=101)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
+
+    # Clear all history
+    Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp)
+    index = IVFFlatIndex(uri=index_uri, timestamp=1)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=51)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=101)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+    index = IVFFlatIndex(uri=index_uri)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 51))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(0, 101))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(0, None))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 51))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(2, 101))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+    index = IVFFlatIndex(uri=index_uri, timestamp=(2, None))
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
+
+
+def test_ivf_flat_ingestion_with_additions_and_timetravel(tmp_path):
+    dataset_dir = os.path.join(tmp_path, "dataset")
+    index_uri = os.path.join(tmp_path, "array")
+    k = 100
+    size = 100
+    partitions = 10
+    dimensions = 128
+    nqueries = 1
+    data = create_random_dataset_u8(
+        nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
+    )
+    dtype = np.uint8
+
+    queries = get_queries(dataset_dir, dtype=dtype)
+    gt_i, gt_d = get_groundtruth(dataset_dir, k)
+    index = ingest(
+        index_type="IVF_FLAT",
+        index_uri=index_uri,
+        source_uri=os.path.join(dataset_dir, "data.u8bin"),
+        partitions=partitions,
+        index_timestamp=1,
+    )
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert accuracy(result, gt_i) == 1.0
+
+    update_ids_offset = MAX_UINT64 - size
+    updated_ids = {}
+    for i in range(100):
+        index.update(
+            vector=data[i].astype(dtype),
+            external_id=i + update_ids_offset,
+            timestamp=i + 2,
+        )
+        updated_ids[i] = i + update_ids_offset
+
+    index = IVFFlatIndex(uri=index_uri)
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert 0.45 < accuracy(result, gt_i) < 0.55
+
+    index = index.consolidate_updates()
+    _, result = index.query(queries, k=k, nprobe=index.partitions)
+    assert 0.45 < accuracy(result, gt_i) < 0.55
+
+
 def test_ivf_flat_ingestion_tdb_random_sampling_policy(tmp_path):
-    ################################################################################################
-    # First set up the data.
-    ################################################################################################
     dataset_dir = os.path.join(tmp_path, "dataset")
     os.mkdir(dataset_dir)
     # data.shape should give you (cols, rows). So we transpose this before using it.
@@ -1081,10 +692,288 @@ def test_ivf_flat_ingestion_tdb_random_sampling_policy(tmp_path):
         [9.0, 9.1, 9.2, 9.3]], dtype=np.float32).transpose()
     create_array(path=os.path.join(dataset_dir, "data.tdb"), data=data)
 
+    for training_sample_size in [3, 5, 9]:
+        for input_vectors_per_work_item in [1, 50, 20]:
+            index_uri = os.path.join(tmp_path, f"array_{training_sample_size}_{input_vectors_per_work_item}")
+            index = ingest(
+                index_type="IVF_FLAT", 
+                index_uri=index_uri, 
+                source_uri=os.path.join(dataset_dir, "data.tdb"),
+                training_sampling_policy=TrainingSamplingPolicy.RANDOM,
+                training_sample_size=training_sample_size,
+                input_vectors_per_work_item=input_vectors_per_work_item,
+                use_sklearn=True
+            )
+
+            queries = np.array([data.transpose()[3]], dtype=np.float32)
+            query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[3]])
+
+
+def test_ivf_flat_ingestion_fvec_random_sampling_policy(tmp_path):
+    source_uri = "test/data/siftsmall/siftsmall_base.fvecs"
+    queries_uri = "test/data/siftsmall/siftsmall_query.fvecs"
+    gt_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
+    index_uri = os.path.join(tmp_path, "array")
+    k = 100
+    partitions = 100
+    nqueries = 100
+    nprobe = 20
+
+    queries = load_fvecs(queries_uri)
+    gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
+
+    index = ingest(
+        index_type="IVF_FLAT",
+        index_uri=index_uri,
+        source_uri=source_uri,
+        partitions=partitions,
+        training_sampling_policy=TrainingSamplingPolicy.RANDOM,
+        input_vectors_per_work_item=5000,
+    )
+    _, result = index.query(queries, k=k, nprobe=nprobe)
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+def test_storage_versions(tmp_path):
+    dataset_dir = os.path.join(tmp_path, "dataset")
+    k = 10
+    size = 1000
+    partitions = 10
+    dimensions = 128
+    nqueries = 100
+    data = create_random_dataset_u8(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
+    source_uri = os.path.join(dataset_dir, "data.u8bin")
+
+    dtype = np.uint8
+    queries = get_queries(dataset_dir, dtype=dtype)
+    gt_i, _ = get_groundtruth(dataset_dir, k)
+    
+    indexes = ["FLAT", "IVF_FLAT"]
+    index_classes = [FlatIndex, IVFFlatIndex]
+    index_files = [tiledb.vector_search.flat_index, tiledb.vector_search.ivf_flat_index]
+    for index_type, index_class, index_file in zip(indexes, index_classes, index_files):
+        # First we test with an invalid storage version.
+        with pytest.raises(ValueError) as error:
+            index_uri = os.path.join(tmp_path, f"array_{index_type}_invalid")
+            ingest(
+                index_type=index_type,
+                index_uri=index_uri,
+                source_uri=source_uri,
+                partitions=partitions,
+                storage_version="Foo"
+            )
+        assert "Invalid storage version" in str(error.value)
+
+        with pytest.raises(ValueError) as error:
+            index_file.create(uri=index_uri, dimensions=3, vector_type=np.dtype(dtype), storage_version="Foo")
+        assert "Invalid storage version" in str(error.value)
+
+        # Then we test with valid storage versions.
+        for storage_version, _ in tiledb.vector_search.storage_formats.items():
+            index_uri = os.path.join(tmp_path, f"array_{index_type}_{storage_version}")
+            index = ingest(
+                index_type=index_type,
+                index_uri=index_uri,
+                source_uri=source_uri,
+                partitions=partitions,
+                storage_version=storage_version
+            )
+            _, result = index.query(queries, k=k)
+            assert accuracy(result, gt_i) >= MINIMUM_ACCURACY
+
+            update_ids_offset = MAX_UINT64 - size
+            updated_ids = {}
+            for i in range(10):
+                index.delete(external_id=i)
+                index.update(vector=data[i].astype(dtype), external_id=i + update_ids_offset)
+                updated_ids[i] = i + update_ids_offset
+
+            _, result = index.query(queries, k=k)
+            assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
+
+            index = index.consolidate_updates(retrain_index=True, partitions=20)
+            _, result = index.query(queries, k=k)
+            assert accuracy(result, gt_i, updated_ids=updated_ids) >= MINIMUM_ACCURACY
+
+            index_ram = index_class(uri=index_uri)
+            _, result = index_ram.query(queries, k=k)
+            assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+def test_copy_centroids_uri(tmp_path):
+    dataset_dir = os.path.join(tmp_path, "dataset")
+    os.mkdir(dataset_dir)
+
+    # Create the index data.
+    data = np.array([[1, 1, 1, 1], [1, 1, 1, 1], [2, 2, 2, 2], [2, 2, 2, 2], [3, 3, 3, 3]], dtype=np.float32)
+
+    # Create the centroids - this is based on ivf_flat_index.py.
+    centroids = np.array([[1, 1, 1, 1], [2, 2, 2, 2]], dtype=np.float32)
+    centroids_in_size = centroids.shape[0]
+    dimensions = centroids.shape[1]
+    schema = tiledb.ArraySchema(
+        domain=tiledb.Domain(
+            *[
+                tiledb.Dim(name="rows", domain=(0, dimensions - 1), tile=dimensions, dtype=np.dtype(np.int32)),
+                tiledb.Dim(name="cols", domain=(0, np.iinfo(np.dtype("int32")).max), tile=100000, dtype=np.dtype(np.int32)),
+            ]
+        ),
+        sparse=False,
+        attrs=[tiledb.Attr(name="centroids", dtype="float32", filters=tiledb.FilterList([tiledb.ZstdFilter()]))],
+        cell_order="col-major",
+        tile_order="col-major",
+    )
+    centroids_uri = os.path.join(dataset_dir, "centroids.tdb")
+    tiledb.Array.create(centroids_uri, schema)
+    index_timestamp = int(time.time() * 1000)
+    with tiledb.open(centroids_uri, mode="w", timestamp=index_timestamp) as A:
+        A[0:dimensions, 0:centroids_in_size] = centroids.transpose()
+
+    # Create the index.
+    index_uri = os.path.join(tmp_path, "array")
+    index = ingest(
+        index_type="IVF_FLAT", 
+        index_uri=index_uri, 
+        input_vectors=data,
+        copy_centroids_uri=centroids_uri,
+        partitions=centroids_in_size
+    )
+
+    # Query the index.
+    queries = np.array([data[4]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[4]])
+
+
+def test_kmeans():
+    k = 128
+    d = 16
+    n = k * k
+    max_iter = 16
+    n_init = 10
+    verbose = False
+
+    import sklearn.model_selection
+    from sklearn.datasets import make_blobs
+    from sklearn.cluster import KMeans
+
+    X, _, centers = make_blobs(n_samples=n, n_features=d, centers=k, return_centers=True, random_state=1)
+    X = X.astype("float32")
+
+    data, queries = sklearn.model_selection.train_test_split(
+        X, test_size=0.1, random_state=1
+    )
+
+    data_x = np.array([[1.0573647,   5.082087],
+                      [-6.229642,   -1.3590931],
+                      [0.7446737,    6.3828287],
+                      [-7.698864,   -3.0493321],
+                      [2.1362762,   -4.4448104],
+                      [1.04019,     -4.0389647],
+                      [0.38996044,   5.7235265],
+    [1.7470839,  -4.717076]]).astype("float32")
+    queries_x = np.array([[-7.3712273, -1.1178735]]).astype("float32")
+
+    km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="random", random_state=1)
+    km.fit(data)
+    centroids_sk = km.cluster_centers_
+    results_sk = km.predict(queries)
+
+    centroids_tdb = kmeans_fit(
+        k, "random", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
+    )
+    centroids_tdb_np = np.transpose(np.array(centroids_tdb))
+    results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
+    results_tdb_np = np.transpose(np.array(results_tdb))
+
+    def get_score(centroids, results):
+        x = []
+        for i in range(len(queries)):
+            x.append(np.linalg.norm(queries[i] - centroids[results[i]]))
+        return np.mean(np.array(x))
+
+    sklearn_score = get_score(centroids_sk, results_sk)
+    tdb_score = get_score(centroids_tdb_np, results_tdb_np)
+
+    km = KMeans(n_clusters=k, n_init=n_init, max_iter=max_iter, verbose=verbose, init="k-means++", random_state=1)
+    km.fit(data)
+    centroids_sk = km.cluster_centers_
+    results_sk = km.predict(queries)
+
+    assert tdb_score < 1.5 * sklearn_score
+
+    centroids_tdb = kmeans_fit(
+        k, "k-means++", max_iter, verbose, n_init, array_to_matrix(np.transpose(data)), seed=1
+    )
+    centroids_tdb_np = np.transpose(np.array(centroids_tdb))
+    results_tdb = kmeans_predict(centroids_tdb, array_to_matrix(np.transpose(queries)))
+    results_tdb_np = np.transpose(np.array(results_tdb))
+
+    sklearn_score = get_score(centroids_sk, results_sk)
+    tdb_score = get_score(centroids_tdb_np, results_tdb_np)
+
+    assert tdb_score < 1.5 * sklearn_score
+
+def test_ingest_with_training_source_uri_f32(tmp_path):
+    dataset_dir = os.path.join(tmp_path, "dataset")
+    data = np.array([[1.0, 1.1, 1.2, 1.3], [2.0, 2.1, 2.2, 2.3], [3.0, 3.1, 3.2, 3.3], [4.0, 4.1, 4.2, 4.3], [5.0, 5.1, 5.2, 5.3]], dtype=np.float32)
+    create_manual_dataset_f32_only_data(data=data, path=dataset_dir)
+
+    training_data = np.array([data[0], data[1], data[2]], dtype=np.float32)
+    create_manual_dataset_f32_only_data(data=training_data, path=dataset_dir, dataset_name="training_data.f32bin")
+    index_uri = os.path.join(tmp_path, "array")
+    index = ingest(
+        index_type="IVF_FLAT", 
+        index_uri=index_uri, 
+        source_uri=os.path.join(dataset_dir, "data.f32bin"),
+        training_source_uri=os.path.join(dataset_dir, "training_data.f32bin")
+    )
+
+    queries = np.array([data[1]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+
+    index = IVFFlatIndex(uri=index_uri)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+
+    # Also test that we can ingest with training_source_type.
+    ingest(
+        index_type="IVF_FLAT",
+        index_uri=os.path.join(tmp_path, "array_2"), 
+        source_uri=os.path.join(dataset_dir, "data.f32bin"),
+        training_source_uri=os.path.join(dataset_dir, "training_data.f32bin"),
+        training_source_type="F32BIN"
+    )
+
+def test_ingest_with_training_source_uri_tdb(tmp_path):
+    ################################################################################################
+    # First set up the data.
+    ################################################################################################
+    dataset_dir = os.path.join(tmp_path, "dataset")
+    os.mkdir(dataset_dir)
+    # data.shape should give you (cols, rows). So we transpose this before using it.
+    data = np.array([
+        [1.0, 1.1, 1.2, 1.3], 
+        [2.0, 2.1, 2.2, 2.3], 
+        [3.0, 3.1, 3.2, 3.3], 
+        [4.0, 4.1, 4.2, 4.3], 
+        [5.0, 5.1, 5.2, 5.3]], dtype=np.float32).transpose()
+    create_array(path=os.path.join(dataset_dir, "data.tdb"), data=data)
+
     training_data = np.array([
         [1.0, 1.1, 1.2, 1.3], 
         [5.0, 5.1, 5.2, 5.3]], dtype=np.float32).transpose()
     create_array(path=os.path.join(dataset_dir, "training_data.tdb"), data=training_data)
+
+    # Run a quick test that if we set up training_data incorrectly, we will raise an exception.
+    with pytest.raises(ValueError) as error:
+        training_data_invalid = np.array([
+            [1.0, 1.1, 1.2], 
+            [5.0, 5.1, 5.2]], dtype=np.float32).transpose()
+        create_array(path=os.path.join(dataset_dir, "training_data_invalid.tdb"), data=training_data_invalid)
+        index = ingest(
+            index_type="IVF_FLAT", 
+            index_uri=os.path.join(tmp_path, f"array_invalid"), 
+            source_uri=os.path.join(dataset_dir, "data.tdb"),
+            training_source_uri=os.path.join(dataset_dir, "training_data_invalid.tdb")
+        )
+    assert "training data dimensions" in str(error.value)
 
     ################################################################################################
     # Test we can ingest, query, update, and consolidate.
@@ -1094,8 +983,138 @@ def test_ivf_flat_ingestion_tdb_random_sampling_policy(tmp_path):
         index_type="IVF_FLAT", 
         index_uri=index_uri, 
         source_uri=os.path.join(dataset_dir, "data.tdb"),
-        training_sampling_policy=TrainingSamplingPolicy.RANDOM,
-        training_sample_size=3,
-        input_vectors_per_work_item=4,
-        use_sklearn=True
+        training_source_uri=os.path.join(dataset_dir, "training_data.tdb")
     )
+
+    queries = np.array([data.transpose()[1]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+
+    update_vectors = np.empty([3], dtype=object)
+    update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
+    update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
+    
+    index = index.consolidate_updates()
+
+    queries = np.array([update_vectors[2]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
+
+    ################################################################################################
+    # Test we can load the index again and query, update, and consolidate.
+    ################################################################################################
+    # Load the index again and query.
+    index = IVFFlatIndex(uri=index_uri)
+
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
+    
+    # Update the index and query.
+    update_vectors = np.empty([2], dtype=object)
+    update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+    index = index.consolidate_updates()
+    
+    queries = np.array([update_vectors[0]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
+
+    # Clear the index history, load, update, and query.
+    Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
+
+    index = IVFFlatIndex(uri=index_uri)
+
+    update_vectors = np.empty([2], dtype=object)
+    update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([12.0, 12.1, 12.2, 12.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+    index = index.consolidate_updates()
+
+    queries = np.array([update_vectors[0]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
+
+    ###############################################################################################
+    # Also test that we can ingest with training_source_type.
+    ###############################################################################################
+    ingest(
+        index_type="IVF_FLAT",
+        index_uri=os.path.join(tmp_path, "array_2"), 
+        source_uri=os.path.join(dataset_dir, "data.tdb"),
+        training_source_uri=os.path.join(dataset_dir, "training_data.tdb"),
+        training_source_type="TILEDB_ARRAY"
+    )
+
+def test_ingest_with_training_source_uri_numpy(tmp_path):
+    ################################################################################################
+    # First set up the data.
+    ################################################################################################
+    data = np.array([
+        [1.0, 1.1, 1.2, 1.3], 
+        [2.0, 2.1, 2.2, 2.3], 
+        [3.0, 3.1, 3.2, 3.3], 
+        [4.0, 4.1, 4.2, 4.3], 
+        [5.0, 5.1, 5.2, 5.3]], dtype=np.float32)
+    training_data = data[1:3]
+
+    # Run a quick test that if we set up training_data incorrectly, we will raise an exception.
+    with pytest.raises(ValueError) as error:
+        training_data_invalid = np.array([
+            [4.0, 4.1, 4.2], 
+            [5.0, 5.1, 5.2]], dtype=np.float32)
+        index = ingest(
+            index_type="IVF_FLAT", 
+            index_uri=os.path.join(tmp_path, "array_invalid"), 
+            input_vectors=data,
+            training_input_vectors=training_data_invalid,
+        )
+    assert "training data dimensions" in str(error.value)
+
+    ################################################################################################
+    # Test we can ingest, query, update, and consolidate.
+    ################################################################################################
+    index_uri = os.path.join(tmp_path, "array")
+    index = ingest(
+        index_type="IVF_FLAT", 
+        index_uri=index_uri, 
+        input_vectors=data,
+        training_input_vectors=training_data,
+    )
+
+    queries = np.array([data[1]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+
+    update_vectors = np.empty([3], dtype=object)
+    update_vectors[0] = np.array([6.0, 6.1, 6.2, 6.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([7.0, 7.1, 7.2, 7.3], dtype=np.dtype(np.float32))
+    update_vectors[2] = np.array([8.0, 8.1, 8.2, 8.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1000, 1001, 1002]))
+    
+    index = index.consolidate_updates()
+
+    queries = np.array([update_vectors[2]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1002]])
+
+    ################################################################################################
+    # Test we can load the index again and query, update, and consolidate.
+    ################################################################################################
+    index_ram = IVFFlatIndex(uri=index_uri)
+
+    queries = np.array([data[1]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1]])
+
+    update_vectors = np.empty([2], dtype=object)
+    update_vectors[0] = np.array([9.0, 9.1, 9.2, 9.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([10.0, 10.1, 10.2, 10.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+    index_ram = index_ram.consolidate_updates()
+
+    queries = np.array([update_vectors[0]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])
+
+    update_vectors = np.empty([2], dtype=object)
+    update_vectors[0] = np.array([11.0, 11.1, 11.2, 11.3], dtype=np.dtype(np.float32))
+    update_vectors[1] = np.array([12.0, 12.1, 12.2, 12.3], dtype=np.dtype(np.float32))
+    index.update_batch(vectors=update_vectors, external_ids=np.array([1003, 1004]))
+    index_ram = index_ram.consolidate_updates(retrain_index=True, training_sample_size=3)
+
+    queries = np.array([update_vectors[0]], dtype=np.float32)
+    query_and_check_equals(index=index, queries=queries, expected_result_d=[[0]], expected_result_i=[[1003]])


### PR DESCRIPTION
### What
Here we add support for randomly sampling from the input data for use in computing centroids. This leaves us with the following ways to compute centroids:
- Have `ingest()` choose the first N vectors from the input data
- Have `ingest()` choose a random set of N vectors from the input data
- Pass vectors directly as a numpy array (`training_input_vectors`)
- Pass `training_source_uri` which points to vectors
- Pass `copy_centroids_uri` which points to already computed centroids

One interesting design decision here is how to setup the user facing API. 

Option 1 is to be very explicit:
```
class TrainingSamplingPolicy(enum.Enum):
    FIRST_N = 1
    RANDOM = 2
    INPUT_VECTORS = 3
    SOURCE_URI = 4
    COPY_CENTROIDS_URI = 5
  
here we throw an error if the appropriate parameters are not passed in along with the policy.
```

Option 2 is to be more implicit, i.e.:
```
class TrainingSamplingPolicy(enum.Enum):
    FIRST_N = 1
    RANDOM = 2

here we choose the right policy based on what the user passes in. If the user passes in `training_input_vectors` then we use `INPUT_VECTORS` policy. If the user passes in `training_source_uri` then we use `SOURCE_URI` policy. If the user passes in `copy_centroids_uri` then we use `COPY_CENTROIDS_URI` policy. If the user passes in `training_sampling_policy` then we use either FIRST_N / RANDOM.
```

We opted with #2 as it better fits the current code, though I would be open to change it based on feedback.

### Open questions
1. Is this the right way to use a DAG? It seemed okay, but I may have missed something
2. Is there a way to avoid needing the `combine_vectors` step? I tried doing it without but just ended up with node objects which looked like they needed to be awaited.

### Testing
* Adds unit tests, as well as a check that the total number of sampled vectors is correct.
* Also manually looked at tests.