### PR TITLE
Support random sampling in distributed ingestion

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -1082,12 +1082,17 @@ def ingest(
                 new_centroid_thread_sums.append(new_centroid_sums_queue)
                 new_centroid_counts_queue = mp.Queue()
                 new_centroid_thread_counts.append(new_centroid_counts_queue)
+
+                start = i
+                end = i + batch_size
+                if end > len(vectors):
+                    end = len(vectors)
                 worker = mp.Process(
                     target=generate_new_centroid_per_thread,
                     args=(
                         thread_id,
-                        i,
-                        i + batch_size,
+                        start,
+                        end,
                         new_centroid_sums_queue,
                         new_centroid_counts_queue,
                     ),
@@ -1837,10 +1842,12 @@ def ingest(
                     for random_sample_node in random_sample_nodes:
                         centroids_node.depends_on(random_sample_node)
                 else:
+                    uri = training_source_uri if training_source_uri is not None else source_uri
+                    uri_type = training_source_type if training_source_uri is not None else source_type
                     internal_centroids_node = submit(
                         init_centroids,
-                        source_uri=source_uri,
-                        source_type=source_type,
+                        source_uri=uri,
+                        source_type=uri_type,
                         vector_type=vector_type,
                         partitions=partitions,
                         dimensions=dimensions,
@@ -1851,6 +1858,9 @@ def ingest(
                         resources={"cpu": "1", "memory": "1Gi"},
                         image_name=DEFAULT_IMG_NAME,
                     )
+
+                    for random_sample_node in random_sample_nodes:
+                        internal_centroids_node.depends_on(random_sample_node)
 
                     for it in range(5):
                         kmeans_workers = []
@@ -1866,8 +1876,8 @@ def ingest(
                                 submit(
                                     assign_points_and_partial_new_centroids,
                                     centroids=internal_centroids_node,
-                                    source_uri=source_uri,
-                                    source_type=source_type,
+                                    source_uri=uri,
+                                    source_type=uri_type,
                                     vector_type=vector_type,
                                     partitions=partitions,
                                     dimensions=dimensions,
@@ -2145,6 +2155,8 @@ def ingest(
         logger.debug("Training sample size %d", training_sample_size)
         logger.debug("Training source uri %s and type %s", training_source_uri, training_source_type)
         logger.debug("Number of workers %d", workers)
+        if training_sample_size < partitions:
+            raise ValueError(f"training_sample_size ({training_sample_size}) must be greater than or equal to the number of partitions ({partitions})")
 
         if external_ids is not None:
             external_ids_uri = write_external_ids(


### PR DESCRIPTION
### What
Here we add support for random sampling in distributed ingestion.

### Testing
* I'm getting out of memory error when I run `test_cloud_ivf_flat_random_sampling` with `tiledb://TileDB-Inc/ann_sift1b_raw_vectors_col_major`, so we need another look there when using large tiledb URIs.
* But I did test using `tiledb://TileDB-Inc/sift_10k` with `CENTRALISED_KMEANS_MAX_SAMPLE_SIZE = 1` to force distributed, and it worked: https://cloud.tiledb.com/activity/taskgraphs/TileDB-Inc/f25c2965-d5ca-4540-ac87-1f6a28f5d146
* Existing tests pass.