### PR TITLE
Add `pre-commit` to format files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.265"
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+
+  - repo: https://github.com/psf/black
+    rev: "23.3.0"
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v17.0.6'
+    hooks:
+      - id: clang-format

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["nbmake", "pytest"]
+formatting = ["pre-commit"]
 
 
 [project.urls]
@@ -50,6 +51,7 @@ write_to = "apis/python/src/tiledb/vector_search/version.py"
 
 [tool.ruff]
 extend-select = ["I"]
+ignore = ["F403", "F405", "E501", "E741"]
 
 [tool.ruff.isort]
 known-first-party = ["tiledb"]

--- a/documentation/Building.md
+++ b/documentation/Building.md
@@ -69,16 +69,29 @@ docker run --rm tiledb/tiledb-vector-search
 ```
 
 # Formatting
+There are two ways you can format your code.
 
-The C++ code is formatted with `clang-format` version 17. Install it yourself or by running:
+If you just want to format C++ code and don't want to `pip install` anything, you can install [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 17 and use that directly. Install it yourself, or by running this installation script:
 ```bash
 ./scripts/install_clang_format.sh
 ```
-Check if any files require formatting changes with:
+Then run it:
 ```bash
+# Check if any files require formatting changes:
 ./scripts/run_clang_format.sh . clang-format 0
-```
-Make all required formatting changes with:
-```bash
+# Run on all files and make formatting changes:
 ./scripts/run_clang_format.sh . clang-format 1
+```
+
+Alternatively, you can format all code in the repo (i.e. C++, Python, YAML, and Markdown files) with [pre-commit](https://pre-commit.com/), though it requires installing with `pip`. Install it with:
+```bash
+cd apis/python
+pip install ".[formatting]"
+```
+Then run it:
+```bash
+# Run on all files and make formatting changes:
+pre-commit run --all-files
+# Run on single file and make formatting changes:
+pre-commit run --files path/to/file.py
 ```


### PR DESCRIPTION
### What
Here we add `pre-commit` to format files in the repo. We use the same configuration as https://github.com/TileDB-Inc/TileDB-Cloud-Py/blob/main/.pre-commit-config.yaml, but we also add `clang-format`.

To keep this easier to review, I'll split the code into three PRs:
1. This PR to add `pre-commit`.
2. A PR to run `pre-commit` on all files.
3. A PR to add a CI job which runs `pre-commit` (and runs it again in case any new files made it in which require formatting - this is still nicer to review than combining them).

Note that I did ignore some things in `ignore = ["F403", "F405", "E501", "E741"]` - these are mainly for line length, undefined imports, and other things which don't get automatically fixed. It would be nice to not ignore these, but ignoring them helps get this in faster and keep churn down. I would propose in a later follow-up we can add these back if we'd like.

### Testing
* #196 runs a CI job succesfully.
* I have checked that manually running `clang-format` vs running `pre-commit` result in the same formatting changes.
* I have run it locally and can get everything formatted well:
```
(TileDB-Vector-Search) ~/repo/TileDB-Vector-Search pre-commit run --all-files
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
prettier.................................................................Passed
ruff.....................................................................Passed
black....................................................................Passed
clang-format.............................................................Passed
```