### PR TITLE
Implement read_bin_local using VFS

### DIFF
--- a/src/include/detail/linalg/tdb_io.h
+++ b/src/include/detail/linalg/tdb_io.h
@@ -37,7 +37,6 @@
 #include <vector>
 
 #include <tiledb/tiledb>
-// #include <tiledb/vfs.h>
 #include "detail/linalg/matrix.h"
 #include "detail/linalg/tdb_helpers.h"
 #include "utils/logging.h"
@@ -378,7 +377,7 @@ auto read_bin_local(
     size_t subset = 0) {
   auto vfs = tiledb::VFS{ctx};
 
-  std::uint32_t dimension = 0u;
+  uint32_t dimension = 0u;
 
   const auto file_size = vfs.file_size(bin_file);
   auto filebuf = tiledb::VFS::filebuf{vfs};
@@ -406,8 +405,8 @@ auto read_bin_local(
   auto result = ColMajorMatrix<T>{dimension, num_vectors};
   auto* result_ptr = result.data();
 
-  for (std::size_t i = 0; i < num_vectors; ++i) {
-    std::uint32_t d = 0u;
+  for (size_t i = 0; i < num_vectors; ++i) {
+    uint32_t d = 0u;
 
     if (!file.read(reinterpret_cast<char*>(&d), sizeof(d))) {
       throw std::runtime_error(

--- a/src/include/detail/linalg/tdb_io.h
+++ b/src/include/detail/linalg/tdb_io.h
@@ -481,7 +481,7 @@ auto read_bin_local(const std::string& bin_file, size_t subset = 0) {
 
     if (!file.read(reinterpret_cast<char*>(&d), sizeof(d))) {
       throw std::runtime_error(
-        "failed to read dimension for vector at pos: " + std::to_string(i));
+          "failed to read dimension for vector at pos: " + std::to_string(i));
     }
 
     if (d != dimension) {

--- a/src/include/detail/linalg/tdb_io.h
+++ b/src/include/detail/linalg/tdb_io.h
@@ -32,26 +32,12 @@
 #ifndef TILEDB_TDB_IO_H
 #define TILEDB_TDB_IO_H
 
-#if defined __has_include
-#if __has_include(<sys/mman.h>)
-#define USE_MMAP
-#endif
-#endif
-
-#ifdef USE_MMAP
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#else
-#include <fstream>
-#endif
-
 #include <filesystem>
 #include <numeric>
 #include <vector>
 
 #include <tiledb/tiledb>
+// #include <tiledb/vfs.h>
 #include "detail/linalg/matrix.h"
 #include "detail/linalg/tdb_helpers.h"
 #include "utils/logging.h"
@@ -386,71 +372,20 @@ auto sizes_to_indices(const std::vector<T>& sizes) {
  * @return a Matrix of the data
  */
 template <class T>
-auto read_bin_local(const std::string& bin_file, size_t subset = 0) {
-#ifdef USE_MMAP
-  if (!std::filesystem::exists(bin_file)) {
-    throw std::runtime_error("file " + bin_file + " does not exist");
-  }
-  auto file_size = std::filesystem::file_size(bin_file);
+auto read_bin_local(
+  const tiledb::Context& ctx,
+  const std::string& bin_file,
+  size_t subset = 0) {
+  auto vfs = tiledb::VFS{ctx};
 
-  auto fd = open(bin_file.c_str(), O_RDONLY);
-  if (fd == -1) {
-    throw std::runtime_error("could not open " + bin_file);
-  }
-
-  uint32_t dimension{0};
-  auto num_read = read(fd, &dimension, 4);
-  lseek(fd, 0, SEEK_SET);
-
-  auto max_vectors = file_size / (4 + dimension * sizeof(T));
-  if (subset > max_vectors) {
-    throw std::runtime_error(
-        "specified subset is too large " + std::to_string(subset) + " > " +
-        std::to_string(max_vectors));
-  }
-  auto num_vectors = subset == 0 ? max_vectors : subset;
-
-  struct stat s;
-  fstat(fd, &s);
-  size_t mapped_size = s.st_size;
-  assert((size_t)s.st_size == (size_t)file_size);
-
-  T* mapped_ptr = reinterpret_cast<T*>(
-      mmap(0, mapped_size, PROT_READ, MAP_FILE | MAP_PRIVATE, fd, 0));
-
-  if ((long)mapped_ptr == -1) {
-    throw std::runtime_error("mmap failed");
-  }
-
-  ColMajorMatrix<T> X(dimension, num_vectors);
-
-  auto data_ptr = X.data();
-  auto sift_ptr = mapped_ptr;
-
-  // Perform strided read
-  for (size_t k = 0; k < num_vectors; ++k) {
-    // Check for consistency of dimensions
-    decltype(dimension) dim = *reinterpret_cast<int*>(sift_ptr++);
-    if (dim != dimension) {
-      throw std::runtime_error(
-          "dimension mismatch: " + std::to_string(dim) +
-          " != " + std::to_string(dimension));
-    }
-    std::copy(sift_ptr, sift_ptr + dimension, data_ptr);
-    data_ptr += dimension;
-    sift_ptr += dimension;
-  }
-
-  munmap(mapped_ptr, mapped_size);
-  close(fd);
-
-  return X;
-#else
   std::uint32_t dimension = 0u;
 
-  const auto file_size = std::filesystem::file_size(bin_file);
+  const auto file_size = vfs.file_size(bin_file);
+  auto filebuf = tiledb::VFS::filebuf{vfs};
+  filebuf.open(bin_file, std::ios::in | std::ios::binary);
+
   auto file = std::ifstream{bin_file, std::ios::binary};
-  if (!file.is_open()) {
+  if (!file.good()) {
     throw std::runtime_error("failed to open file: " + bin_file);
   }
 
@@ -491,7 +426,6 @@ auto read_bin_local(const std::string& bin_file, size_t subset = 0) {
   }
 
   return result;
-#endif
 }
 
 #endif  // TILEDB_TDB_IO_H

--- a/src/include/detail/linalg/tdb_io.h
+++ b/src/include/detail/linalg/tdb_io.h
@@ -34,22 +34,17 @@
 
 #if defined __has_include
 #if __has_include(<sys/mman.h>)
-
 #define USE_MMAP
+#endif
+#endif
+
+#ifdef USE_MMAP
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
-
 #else
-
 #include <fstream>
-
-#endif
-#else
-
-#include <fstream>
-
 #endif
 
 #include <filesystem>

--- a/src/include/detail/linalg/tdb_io.h
+++ b/src/include/detail/linalg/tdb_io.h
@@ -373,9 +373,9 @@ auto sizes_to_indices(const std::vector<T>& sizes) {
  */
 template <class T>
 auto read_bin_local(
-  const tiledb::Context& ctx,
-  const std::string& bin_file,
-  size_t subset = 0) {
+    const tiledb::Context& ctx,
+    const std::string& bin_file,
+    size_t subset = 0) {
   auto vfs = tiledb::VFS{ctx};
 
   std::uint32_t dimension = 0u;

--- a/src/include/detail/linalg/tdb_io.h
+++ b/src/include/detail/linalg/tdb_io.h
@@ -33,7 +33,7 @@
 #define TILEDB_TDB_IO_H
 
 #if defined __has_include
-#if __has_include (<sys/mman.h>)
+#if __has_include(<sys/mman.h>)
 
 #define USE_MMAP
 #include <fcntl.h>
@@ -480,7 +480,8 @@ auto read_bin_local(const std::string& bin_file, size_t subset = 0) {
     std::uint32_t d = 0u;
 
     if (!file.read(reinterpret_cast<char*>(&d), sizeof(d))) {
-      throw std::runtime_error("failed to read dimension for vector at pos: " + std::to_string(i));
+      throw std::runtime_error(
+        "failed to read dimension for vector at pos: " + std::to_string(i));
     }
 
     if (d != dimension) {

--- a/src/include/scoring.h
+++ b/src/include/scoring.h
@@ -746,8 +746,8 @@ template <class Matrix1, class Matrix2, class Matrix3>
 void gemm_scores(
     const Matrix1& A, const Matrix2& B, Matrix3& C, unsigned nthreads)
   requires(
-      ((!std::is_same_v<typename Matrix1::value_type, float>)&&std::
-           is_same_v<typename Matrix2::value_type, float> &&
+      ((!std::is_same_v<typename Matrix1::value_type, float>) &&
+       std::is_same_v<typename Matrix2::value_type, float> &&
        std::is_same_v<typename Matrix3::value_type, float>))
 {
   ColMajorMatrix<float> A_f(A.num_rows(), A.num_cols());
@@ -759,9 +759,10 @@ void gemm_scores(
 template <class Matrix1, class Matrix2, class Matrix3>
 void gemm_scores(
     const Matrix1& A, const Matrix2& B, Matrix3& C, unsigned nthreads)
-  requires(((!std::is_same_v<typename Matrix1::value_type, float>)&&(
-      !std::is_same_v<typename Matrix2::value_type, float>)&&std::
-                is_same_v<typename Matrix3::value_type, float>))
+  requires(
+      ((!std::is_same_v<typename Matrix1::value_type, float>) &&
+       (!std::is_same_v<typename Matrix2::value_type, float>) &&
+       std::is_same_v<typename Matrix3::value_type, float>))
 {
   ColMajorMatrix<float> A_f(A.num_rows(), A.num_cols());
   std::copy(A.data(), A.data() + A.num_rows() * A.num_cols(), A_f.data());

--- a/src/include/scoring.h
+++ b/src/include/scoring.h
@@ -746,8 +746,8 @@ template <class Matrix1, class Matrix2, class Matrix3>
 void gemm_scores(
     const Matrix1& A, const Matrix2& B, Matrix3& C, unsigned nthreads)
   requires(
-      ((!std::is_same_v<typename Matrix1::value_type, float>) &&
-       std::is_same_v<typename Matrix2::value_type, float> &&
+      ((!std::is_same_v<typename Matrix1::value_type, float>)&&std::
+           is_same_v<typename Matrix2::value_type, float> &&
        std::is_same_v<typename Matrix3::value_type, float>))
 {
   ColMajorMatrix<float> A_f(A.num_rows(), A.num_cols());
@@ -759,10 +759,9 @@ void gemm_scores(
 template <class Matrix1, class Matrix2, class Matrix3>
 void gemm_scores(
     const Matrix1& A, const Matrix2& B, Matrix3& C, unsigned nthreads)
-  requires(
-      ((!std::is_same_v<typename Matrix1::value_type, float>) &&
-       (!std::is_same_v<typename Matrix2::value_type, float>) &&
-       std::is_same_v<typename Matrix3::value_type, float>))
+  requires(((!std::is_same_v<typename Matrix1::value_type, float>)&&(
+      !std::is_same_v<typename Matrix2::value_type, float>)&&std::
+                is_same_v<typename Matrix3::value_type, float>))
 {
   ColMajorMatrix<float> A_f(A.num_rows(), A.num_cols());
   std::copy(A.data(), A.data() + A.num_rows() * A.num_cols(), A_f.data());

--- a/src/include/test/unit_array_defs.cc
+++ b/src/include/test/unit_array_defs.cc
@@ -324,7 +324,8 @@ TEST_CASE("array_defs: compare siftsmall arrays and files", "[array_defs]") {
       read_bin_local<siftsmall_feature_type>(ctx, siftsmall_inputs_file);
   auto file_queries =
       read_bin_local<siftsmall_feature_type>(ctx, siftsmall_query_file);
-  auto file_groundtruth = read_bin_local<uint32_t>(ctx, siftsmall_groundtruth_file);
+  auto file_groundtruth =
+      read_bin_local<uint32_t>(ctx, siftsmall_groundtruth_file);
 
   auto file_groundtruth_64 = ColMajorMatrix<siftsmall_groundtruth_type>(
       file_groundtruth.num_rows(), file_groundtruth.num_cols());

--- a/src/include/test/unit_array_defs.cc
+++ b/src/include/test/unit_array_defs.cc
@@ -321,10 +321,10 @@ TEST_CASE("array_defs: compare siftsmall arrays and files", "[array_defs]") {
       ctx, siftsmall_groundtruth_uri);
 
   auto file_inputs =
-      read_bin_local<siftsmall_feature_type>(siftsmall_inputs_file);
+      read_bin_local<siftsmall_feature_type>(ctx, siftsmall_inputs_file);
   auto file_queries =
-      read_bin_local<siftsmall_feature_type>(siftsmall_query_file);
-  auto file_groundtruth = read_bin_local<uint32_t>(siftsmall_groundtruth_file);
+      read_bin_local<siftsmall_feature_type>(ctx, siftsmall_query_file);
+  auto file_groundtruth = read_bin_local<uint32_t>(ctx, siftsmall_groundtruth_file);
 
   auto file_groundtruth_64 = ColMajorMatrix<siftsmall_groundtruth_type>(
       file_groundtruth.num_rows(), file_groundtruth.num_cols());

--- a/src/include/test/unit_flat_qv.cc
+++ b/src/include/test/unit_flat_qv.cc
@@ -235,10 +235,10 @@ TEST_CASE(
   size_t k_nn = 10;
 
   auto array_inputs =
-      read_bin_local<siftsmall_feature_type>(siftsmall_inputs_file);
+      read_bin_local<siftsmall_feature_type>(ctx, siftsmall_inputs_file);
   auto array_queries =
-      read_bin_local<siftsmall_feature_type>(siftsmall_query_file);
-  auto array_groundtruth = read_bin_local<uint32_t>(siftsmall_groundtruth_file);
+      read_bin_local<siftsmall_feature_type>(ctx, siftsmall_query_file);
+  auto array_groundtruth = read_bin_local<uint32_t>(ctx, siftsmall_groundtruth_file);
 
   auto&& [D00, I00] =
       detail::flat::qv_query_heap(array_inputs, array_queries, k_nn, 1);

--- a/src/include/test/unit_flat_qv.cc
+++ b/src/include/test/unit_flat_qv.cc
@@ -238,7 +238,8 @@ TEST_CASE(
       read_bin_local<siftsmall_feature_type>(ctx, siftsmall_inputs_file);
   auto array_queries =
       read_bin_local<siftsmall_feature_type>(ctx, siftsmall_query_file);
-  auto array_groundtruth = read_bin_local<uint32_t>(ctx, siftsmall_groundtruth_file);
+  auto array_groundtruth =
+      read_bin_local<uint32_t>(ctx, siftsmall_groundtruth_file);
 
   auto&& [D00, I00] =
       detail::flat::qv_query_heap(array_inputs, array_queries, k_nn, 1);

--- a/src/include/test/unit_tdb_io.cc
+++ b/src/include/test/unit_tdb_io.cc
@@ -94,6 +94,18 @@ TEST_CASE("tdb_io: read matrix", "[tdb_io]") {
   CHECK(dimension(X) == bigann1M_dimension);
 }
 
+TEST_CASE("tdb_io: load_file", "[tdb_io]") {
+  tiledb::Context ctx;
+
+  auto A = tdbColMajorMatrix<float>(ctx, siftsmall_inputs_uri);
+  auto B = read_bin_local<float>(siftsmall_inputs_file);
+
+  CHECK(A[0][0] == B[0][0]);
+  CHECK(A[0][1] == B[0][1]);
+  CHECK(A[1][0] == B[1][0]);
+  REQUIRE(A == B);
+}
+
 TEMPLATE_TEST_CASE("tdb_io: write matrix", "[tdb_io]", float, uint8_t) {
   tiledb::Context ctx;
   std::string tmp_matrix_uri = "/tmp/tmp_matrix";

--- a/src/include/test/unit_tdb_io.cc
+++ b/src/include/test/unit_tdb_io.cc
@@ -99,14 +99,14 @@ TEST_CASE("tdb_io: load_file", "[tdb_io]") {
 
   SECTION("inputs") {
     const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(ctx, siftsmall_inputs_uri);
-    const auto B = read_bin_local<siftsmall_feature_type>(siftsmall_inputs_file);
+    const auto B = read_bin_local<siftsmall_feature_type>(ctx, siftsmall_inputs_file);
 
     REQUIRE(A == B);
   }
 
   SECTION("query") {
     const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(ctx, siftsmall_query_uri);
-    const auto B = read_bin_local<siftsmall_feature_type>(siftsmall_query_file);
+    const auto B = read_bin_local<siftsmall_feature_type>(ctx, siftsmall_query_file);
 
     REQUIRE(A == B);
   }

--- a/src/include/test/unit_tdb_io.cc
+++ b/src/include/test/unit_tdb_io.cc
@@ -98,15 +98,19 @@ TEST_CASE("tdb_io: load_file", "[tdb_io]") {
   tiledb::Context ctx;
 
   SECTION("inputs") {
-    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(ctx, siftsmall_inputs_uri);
-    const auto B = read_bin_local<siftsmall_feature_type>(ctx, siftsmall_inputs_file);
+    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(
+        ctx, siftsmall_inputs_uri);
+    const auto B =
+        read_bin_local<siftsmall_feature_type>(ctx, siftsmall_inputs_file);
 
     REQUIRE(A == B);
   }
 
   SECTION("query") {
-    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(ctx, siftsmall_query_uri);
-    const auto B = read_bin_local<siftsmall_feature_type>(ctx, siftsmall_query_file);
+    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(
+        ctx, siftsmall_query_uri);
+    const auto B =
+        read_bin_local<siftsmall_feature_type>(ctx, siftsmall_query_file);
 
     REQUIRE(A == B);
   }

--- a/src/include/test/unit_tdb_io.cc
+++ b/src/include/test/unit_tdb_io.cc
@@ -97,13 +97,19 @@ TEST_CASE("tdb_io: read matrix", "[tdb_io]") {
 TEST_CASE("tdb_io: load_file", "[tdb_io]") {
   tiledb::Context ctx;
 
-  auto A = tdbColMajorMatrix<float>(ctx, siftsmall_inputs_uri);
-  auto B = read_bin_local<float>(siftsmall_inputs_file);
+  SECTION("inputs") {
+    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(ctx, siftsmall_inputs_uri);
+    const auto B = read_bin_local<siftsmall_feature_type>(siftsmall_inputs_file);
 
-  CHECK(A[0][0] == B[0][0]);
-  CHECK(A[0][1] == B[0][1]);
-  CHECK(A[1][0] == B[1][0]);
-  REQUIRE(A == B);
+    REQUIRE(A == B);
+  }
+
+  SECTION("query") {
+    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(ctx, siftsmall_query_uri);
+    const auto B = read_bin_local<siftsmall_feature_type>(siftsmall_query_file);
+
+    REQUIRE(A == B);
+  }
 }
 
 TEMPLATE_TEST_CASE("tdb_io: write matrix", "[tdb_io]", float, uint8_t) {

--- a/src/include/test/unit_tdb_io.cc
+++ b/src/include/test/unit_tdb_io.cc
@@ -98,17 +98,14 @@ TEST_CASE("tdb_io: load_file", "[tdb_io]") {
   tiledb::Context ctx;
 
   SECTION("inputs") {
-    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(
-        ctx, siftsmall_inputs_uri);
-    const auto B =
-        read_bin_local<siftsmall_feature_type>(siftsmall_inputs_file);
+    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(ctx, siftsmall_inputs_uri);
+    const auto B = read_bin_local<siftsmall_feature_type>(siftsmall_inputs_file);
 
     REQUIRE(A == B);
   }
 
   SECTION("query") {
-    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(
-        ctx, siftsmall_query_uri);
+    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(ctx, siftsmall_query_uri);
     const auto B = read_bin_local<siftsmall_feature_type>(siftsmall_query_file);
 
     REQUIRE(A == B);

--- a/src/include/test/unit_tdb_io.cc
+++ b/src/include/test/unit_tdb_io.cc
@@ -98,14 +98,17 @@ TEST_CASE("tdb_io: load_file", "[tdb_io]") {
   tiledb::Context ctx;
 
   SECTION("inputs") {
-    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(ctx, siftsmall_inputs_uri);
-    const auto B = read_bin_local<siftsmall_feature_type>(siftsmall_inputs_file);
+    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(
+        ctx, siftsmall_inputs_uri);
+    const auto B =
+        read_bin_local<siftsmall_feature_type>(siftsmall_inputs_file);
 
     REQUIRE(A == B);
   }
 
   SECTION("query") {
-    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(ctx, siftsmall_query_uri);
+    const auto A = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(
+        ctx, siftsmall_query_uri);
     const auto B = read_bin_local<siftsmall_feature_type>(siftsmall_query_file);
 
     REQUIRE(A == B);


### PR DESCRIPTION
This PR aims to implement read_bin_local using fstream instead of mmap, since mmap is not supported outside of unix platforms e.g. windows builds fail.