### PR TITLE
Add a test that verifies there are no output logs

### DIFF
--- a/apis/python/test/conftest.py
+++ b/apis/python/test/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+import ctypes
+
+# Fails if there is any output to stdout or stderr.
+# Based on https://github.com/TileDB-Inc/TileDB-Py/blob/6f02f34e087a9c1eb408cd7c61aeecb3817f9947/tiledb/tests/conftest.py#L25
+@pytest.fixture(scope="function", autouse=True)
+def no_output(capfd):
+    # Wait for the test to finish.
+    yield
+
+    # Flush stdout.
+    libc = ctypes.CDLL(None)
+    libc.fflush(None)
+
+    # Fail if there is any output.
+    out, err = capfd.readouterr()
+    if out or err:
+        pytest.fail(f"Test failed because output was captured. out:\n{out}\nerr:\n{err}")


### PR DESCRIPTION
### What
We add a test that verifies there are no output logs. This should prevent stray debug logs from being introduced.

### Testing
* Unit tests pass.
* If I add a log then the test fails.