### PR TITLE
Add `write_ivecs` and `write_fvecs` utils

### DIFF
--- a/apis/python/src/tiledb/vector_search/utils.py
+++ b/apis/python/src/tiledb/vector_search/utils.py
@@ -46,7 +46,7 @@ def _write_vecs_t(uri, data, dtype, ctx_or_config=None):
     with tiledb.scope_ctx(ctx_or_config) as ctx:
         dtype = np.dtype(dtype)
         vfs = tiledb.VFS(ctx.config())
-        ndim = data.shape[1]  # Get the number of dimensions from the input data
+        ndim = data.shape[1]
 
         buffer = io.BytesIO()
 

--- a/apis/python/test/test_utils.py
+++ b/apis/python/test/test_utils.py
@@ -1,0 +1,30 @@
+import os
+import numpy as np
+from tiledb.vector_search.utils import load_fvecs, load_ivecs, write_fvecs, write_ivecs
+
+def test_load_and_write_vecs(tmp_path):
+    fvecs_uri = "test/data/siftsmall/siftsmall_base.fvecs"
+    ivecs_uri = "test/data/siftsmall/siftsmall_groundtruth.ivecs"
+
+    fvecs = load_fvecs(fvecs_uri)
+    assert fvecs.shape == (10000, 128)
+    assert not np.any(np.isnan(fvecs))
+
+    ivecs = load_ivecs(ivecs_uri)
+    assert ivecs.shape == (100, 100)
+    assert not np.any(np.isnan(ivecs))
+
+    fvecs_uri = os.path.join(tmp_path, "fvecs")
+    ivecs_uri = os.path.join(tmp_path, "ivecs")
+
+    write_fvecs(fvecs_uri, fvecs[:10])
+    write_ivecs(ivecs_uri, ivecs[:10])
+
+    new_fvecs = load_fvecs(fvecs_uri)
+    assert new_fvecs.shape == (10, 128)
+    assert not np.any(np.isnan(fvecs))
+
+    new_ivecs = load_ivecs(ivecs_uri)
+    assert new_ivecs.shape == (10, 100)
+    assert not np.any(np.isnan(ivecs))
+


### PR DESCRIPTION
### What
These will be used to create a SIFT micro dataset.

### Testing
* Adds a unit test
* Read from fvecs file A, wrote 100 of those values to a fvecs file B, read from fvecs file B, and confirmed the values match:

<img width="1462" alt="Screenshot 2024-01-10 at 3 16 08 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/6efe3ce8-cce2-4396-a6da-35cc8f10869f">

### Not done
I did not implement `write_bvecs` because it is not used and has a different format. I think we can write this as needed later.