### PR TITLE
Run `clang-format` in the python src dir

### DIFF
--- a/apis/python/src/tiledb/vector_search/kmeans.cc
+++ b/apis/python/src/tiledb/vector_search/kmeans.cc
@@ -1,13 +1,13 @@
 #include <tiledb/tiledb>
 
-#include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include "linalg.h"
+#include "flat_query.h"
 #include "ivf_index.h"
 #include "ivf_query.h"
-#include "flat_query.h"
+#include "linalg.h"
 
 namespace py = pybind11;
 using Ctx = tiledb::Context;
@@ -16,41 +16,48 @@ namespace {
 
 template <typename T, typename shuffled_ids_type = uint64_t>
 static void declare_kmeans(py::module& m, const std::string& suffix) {
-  m.def(("kmeans_fit_" + suffix).c_str(),
-        [](size_t n_clusters,
-           std::string init,
-           size_t max_iter,
-           bool verbose,
-           size_t n_init,
-           const ColMajorMatrix<T>& sample_vectors,
-           std::optional<double> tol,
-           std::optional<unsigned int> seed,
-           std::optional<size_t> nthreads) {
-             // TODO: support verbose and n_init
-             std::ignore = verbose;
-             std::ignore = n_init;
-             kmeans_init init_val;
-             if (init == "k-means++") {
-                init_val = kmeans_init::kmeanspp;
-             } else if (init == "random") {
-                init_val = kmeans_init::random;
-             } else {
-                throw std::invalid_argument("Invalid init method");
-             }
-             kmeans_index<T> idx(sample_vectors.num_rows(), n_clusters, max_iter, tol.value_or(0.0001), nthreads, seed);
-             idx.train(sample_vectors, init_val);
-             return std::move(idx.get_centroids());
-  });
+  m.def(
+      ("kmeans_fit_" + suffix).c_str(),
+      [](size_t n_clusters,
+         std::string init,
+         size_t max_iter,
+         bool verbose,
+         size_t n_init,
+         const ColMajorMatrix<T>& sample_vectors,
+         std::optional<double> tol,
+         std::optional<unsigned int> seed,
+         std::optional<size_t> nthreads) {
+        // TODO: support verbose and n_init
+        std::ignore = verbose;
+        std::ignore = n_init;
+        kmeans_init init_val;
+        if (init == "k-means++") {
+          init_val = kmeans_init::kmeanspp;
+        } else if (init == "random") {
+          init_val = kmeans_init::random;
+        } else {
+          throw std::invalid_argument("Invalid init method");
+        }
+        kmeans_index<T> idx(
+            sample_vectors.num_rows(),
+            n_clusters,
+            max_iter,
+            tol.value_or(0.0001),
+            nthreads,
+            seed);
+        idx.train(sample_vectors, init_val);
+        return std::move(idx.get_centroids());
+      });
 
-  m.def(("kmeans_predict_" + suffix).c_str(),
-		[](const ColMajorMatrix<T>& centroids,
-		   const ColMajorMatrix<T>& sample_vectors) {
-			 return kmeans_index<T>::predict(centroids, sample_vectors);
-  });
+  m.def(
+      ("kmeans_predict_" + suffix).c_str(),
+      [](const ColMajorMatrix<T>& centroids,
+         const ColMajorMatrix<T>& sample_vectors) {
+        return kmeans_index<T>::predict(centroids, sample_vectors);
+      });
 }
 
-} // anonymous namespace
-
+}  // anonymous namespace
 
 void init_kmeans(py::module_& m) {
   declare_kmeans<float>(m, "f32");

--- a/apis/python/src/tiledb/vector_search/module.cc
+++ b/apis/python/src/tiledb/vector_search/module.cc
@@ -9,9 +9,9 @@
 // @todo Replace
 #include "detail/flat/qv.h"
 #include "detail/flat/vq.h"
+#include "detail/ivf/dist_qv.h"
 #include "detail/ivf/index.h"
 #include "detail/ivf/qv.h"
-#include "detail/ivf/dist_qv.h"
 #include "detail/linalg/compat.h"
 #include "detail/linalg/matrix.h"
 #include "detail/linalg/partitioned_matrix.h"
@@ -107,19 +107,18 @@ static void declareColMajorMatrix(py::module& mod, std::string const& suffix) {
 }
 
 template <class T>
-static void declare_debug_slice(
-    py::module& m, const std::string& suffix) {
+static void declare_debug_slice(py::module& m, const std::string& suffix) {
   m.def(
       ("debug_slice" + suffix).c_str(),
       [](ColMajorMatrix<T>& mat, const std::string& msg = "module.cc: ") {
         debug_slice(mat, msg);
       });
-// py::keep_alive<1, 2>());
+  // py::keep_alive<1, 2>());
 }
 
 template <class T>
 static void declare_pyarray_to_matrix(
-        py::module& m, const std::string& suffix) {
+    py::module& m, const std::string& suffix) {
   m.def(
       ("pyarray_copyto_matrix" + suffix).c_str(),
       [](py::array_t<T, py::array::f_style> arr) -> ColMajorMatrix<T> {
@@ -163,7 +162,6 @@ static void declare_qv_query_heap_infinite_ram(
          size_t nprobe,
          size_t k_nn,
          size_t nthreads) -> py::tuple {
-
         auto mat = ColMajorPartitionedMatrixWrapper<T, Id_Type, Id_Type>(
             parts, ids, indices);
 
@@ -231,9 +229,8 @@ static void declare_nuv_query_heap_infinite_ram(
           -> std::tuple<
               ColMajorMatrix<float>,
               ColMajorMatrix<uint64_t>> {  // TODO change return type
-
-        auto mat =
-            ColMajorPartitionedMatrixWrapper<T, Id_Type, Id_Type>(parts, ids, indices);
+        auto mat = ColMajorPartitionedMatrixWrapper<T, Id_Type, Id_Type>(
+            parts, ids, indices);
 
         auto&& [active_partitions, active_queries] =
             detail::ivf::partition_ivf_flat_index<Id_Type>(
@@ -296,7 +293,8 @@ static void declare_nuv_query_heap_finite_ram(
       py::keep_alive<1, 2>());
 }
 
-/** Calls the principal ivf_index in index.h -- does not create a C++ `ivf_index` object */
+/** Calls the principal ivf_index in index.h -- does not create a C++
+ * `ivf_index` object */
 template <class T>
 static void declare_ivf_index(py::module& m, const std::string& suffix) {
   m.def(
@@ -330,7 +328,8 @@ static void declare_ivf_index(py::module& m, const std::string& suffix) {
       py::keep_alive<1, 2>());
 }
 
-/** Calls the second ivf_index function in index.h -- does not create a C++ `ivf_index` object */
+/** Calls the second ivf_index function in index.h -- does not create a C++
+ * `ivf_index` object */
 template <class T>
 static void declare_ivf_index_tdb(py::module& m, const std::string& suffix) {
   m.def(
@@ -370,7 +369,7 @@ static void declareFixedMinPairHeap(py::module& mod) {
   PyFixedMinPairHeap cls(mod, "FixedMinPairHeap", py::buffer_protocol());
 
   cls.def(py::init<unsigned>());
-    cls.def(
+  cls.def(
       "insert",
       [](fixed_min_pair_heap<T, U>& heap, const T& x, const U& y) {
         return heap.insert(x, y);
@@ -422,7 +421,7 @@ static void declarePartitionedMatrix(
   cls.def(
       py::init<
           const tiledb::Context&,
-          const std::string&,                 // sift_inputs_uri
+          const std::string&,  // sift_inputs_uri
           const std::string&,
           const std::string&,                // id_uri
           const std::vector<Indices_Type>&,  // partition list to load
@@ -482,12 +481,12 @@ template <
 static void declare_dist_qv(py::module& m, const std::string& suffix) {
   m.def(
       ("dist_qv_" + suffix).c_str(),
-      [](tiledb::Context& ctx,                                    // 0
-         const std::string& part_uri,                             // 1
-         std::vector<indices_type>& active_partitions,            // 2
-         ColMajorMatrix<float>& query,                            // 3
-         std::vector<std::vector<int>>& active_queries,           // 4
-         std::vector<indices_type>& indices,                      // 5
+      [](tiledb::Context& ctx,                           // 0
+         const std::string& part_uri,                    // 1
+         std::vector<indices_type>& active_partitions,   // 2
+         ColMajorMatrix<float>& query,                   // 3
+         std::vector<std::vector<int>>& active_queries,  // 4
+         std::vector<indices_type>& indices,             // 5
          const std::string& id_uri,
          size_t k_nn,
          uint64_t timestamp
@@ -506,58 +505,62 @@ static void declare_dist_qv(py::module& m, const std::string& suffix) {
               id_uri,
               k_nn,
               timestamp);
-      }, py::keep_alive<1,2>());
-  m.def(("dist_qv_" + suffix).c_str(),
-        [](tiledb::Context& ctx,
-           const std::string& part_uri,
-           std::vector<indices_type>& active_partitions,
-           ColMajorMatrix<T>& query,
-           py::array& active_queries_arr,  // Alternative to std::vector argument in above API
-           std::vector<shuffled_ids_type>& indices,
-           const std::string& id_uri,
-           size_t k_nn,
-           uint64_t timestamp
-           /* size_t nthreads @todo: optional arg w/ fallback to C++ default arg */
-        ) { /* @todo: return type */
+      },
+      py::keep_alive<1, 2>());
+  m.def(
+      ("dist_qv_" + suffix).c_str(),
+      [](tiledb::Context& ctx,
+         const std::string& part_uri,
+         std::vector<indices_type>& active_partitions,
+         ColMajorMatrix<T>& query,
+         py::array& active_queries_arr,  // Alternative to std::vector argument
+                                         // in above API
+         std::vector<shuffled_ids_type>& indices,
+         const std::string& id_uri,
+         size_t k_nn,
+         uint64_t timestamp
+         /* size_t nthreads @todo: optional arg w/ fallback to C++ default arg
+          */
+      ) { /* @todo: return type */
+          size_t upper_bound{0};
+          auto nthreads = std::thread::hardware_concurrency();
+          auto temporal_policy{
+              (timestamp == 0) ?
+                  tiledb::TemporalPolicy() :
+                  tiledb::TemporalPolicy(tiledb::TimeTravel, timestamp)};
 
-            size_t upper_bound{0};
-            auto nthreads = std::thread::hardware_concurrency();
-            auto temporal_policy{
-                (timestamp == 0) ?
-                    tiledb::TemporalPolicy() :
-                    tiledb::TemporalPolicy(tiledb::TimeTravel, timestamp)};
+          py::buffer_info buf_info = active_queries_arr.request();
+          auto shape = active_queries_arr.shape();
+          auto num_rows = shape[0];
 
-            py::buffer_info buf_info = active_queries_arr.request();
-            auto shape = active_queries_arr.shape();
-            auto num_rows = shape[0];
+          auto active_queries = std::vector<std::vector<indices_type>>();
+          active_queries.reserve(num_rows);
 
-            auto active_queries = std::vector<std::vector<indices_type>>();
-            active_queries.reserve(num_rows);
+          auto ptr = static_cast<py::object*>(buf_info.ptr);
 
-            auto ptr = static_cast<py::object*>(buf_info.ptr);
-
-            for (size_t i = 0; i < num_rows; ++i) {
-              py::list sublist = py::cast<py::list>(ptr[i]);
-              size_t sublist_length = py::len(sublist);
-              active_queries.emplace_back();
-              active_queries.back().reserve(sublist_length);
-              for (size_t j = 0; j < sublist_length; ++j) {
-                active_queries.back().emplace_back(py::cast<indices_type>(sublist[j]));
-              }
+          for (size_t i = 0; i < num_rows; ++i) {
+            py::list sublist = py::cast<py::list>(ptr[i]);
+            size_t sublist_length = py::len(sublist);
+            active_queries.emplace_back();
+            active_queries.back().reserve(sublist_length);
+            for (size_t j = 0; j < sublist_length; ++j) {
+              active_queries.back().emplace_back(
+                  py::cast<indices_type>(sublist[j]));
             }
+          }
 
-  return detail::ivf::dist_qv_finite_ram_part<T, shuffled_ids_type>(
-      ctx,
-      part_uri,
-      active_partitions,
-      query,
-      active_queries,
-      indices,
-      id_uri,
-      k_nn,
-      timestamp);
-}, py::keep_alive<1,2>());
-
+          return detail::ivf::dist_qv_finite_ram_part<T, shuffled_ids_type>(
+              ctx,
+              part_uri,
+              active_partitions,
+              query,
+              active_queries,
+              indices,
+              id_uri,
+              k_nn,
+              timestamp);
+      },
+      py::keep_alive<1, 2>());
 }
 
 template <class T, class shuffled_ids_type = uint64_t>
@@ -598,12 +601,11 @@ static void declare_vq_query_heap_pyarray(
 void init_kmeans(py::module&);
 void init_type_erased_module(py::module&);
 
-
-  /**************************************************************************
-   *
-   * Template instantiations to create typed interface functions
-   *
-   **************************************************************************/
+/**************************************************************************
+ *
+ * Template instantiations to create typed interface functions
+ *
+ **************************************************************************/
 
 PYBIND11_MODULE(_tiledbvspy, m) {
   py::class_<tiledb::Context>(m, "Ctx", py::module_local())

--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -1,40 +1,39 @@
 /**
-* @file   tiledb/vector_search/type_erased_module.cc
-*
-* @section LICENSE
-*
-* The MIT License
-*
-* @copyright Copyright (c) 2023 TileDB, Inc.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-* THE SOFTWARE.
-*
-* @section DESCRIPTION
-*/
+ * @file   tiledb/vector_search/type_erased_module.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
 
 #include <tiledb/tiledb>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 #include <pybind11/functional.h>
 #include <pybind11/numpy.h>
-
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "api/feature_vector.h"
 #include "api/feature_vector_array.h"
@@ -50,14 +49,13 @@
 namespace py = pybind11;
 
 namespace {
-template <typename ...TArgs>
+template <typename... TArgs>
 py::tuple make_python_pair(std::tuple<TArgs...>&& arg) {
   static_assert(sizeof...(TArgs) == 2, "Must have exactly two arguments");
 
   return py::make_tuple<py::return_value_policy::automatic>(
       py::cast(std::get<0>(arg), py::return_value_policy::move),
-      py::cast(std::get<1>(arg), py::return_value_policy::move)
-  );
+      py::cast(std::get<1>(arg), py::return_value_policy::move));
 }
 
 std::map<std::string, std::string> kwargs_to_map(py::kwargs kwargs) {
@@ -74,33 +72,33 @@ std::map<std::string, std::string> kwargs_to_map(py::kwargs kwargs) {
   return result;
 }
 
-} // namespace
+}  // namespace
 
 auto datatype_to_format(tiledb_datatype_t datatype) {
-    switch(datatype) {
-        case TILEDB_FLOAT32:
-            return py::format_descriptor<float>::format();
-        case TILEDB_FLOAT64:
-            return py::format_descriptor<double>::format();
-        case TILEDB_INT8:
-            return py::format_descriptor<int8_t>::format();
-        case TILEDB_UINT8:
-            return py::format_descriptor<uint8_t>::format();
-        case TILEDB_INT16:
-            return py::format_descriptor<int16_t>::format();
-        case TILEDB_UINT16:
-            return py::format_descriptor<uint16_t>::format();
-        case TILEDB_INT32:
-            return py::format_descriptor<int32_t>::format();
-        case TILEDB_UINT32:
-            return py::format_descriptor<uint32_t>::format();
-        case TILEDB_INT64:
-            return py::format_descriptor<int64_t>::format();
-        case TILEDB_UINT64:
-            return py::format_descriptor<uint64_t>::format();
-        default:
-            throw std::runtime_error("Unsupported datatype");
-    }
+  switch (datatype) {
+    case TILEDB_FLOAT32:
+      return py::format_descriptor<float>::format();
+    case TILEDB_FLOAT64:
+      return py::format_descriptor<double>::format();
+    case TILEDB_INT8:
+      return py::format_descriptor<int8_t>::format();
+    case TILEDB_UINT8:
+      return py::format_descriptor<uint8_t>::format();
+    case TILEDB_INT16:
+      return py::format_descriptor<int16_t>::format();
+    case TILEDB_UINT16:
+      return py::format_descriptor<uint16_t>::format();
+    case TILEDB_INT32:
+      return py::format_descriptor<int32_t>::format();
+    case TILEDB_UINT32:
+      return py::format_descriptor<uint32_t>::format();
+    case TILEDB_INT64:
+      return py::format_descriptor<int64_t>::format();
+    case TILEDB_UINT64:
+      return py::format_descriptor<uint64_t>::format();
+    default:
+      throw std::runtime_error("Unsupported datatype");
+  }
 }
 
 // Define Pybind11 bindings
@@ -312,4 +310,3 @@ void init_type_erased_module(py::module_& m) {
       .def("dimension", &IndexIVFFlat::dimension);
 #endif
 }
-

--- a/scripts/run_clang_format.sh
+++ b/scripts/run_clang_format.sh
@@ -26,7 +26,7 @@ echo "Running clang-format version:" `$CLANG_FORMAT --version`
 pushd $SOURCE_DIR
 
 src=$SOURCE_DIR
-SOURCE_PATHS=($src/src)
+SOURCE_PATHS=($src/src $src/apis/python/src)
 FIND_FILES=(-name "*.cc" -or -name "*.c" -or -name "*.h")
 
 if [ "$APPLY_FIXES" == "1" ]; then


### PR DESCRIPTION
### What
I missed adding this when setting up `clang-format`, so do it now.

### Testing
After:
```
~/repo/TileDB-Vector-Search-3 ./scripts/run_clang_format.sh . clang-format 0      
Running clang-format version: clang-format version 17.0.6
~/repo/TileDB-Vector-Search-3 ~/repo/TileDB-Vector-Search-3
clang-format suggested        0 changes
~/repo/TileDB-Vector-Search-3
```