### PR TITLE
Increment TileDB version

### DIFF
--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 dependencies = [
     "tiledb-cloud>=0.11",
-    "tiledb>=0.23.1",
+    "tiledb>=0.25.0",
     "typing-extensions", # for tiledb-cloud indirect, x-ref https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/428
     "scikit-learn",
 ]

--- a/apis/python/requirements-py.txt
+++ b/apis/python/requirements-py.txt
@@ -1,3 +1,3 @@
 numpy==1.24.3
 tiledb-cloud==0.10.24
-tiledb==0.23.1
+tiledb==0.25.0

--- a/src/cmake/Modules/FindTileDB_EP.cmake
+++ b/src/cmake/Modules/FindTileDB_EP.cmake
@@ -52,8 +52,8 @@ else()
     # Try to download prebuilt artifacts unless the user specifies to build from source
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.18.2/tiledb-windows-x86_64-2.18.2-9ae6e1a.zip")
-          SET(DOWNLOAD_SHA1 "c440403fde701e5014a7ffa046d38bb49b141e55")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-windows-x86_64-2.19.0-fa30a88a.zip")
+          SET(DOWNLOAD_SHA1 "ab8b61a35f0776e851c4eedcb1340df4d8cfb4b3")
         elseif(APPLE) # OSX
           if (DEFINED CMAKE_OSX_ARCHITECTURES)
             set(ACTUAL_TARGET ${CMAKE_OSX_ARCHITECTURES})
@@ -63,15 +63,15 @@ else()
 
 
           if (ACTUAL_TARGET MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.18.2/tiledb-macos-x86_64-2.18.2-9ae6e1a.tar.gz")
-            SET(DOWNLOAD_SHA1 "6ba986407b2d0e25fb5df19d08ed22fefeac1c2a")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-macos-x86_64-2.19.0-fa30a88a.tar.gz")
+            SET(DOWNLOAD_SHA1 "089b3aa8a92df0bd5a8f7515ed8e5b6bacb5ab47")
           elseif (ACTUAL_TARGET STREQUAL arm64 OR ACTUAL_TARGET MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.18.2/tiledb-macos-arm64-2.18.2-9ae6e1a.tar.gz")
-            SET(DOWNLOAD_SHA1 "4395a283db57844a944f02dab5bd0f0001eb7e30")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-macos-arm64-2.19.0-fa30a88a.tar.gz")
+            SET(DOWNLOAD_SHA1 "83acdc7529d50dcf293dbd6bbc81263856c7c74c")
           endif()
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.18.2/tiledb-linux-x86_64-2.18.2-9ae6e1a.tar.gz")
-          SET(DOWNLOAD_SHA1 "6386504a58d52330f41fa688a2b259b67824e2c8")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.19.0/tiledb-linux-x86_64-2.19.0-fa30a88a.tar.gz")
+          SET(DOWNLOAD_SHA1 "d236688dbeff2536a8938cf8bf0d478b9f6108f6")
         endif()
 
         ExternalProject_Add(ep_tiledb
@@ -93,8 +93,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.18.2.zip"
-          URL_HASH SHA1=70bb2e9a7603675849830b763d1a0d17fce4bafa
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.19.0.zip"
+          URL_HASH SHA1=ade4c52490440f3d348e0f2d4677b322c83993df
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}


### PR DESCRIPTION
This PR increments the TileDB version to 2.19.0 (and also TileDB-Py to 0.25)