### PR TITLE
Reintegrate flatpq index

### DIFF
--- a/src/include/index/README.md
+++ b/src/include/index/README.md
@@ -1,5 +1,24 @@
 
-# `IVFFlatIndex` Design
+# PQ Encoding
+
+Product quantization (pq) is a method for compressing vectors in a vector database.  The basic idea is to divide the vectors into some number of subvectors and then to use the nearest centroid to each subvector to represent the original vector.  Since there are a fixed number of actual centroids, we only need to store the index of the centroid.  
+For example, if we have 256 centroids, we can represent each centroid with an 8-bit index.  If we subdivide a vector into, say, eight subvectors, we can represent each subvector with 8bits, for a total of 64bits for the entire vector.  If the original vector comprised 128 floats, this is a compression of (128 * 32 ) / 64 -- a factor of 64. 
+
+In addition to space savings, distance computation can also be greatly accelerated.  If we are using the "L2" distance -- which is really the sum of squares -- the distance between two vectors is the sum of the distance between each of its subvectors.  Since each subvector is represented by the index of the nearest centroid, we can store those distances in a lookup table and access them with a simple lookup.
+
+The tutorial at https://www.pinecone.io/learn/series/faiss/product-quantization/ explains the general idea of product quantization in more detail.
+
+To realize PQ in TileDB-Vector-Search, we implement the following:
+* The `flatpq_index` constructor defines the number of subvectors and bits per subvector (equivalent to the number of centroids).
+* `train()` runs a kmeans algorithm to compute the centroids for each subspace.  Each subspace has its own set of centroids.  For each subspace, a 2D table is created holding the distance between each pair of centroids in the subspace.
+* `add()` takes a set of input vectors and runs `qv_partition` on each subspace to obtain the codes.
+* `symmetri_query()` first encodes the query vectors and then calls `flat::qv_query_heap` on the encoded queries, using the symmetric pq distance function defined in the class.  They symmetric distance function uses the lookup tables for computing distances.
+* `asymmetric_query()` calls `flat::qv_query_heap` directly on the query vectors, using the asymmetric pq distance function defined in the class.  The asymmetric distance function decodes the encoded vector and computes the distance in the normal fashion.
+* `write_index` saves the index information.  This needs to be brought up to speed by defining index group and index metadata classes.  
+* The "loading" constructor reads an index -- it also needs to be brought up to speed.
+
+
+# `IVFFlatIndex` 
 
 There are four primary classes in the `IVFFlatIndex` design:
 1. `IVFFlatIndex`: The type-erased C++ class interface to an IVF index.
@@ -209,3 +228,13 @@ In the non-cloud case, insertions into the `vamana` (graph-based) indexes is ext
 ### `ivf_flat_index_group`
 
 ### `ivf_flat_index_metadata`
+
+
+# Product Quantization
+
+A more detailed overview of product quantization for vector search is given in https://www.pinecone.io/learn/series/faiss/product-quantization/ .
+
+Product quantization is an approach to compressing the vectors in a vector database.
+The basic idea is to divide the vectors into `m` subvectors and to quantize each subvector
+into `k` centroids.  The centroids are stored in a codebook.  The original vectors are
+then replaced by the indices of the centroids in the codebook.  The codebook is stored

--- a/src/include/index/flatpq_index.h
+++ b/src/include/index/flatpq_index.h
@@ -1,0 +1,927 @@
+/**
+ * @file   flatpq_index.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Header-only library of class that implements a flat index that used product
+ * quantization.
+ *
+ */
+
+#ifndef TILEDB_FLATPQ_INDEX_H
+#define TILEDB_FLATPQ_INDEX_H
+
+#include <cstddef>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+
+#include "detail/flat/qv.h"
+#include "detail/linalg/matrix.h"
+#include "detail/linalg/tdb_io.h"
+
+#include <tiledb/group_experimental.h>
+#include <tiledb/tiledb>
+
+template <class T, class U>
+void sub_kmeans_random_init(
+    const ColMajorMatrix<T>& training_set,
+    ColMajorMatrix<U>& centroids,
+    size_t sub_begin,
+    size_t sub_end,
+    size_t seed = 0) {
+  scoped_timer _{__FUNCTION__};
+
+  if (num_vectors(training_set) < num_vectors(centroids)) {
+    throw std::invalid_argument(
+        "Number of vectors in training set must be greater than or equal to "
+        "number of centroids");
+  }
+
+  std::mt19937 gen(seed == 0 ? std::random_device{}() : seed);
+  std::uniform_int_distribution<> dis(0, num_vectors(training_set) - 1);
+
+  size_t num_clusters = num_vectors(centroids);
+
+  std::vector<size_t> indices(num_clusters);
+  std::unordered_set<size_t> visited;
+  for (size_t i = 0; i < num_clusters; ++i) {
+    size_t index;
+    do {
+      index = dis(gen);
+    } while (visited.contains(index));
+    indices[i] = index;
+    visited.insert(index);
+  }
+  // std::iota(begin(indices), end(indices), 0);
+  // std::shuffle(begin(indices), end(indices), gen);
+
+  for (size_t i = 0; i < num_clusters; ++i) {
+    for (size_t j = sub_begin; j < sub_end; ++j) {
+      centroids(j, i) = training_set(j, indices[i]);
+    }
+  }
+}
+
+// #define REASSIGN
+
+/**
+ * @brief Run kmeans on a subspace
+ * @tparam T Data type of the input vectors
+ * @param training_set Training set
+ * @param centroids Initial locations of centroids.  Will be updated in
+ * locations [sub_begin, sub_end).
+ * @param sub_begin Beginning of the subspace
+ * @param sub_end End of the subspace
+ * @param num_clusters Number of clusters to find
+ * @return
+ *
+ * @todo update with concepts
+ * @todo fix up zero sized partitions
+ * @todo this would be more cache friendly to do sub_begin and sub_end
+ * in an inner loop
+ * @todo We can probably just reuse plain kmeans at some point.
+ */
+template <class T, class U>
+auto sub_kmeans(
+    const ColMajorMatrix<T>& training_set,
+    ColMajorMatrix<U>& centroids,
+    size_t sub_begin,
+    size_t sub_end,
+    size_t num_clusters,
+    double tol,
+    size_t max_iter,
+    size_t num_threads,
+    float reassign_ratio = 0.05) {
+  // using feature_type = T;
+  // using centroids_feature_type = U;
+  // using index_type = size_t;
+
+  size_t sub_dimension_ = sub_end - sub_begin;
+
+  std::vector<size_t> degrees(num_clusters, 0);
+
+  // Copy centroids to new centroids -- note only one subspace will be changing
+  // @todo Keep new_centroids outside function so we don't need to copy all
+  ColMajorMatrix<U> new_centroids(dimension(centroids), num_vectors(centroids));
+  for (size_t i = 0; i < num_vectors(new_centroids); ++i) {
+    for (size_t j = 0; j < dimension(new_centroids); ++j) {
+      new_centroids(j, i) = centroids(j, i);
+    }
+  }
+
+  size_t iter = 0;
+  double max_diff = 0.0;
+  double total_weight = 0.0;
+  for (iter = 0; iter < max_iter; ++iter) {
+#ifdef REASSIGN
+    auto [scores, parts] = detail::flat::qv_partition_with_scores(
+        centroids,
+        training_set,
+        num_threads,
+        sub_sum_of_squares_distance{sub_begin, sub_end});
+#else
+    auto parts = detail::flat::qv_partition(
+        centroids,
+        training_set,
+        num_threads,
+        sub_sum_of_squares_distance{sub_begin, sub_end});
+#endif
+
+    for (size_t j = 0; j < num_vectors(new_centroids); ++j) {
+      for (size_t i = sub_begin; i < sub_end; ++i) {
+        new_centroids(i, j) = 0;
+      }
+    }
+    std::fill(begin(degrees), end(degrees), 0);
+
+#ifdef REASSIGN
+    // How many centroids should we try to fix up
+    size_t heap_size = std::ceil(reassign_ratio * num_clusters) + 5;
+    auto high_scores = fixed_min_pair_heap<
+        feature_type,
+        index_type,
+        std::greater<feature_type>>(heap_size, std::greater<feature_type>());
+    auto low_degrees = fixed_min_pair_heap<index_type, index_type>(heap_size);
+#endif
+
+    for (size_t i = 0; i < num_vectors(training_set); ++i) {
+      auto part = parts[i];
+      auto centroid = new_centroids[part];
+      auto vector = training_set[i];
+
+      for (size_t j = sub_begin; j < sub_end; ++j) {
+        centroid[j] += vector[j];
+      }
+      ++degrees[part];
+#ifdef REASSIGN
+      high_scores.insert(scores[i], i);
+#endif
+    }
+
+#ifdef REASSIGN
+    size_t max_degree = 0;
+
+    for (size_t i = 0; i < num_clusters; ++i) {
+      auto degree = degrees[i];
+      max_degree = std::max<size_t>(max_degree, degree);
+      low_degrees.insert(degree, i);
+    }
+    size_t lower_degree_bound = std::ceil(max_degree * reassign_ratio);
+
+    if (iter != max_iter - 1) {
+#if 0
+        // Pick a random vector to be a new centroid
+        std::uniform_int_distribution<> dis(0, training_set.num_cols() - 1);
+        for (auto&& [degree, zero_part] : low_degrees) {
+          if (degree < lower_degree_bound) {
+            auto index = dis(gen);
+            auto rand_vector = training_set[index];
+            auto low_centroid = new_centroids[zero_part];
+            std::copy(begin(rand_vector), end(rand_vector), begin(low_centroid));
+            for (size_t i = 0; i < dimension_; ++i) {
+              new_centroids[parts[index]][i] -= rand_vector[i];
+            }
+          }
+        }
+#endif
+      // Move vectors with high scores to replace zero-degree partitions
+      std::sort_heap(begin(low_degrees), end(low_degrees));
+      std::sort_heap(begin(high_scores), end(high_scores), [](auto a, auto b) {
+        return std::get<0>(a) > std::get<0>(b);
+      });
+      for (size_t i = 0; i < size(low_degrees) &&
+                         std::get<0>(low_degrees[i]) <= lower_degree_bound;
+           ++i) {
+        // std::cout << "i: " << i << " low_degrees: ("
+        //           << std::get<1>(low_degrees[i]) << " "
+        //           << std::get<0>(low_degrees[i]) << ") high_scores: ("
+        //           << parts[std::get<1>(high_scores[i])] << " "
+        //          << std::get<1>(high_scores[i]) << " "
+        //          << std::get<0>(high_scores[i]) << ")" << std::endl;
+
+        auto [degree, zero_part] = low_degrees[i];
+        auto [score, high_vector_id] = high_scores[i];
+        auto low_centroid = new_centroids[zero_part];
+        auto high_vector = training_set[high_vector_id];
+
+        for (size_t i = sub_begin; i < sub_end; ++i) {
+          low_centroid[i] = high_vector[i];
+        }
+        for (size_t i = sub_begin; i < sub_end; ++i) {
+          new_centroids[parts[high_vector_id]][i] -= high_vector[i];
+        }
+
+        ++degrees[zero_part];
+        --degrees[parts[high_vector_id]];
+      }
+    }
+#endif
+
+    // Check for convergence
+    max_diff = 0;
+    total_weight = 0;
+    for (size_t j = 0; j < num_vectors(centroids); ++j) {
+      if (degrees[j] != 0) {
+        auto centroid = new_centroids[j];
+        for (size_t k = sub_begin; k < sub_end; ++k) {
+          centroid[k] /= degrees[j];
+          total_weight += centroid[k] * centroid[k];
+        }
+      }
+      auto diff = sub_sum_of_squares(
+          centroids[j], new_centroids[j], sub_begin, sub_end);
+      max_diff = std::max<double>(max_diff, diff);
+    }
+    centroids.swap(new_centroids);
+
+    if (max_diff < tol * total_weight) {
+      break;
+    }
+  }
+  return std::make_tuple(iter, max_diff / total_weight);
+}
+
+/**
+ * @brief Flat index that uses product quantization
+ *
+ * @tparam T Data type of the input vectors
+ * @tparam shuffled_ids_type Data type of the shuffled ids
+ * @tparam indices_type Data type of the indices
+ */
+template <
+    class T,
+    class shuffled_ids_type = size_t,
+    class indices_type = size_t>
+class flatpq_index {
+  // using feature_type = typename
+  // std::remove_reference_t<decltype(partitioned_db)>::value_type;
+  using feature_type = T;
+  using id_type = shuffled_ids_type;
+  using score_type = float;
+  using centroid_feature_type = float;
+  using code_type = uint8_t;
+
+  // @todo Temporary only!!
+ public:
+  // metadata
+  size_t dimension_{0};
+  size_t num_subspaces_{0};
+  size_t sub_dimension_{0};
+  size_t bits_per_subspace_{8};
+  size_t num_clusters_{256};
+  float tol_ = 0.001;
+  size_t max_iter_ = 16;
+  size_t num_threads_ = std::thread::hardware_concurrency();
+
+  using metadata_element = std::tuple<std::string, void*, tiledb_datatype_t>;
+  std::vector<metadata_element> metadata{
+      {"dimension", &dimension_, TILEDB_UINT64},
+      {"num_subspaces", &num_subspaces_, TILEDB_UINT64},
+      {"sub_dimension", &sub_dimension_, TILEDB_UINT64},
+      {"bits_per_subspace", &bits_per_subspace_, TILEDB_UINT64},
+      {"num_clusters", &num_clusters_, TILEDB_UINT64},
+      {"tol", &tol_, TILEDB_FLOAT32},
+      {"max_iter", &max_iter_, TILEDB_UINT64},
+      {"num_threads", &num_threads_, TILEDB_UINT64},
+  };
+
+  // array data
+  ColMajorMatrix<centroid_feature_type> centroids_;
+  std::vector<ColMajorMatrix<score_type>> distance_tables_;
+  ColMajorMatrix<code_type> pq_vectors_;
+
+ public:
+  /**
+   * @brief Construct a new flat index object
+   * @param dimension Dimensionality of the input vectors
+   * @param num_subspaces Number of subspaces (number of sections of the
+   *       vector to quantize)
+   * @param bits_per_subspace Number of bits per section (per subspace)
+   *
+   * @todo We don't really need dimension as an argument for any of our indexes
+   */
+  flatpq_index(
+      size_t dimension,
+      size_t num_subspaces,
+      size_t bits_per_subspace = 8,
+      size_t num_clusters = 256)
+      : dimension_(dimension)
+      , num_subspaces_(num_subspaces)
+      , bits_per_subspace_(bits_per_subspace)
+      , num_clusters_(num_clusters) {
+    // Number of subspaces must evenly divide dimension of vector
+    if (dimension_ == 0 || num_subspaces_ == 0 || bits_per_subspace_ == 0) {
+      throw std::invalid_argument(
+          "dimension, num_subspaces, and bits_per_subspace must be greater "
+          "than zero");
+    }
+    if ((dimension_ % num_subspaces_) != 0) {
+      throw std::invalid_argument(
+          "Number of subspaces must evenly divide dimension of vector");
+    }
+    sub_dimension_ = dimension_ / num_subspaces_;
+
+#if 0
+    switch (bits_per_subspace) {
+      case 8: {
+        num_clusters_ = 256;
+        break;
+      }
+      case 16: {
+        // @todo -- allow setting to smaller value
+        // num_clusters_ = 65536;
+        num_clusters_ = 2048;
+        break;
+      }
+        throw std::invalid_argument(
+            "bits_per_subspace must be equal to 8 or 16");
+    }
+#endif
+  }
+
+  /**
+   * Load constructor
+   */
+  flatpq_index(tiledb::Context ctx, const std::string& group_uri) {
+    // ColMajorMatrix<centroid_feature_type> centroids_;
+    // std::vector<ColMajorMatrix<score_type>> distance_tables_;
+    // ColMajorMatrix<code_type> pq_vectors_;
+
+    tiledb::Config cfg;
+    auto read_group = tiledb::Group(ctx, group_uri, TILEDB_READ, cfg);
+
+    for (auto& [name, value, datatype] : metadata) {
+      if (!read_group.has_metadata(name, &datatype)) {
+        throw std::runtime_error("Missing metadata: " + name);
+      }
+      uint32_t count;
+      void* addr;
+      read_group.get_metadata(name, &datatype, &count, (const void**)&addr);
+      if (datatype == TILEDB_UINT64) {
+        *reinterpret_cast<uint64_t*>(value) =
+            *reinterpret_cast<uint64_t*>(addr);
+      } else if (datatype == TILEDB_FLOAT32) {
+        *reinterpret_cast<float*>(value) = *reinterpret_cast<float*>(addr);
+      } else {
+        throw std::runtime_error("Unsupported datatype");
+      }
+    }
+
+    centroids_ =
+        std::move(tdbPreLoadMatrix<centroid_feature_type, stdx::layout_left>(
+            ctx, group_uri + "/centroids"));
+    pq_vectors_ = std::move(tdbPreLoadMatrix<code_type, stdx::layout_left>(
+        ctx, group_uri + "/pq_vectors"));
+    for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
+      std::ostringstream oss;
+      oss << std::setw(2) << std::setfill('0') << subspace;
+      std::string number = oss.str();
+      distance_tables_.emplace_back(
+          std::move(tdbPreLoadMatrix<score_type, stdx::layout_left>(
+              ctx, group_uri + "/distance_table_" + number)));
+    }
+  }
+
+  /**
+   * @brief Train the index on a training set.  Run kmeans on each subspace and
+   * create codewords from the centroids.
+   *
+   * @param training_set Training set
+   */
+  auto train(const ColMajorMatrix<feature_type>& training_set) {
+    centroids_ = std::move(
+        ColMajorMatrix<centroid_feature_type>(dimension_, num_clusters_));
+    distance_tables_ = std::vector<ColMajorMatrix<score_type>>(num_subspaces_);
+    for (size_t i = 0; i < num_subspaces_; ++i) {
+      distance_tables_[i] = std::move(
+          ColMajorMatrix<centroid_feature_type>(num_clusters_, num_clusters_));
+    }
+
+    for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
+      auto sub_begin = subspace * dimension_ / num_subspaces_;
+      auto sub_end = (subspace + 1) * dimension_ / num_subspaces_;
+
+      sub_kmeans_random_init(
+          training_set, centroids_, sub_begin, sub_end, 0xdeadbeef);
+      size_t iters;
+      double conv;
+      std::tie(iters, conv) = sub_kmeans(
+          training_set,
+          centroids_,
+          sub_begin,
+          sub_end,
+          num_clusters_,
+          tol_,
+          max_iter_,
+          num_threads_);
+
+      auto x = 0;
+    }
+
+    // Create table
+    for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
+      for (size_t i = 0; i < num_clusters_; ++i) {
+        for (size_t j = 0; j < num_clusters_; ++j) {
+          auto sub_begin = subspace * sub_dimension_;
+          auto sub_end = (subspace + 1) * sub_dimension_;
+          auto sub_distance = sub_sum_of_squares(
+              centroids_[i], centroids_[j], sub_begin, sub_end);
+          distance_tables_[subspace](i, j) = sub_distance;
+        }
+      }
+    }
+  }
+
+  auto add(const ColMajorMatrix<feature_type>& feature_vectors) {
+    pq_vectors_ = std::move(ColMajorMatrix<code_type>(
+        num_subspaces_, num_vectors(feature_vectors)));
+
+    for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
+      auto sub_begin = sub_dimension_ * subspace;
+      auto sub_end = sub_dimension_ * (subspace + 1);
+
+      auto x = detail::flat::qv_partition(
+          centroids_,
+          feature_vectors,
+          num_threads_,
+          sub_sum_of_squares_distance{sub_begin, sub_end});
+
+      for (size_t i = 0; i < num_vectors(feature_vectors); ++i) {
+        pq_vectors_(subspace, i) = x[i];
+
+        // Debugging
+        std::vector<float> a(
+            begin(feature_vectors[i]), end(feature_vectors[i]));
+        std::vector<float> b{begin(pq_vectors_[i]), end(pq_vectors_[i])};
+        // std::vector<float> c{begin(centroids_[i]), end(centroids_[i])};
+        auto foo = 0;
+      }
+    }
+  }
+
+  float sub_distance_symmetric(auto&& a, auto&& b) {
+    float pq_distance = 0.0;
+    for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
+      auto i = a[subspace];
+      auto j = b[subspace];
+
+      auto sub_distance = distance_tables_[subspace](i, j);
+      pq_distance += sub_distance;
+    }
+    return pq_distance;
+  }
+
+  auto make_pq_distance_symmetric() {
+    using A = decltype(pq_vectors_[0]);
+    using B = decltype(pq_vectors_[0]);
+    struct pq_distance {
+      flatpq_index* outer_;
+      inline float operator()(const A& a, const B& b) {
+        return outer_->sub_distance_symmetric(a, b);
+      }
+    };
+    return pq_distance{this};
+  }
+
+  /**
+   *
+   * @param a The uncompressed vector
+   * @param b The compressed vector
+   * @return
+   */
+  float sub_distance_asymmetric(auto&& a, auto&& b) {
+    float pq_distance = 0.0;
+
+    for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
+      auto sub_begin = subspace * sub_dimension_;
+      auto sub_end = (subspace + 1) * sub_dimension_;
+      auto i = b[subspace];
+
+      pq_distance += sub_sum_of_squares(a, centroids_[i], sub_begin, sub_end);
+    }
+
+    return pq_distance;
+  }
+
+  auto make_pq_distance_asymmetric() {
+    // using A = decltype(centroids_[0]);
+    using A = std::span<feature_type>;  // @todo: Don't hardcode span
+    using B = decltype(pq_vectors_[0]);
+
+    // @todo Do we need to worry about function overhead here?
+    struct pq_distance {
+      flatpq_index* outer_;
+      inline float operator()(const A& a, const B& b) {
+        return outer_->sub_distance_asymmetric(a, b);
+      }
+    };
+    return pq_distance{this};
+  }
+
+  template <feature_vector_array Q>
+  auto asymmetric_query(const Q& query_vectors, size_t k_nn) {
+    return detail::flat::qv_query_heap(
+        pq_vectors_,
+        query_vectors,
+        k_nn,
+        num_threads_,
+        make_pq_distance_asymmetric());
+  }
+
+  template <feature_vector_array Q>
+  auto symmetric_query(const Q& query_vectors, size_t k_nn) {
+    auto encoded_query = encode(query_vectors);
+    return detail::flat::qv_query_heap(
+        pq_vectors_,
+        encoded_query,
+        k_nn,
+        num_threads_,
+        make_pq_distance_symmetric());
+  }
+
+  template <feature_vector V, feature_vector W>
+  auto encode(const V& v, W&& pq) {
+    for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
+      auto sub_begin = sub_dimension_ * subspace;
+      auto sub_end = sub_begin + sub_dimension_;
+
+      auto min_score = std::numeric_limits<score_type>::max();
+      code_type idx{0};
+      for (size_t i = 0; i < num_vectors(centroids_); ++i) {
+        auto score = sub_sum_of_squares(v, centroids_[i], sub_begin, sub_end);
+        if (score < min_score) {
+          min_score = score;
+          idx = i;
+        }
+      }
+      pq[subspace] = idx;
+    }
+  }
+
+  template <feature_vector V>
+  auto encode(const V& v) {
+    // auto pq = Vector<score_type>(num_subspaces_);
+    auto pq = std::vector<code_type>(num_subspaces_);
+    encode(v, pq);
+    return pq;
+  }
+
+  template <feature_vector_array V>
+  auto encode(const V& v) {
+    auto pq = ColMajorMatrix<code_type>(num_subspaces_, num_vectors(v));
+    for (size_t i = 0; i < num_vectors(pq); ++i) {
+      encode(v[i], std::move(pq[i]));
+    }
+
+    return pq;
+  }
+
+  template <class F = feature_type, feature_vector PQ>
+  auto decode(const PQ& pq) {
+    using local_feature_type = F;
+    // auto un_pq = Vector<local_feature_type>(dimension_);
+    auto un_pq = std::vector<local_feature_type>(dimension_);
+
+    for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
+      auto sub_begin = subspace * sub_dimension_;
+      auto sub_end = (subspace + 1) * sub_dimension_;
+      auto i = pq[subspace];
+
+      // Copy the centroid into the appropriate subspace portion of the
+      // decoded vector
+      for (size_t j = sub_begin; j < sub_end; ++j) {
+        un_pq[j] = centroids_(j, i);
+      }
+    }
+    return un_pq;
+  }
+
+  auto write_index(const std::string& group_uri, bool overwrite) {
+    tiledb::Context ctx;
+    tiledb::VFS vfs(ctx);
+    if (vfs.is_dir(group_uri)) {
+      if (overwrite == false) {
+        return false;
+      }
+      vfs.remove_dir(group_uri);
+    }
+
+    tiledb::Config cfg;
+    tiledb::Group::create(ctx, group_uri);
+    auto write_group = tiledb::Group(ctx, group_uri, TILEDB_WRITE, cfg);
+
+    for (auto&& [name, value, type] : metadata) {
+      write_group.put_metadata(name, type, 1, value);
+    }
+
+    // ColMajorMatrix<centroid_feature_type> centroids_;
+    // std::vector<ColMajorMatrix<score_type>> distance_tables_;
+    // ColMajorMatrix<code_type> pq_vectors_;
+
+    auto centroids_uri = group_uri + "/centroids";
+    write_matrix(ctx, centroids_, centroids_uri);
+    write_group.add_member("centroids", true, "centroids");
+
+    auto pq_vectors_uri = group_uri + "/pq_vectors";
+    write_matrix(ctx, pq_vectors_, pq_vectors_uri);
+    write_group.add_member("pq_vectors", true, "pq_vectors");
+
+    for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
+      std::ostringstream oss;
+      oss << std::setw(2) << std::setfill('0') << subspace;
+      std::string number = oss.str();
+
+      auto distance_table_uri = group_uri + "/distance_table_" + number;
+      write_matrix(ctx, distance_tables_[subspace], distance_table_uri);
+      write_group.add_member(
+          "distance_table_" + number, true, "distance_table_" + number);
+    }
+    write_group.close();
+    return true;
+  }
+
+  /***************************************************************************
+   * Methods to aid Testing and Debugging
+   **************************************************************************/
+
+  /**
+   * @brief Verify that the pq encoding is correct by comparing every feature
+   * vector against the corresponding pq encoded value
+   * @param feature_vectors
+   * @return
+   */
+  auto verify_pq_encoding(const ColMajorMatrix<feature_type>& feature_vectors) {
+    double total_distance = 0.0;
+    double total_normalizer = 0.0;
+
+    // debug_slice(centroids_, "verify pq encoding centroids");
+    // debug_slice(feature_vectors, "verify pq encoding feature vectors");
+
+    auto debug_vectors =
+        ColMajorMatrix<float>(dimension_, num_vectors(feature_vectors));
+
+    for (size_t i = 0; i < num_vectors(feature_vectors); ++i) {
+      auto re = std::vector<float>(dimension_);
+      for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
+        auto sub_begin = sub_dimension_ * subspace;
+        auto sub_end = sub_dimension_ * (subspace + 1);
+        auto centroid = centroids_[pq_vectors_(subspace, i)];
+
+        std::vector<float> x(
+            begin(feature_vectors[i]), end(feature_vectors[i]));
+
+        // Reconstruct the encoded vector
+        for (size_t j = sub_begin; j < sub_end; ++j) {
+          re[j] = centroid[j];
+        }
+      }
+      // std::copy(begin(re), end(re), begin(debug_vectors[i]));
+
+      // Measure the distance between the original vector and the reconstructed
+      // vector and accumulate into the total distance as well as the total
+      // weight of the feature vector
+      auto distance = sum_of_squares(feature_vectors[i], re);
+      total_distance += distance;
+      total_normalizer += sum_of_squares(feature_vectors[i]);
+    }
+    // debug_slice(debug_vectors, "verify pq encoding re");
+
+    // Return the total accumulated distance between the encoded and original
+    // vectors, divided by the total weight of the original feature vectors
+    return total_distance / total_normalizer;
+  }
+
+  /**
+   * @brief Verify that recorded distances between centroids are correct by
+   * comparing the distance between every pair of pq vectors against the
+   * distance between every pair of the original feature vectors.
+   * @param feature_vectors
+   * @return
+   */
+  auto verify_pq_distances(
+      const ColMajorMatrix<feature_type>& feature_vectors) {
+    double total_diff = 0.0;
+    double total_normalizer = 0.0;
+
+    for (size_t i = 0; i < num_vectors(feature_vectors); ++i) {
+      for (size_t j = i + 1; j < num_vectors(feature_vectors); ++j) {
+        auto real_distance =
+            sum_of_squares(feature_vectors[i], feature_vectors[j]);
+        total_normalizer += real_distance;
+        auto pq_distance = 0.0;
+
+        for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
+          auto sub_distance = distance_tables_[subspace](
+              pq_vectors_(subspace, i), pq_vectors_(subspace, j));
+          pq_distance += sub_distance;
+        }
+
+        auto diff = std::abs(real_distance - pq_distance);
+        total_diff += diff;
+      }
+    }
+
+    return total_diff / total_normalizer;
+  }
+
+  auto verify_asymmetric_pq_distances(
+      const ColMajorMatrix<feature_type>& feature_vectors) {
+    double total_diff = 0.0;
+    double total_normalizer = 0.0;
+
+    score_type diff_max = 0.0;
+    score_type vec_max = 0.0;
+    for (size_t i = 0; i < num_vectors(feature_vectors); ++i) {
+      for (size_t j = i + 1; j < num_vectors(feature_vectors); ++j) {
+        auto real_distance =
+            sum_of_squares(feature_vectors[i], feature_vectors[j]);
+        total_normalizer += real_distance;
+
+        auto pq_distance =
+            this->sub_distance_asymmetric(feature_vectors[i], pq_vectors_[j]);
+
+        auto diff = std::abs(real_distance - pq_distance);
+        diff_max = std::max(diff_max, diff);
+        total_diff += diff;
+      }
+      vec_max = std::max(vec_max, sum_of_squares(feature_vectors[i]));
+    }
+
+    return std::make_tuple(diff_max / vec_max, total_diff / total_normalizer);
+  }
+
+  auto verify_symmetric_pq_distances(
+      const ColMajorMatrix<feature_type>& feature_vectors) {
+    double total_diff = 0.0;
+    double total_normalizer = 0.0;
+
+    score_type diff_max = 0.0;
+    score_type vec_max = 0.0;
+    for (size_t i = 0; i < num_vectors(feature_vectors); ++i) {
+      for (size_t j = i + 1; j < num_vectors(feature_vectors); ++j) {
+        auto real_distance =
+            sum_of_squares(feature_vectors[i], feature_vectors[j]);
+        total_normalizer += real_distance;
+
+        auto pq_distance =
+            this->sub_distance_symmetric(pq_vectors_[i], pq_vectors_[j]);
+
+        auto diff = std::abs(real_distance - pq_distance);
+        diff_max = std::max(diff_max, diff);
+        total_diff += diff;
+      }
+      vec_max = std::max(vec_max, sum_of_squares(feature_vectors[i]));
+    }
+
+    return std::make_tuple(diff_max / vec_max, total_diff / total_normalizer);
+  }
+
+  /**
+   * @brief Compare the metadata information between two flatpq_index
+   * @param rhs
+   * @return
+   */
+  bool compare_metadata(const flatpq_index& rhs) {
+    if (dimension_ != rhs.dimension_) {
+      std::cout << "dimension_ " << dimension_ << " != " << rhs.dimension_
+                << std::endl;
+      return false;
+    }
+    if (num_subspaces_ != rhs.num_subspaces_) {
+      std::cout << "num_subspaces_ " << num_subspaces_
+                << " != " << rhs.num_subspaces_ << std::endl;
+      return false;
+    }
+    if (sub_dimension_ != rhs.sub_dimension_) {
+      std::cout << "sub_dimension_ " << sub_dimension_
+                << " != " << rhs.sub_dimension_ << std::endl;
+      return false;
+    }
+    if (bits_per_subspace_ != rhs.bits_per_subspace_) {
+      std::cout << "bits_per_subspace_ " << bits_per_subspace_
+                << " != " << rhs.bits_per_subspace_ << std::endl;
+      return false;
+    }
+    if (num_clusters_ != rhs.num_clusters_) {
+      std::cout << "num_clusters_ " << num_clusters_
+                << " != " << rhs.num_clusters_ << std::endl;
+      return false;
+    }
+    if (tol_ != rhs.tol_) {
+      std::cout << "tol_ " << tol_ << " != " << rhs.tol_ << std::endl;
+      return false;
+    }
+    if (max_iter_ != rhs.max_iter_) {
+      std::cout << "max_iter_ " << max_iter_ << " != " << rhs.max_iter_
+                << std::endl;
+      return false;
+    }
+    if (num_threads_ != rhs.num_threads_) {
+      std::cout << "num_threads_ " << num_threads_ << " != " << rhs.num_threads_
+                << std::endl;
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * @brief Compare the pq vectors information between two flatpq_index
+   * @param rhs
+   * @return
+   */
+  auto compare_pq_vectors(const flatpq_index& rhs) {
+    // @todo use std::equal
+    if (pq_vectors_.size() != rhs.pq_vectors_.size() ||
+        num_vectors(pq_vectors_) != num_vectors(rhs.pq_vectors_)) {
+      std::cout << "pq_vectors_.size() " << pq_vectors_.size()
+                << " != " << rhs.pq_vectors_.size() << std::endl;
+      return false;
+    }
+    for (size_t i = 0; i < num_vectors(pq_vectors_); ++i) {
+      if (!std::equal(
+              begin(pq_vectors_[i]),
+              end(pq_vectors_[i]),
+              begin(rhs.pq_vectors_[i]))) {
+        std::cout << "pq_vectors_[" << i << "] != rhs.pq_vectors_[" << i << "]"
+                  << std::endl;
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * @brief Compare the centroids information between two flatpq_index
+   * @param rhs
+   * @return
+   */
+  auto compare_centroids(const flatpq_index& rhs) {
+    // @todo use std::equal
+    if (centroids_.size() != rhs.centroids_.size() ||
+        num_vectors(centroids_) != num_vectors(rhs.centroids_)) {
+      std::cout << "centroids_.size() " << centroids_.size()
+                << " != " << rhs.centroids_.size() << std::endl;
+      return false;
+    }
+    for (size_t i = 0; i < num_vectors(centroids_); ++i) {
+      if (!std::equal(
+              begin(centroids_[i]),
+              end(centroids_[i]),
+              begin(rhs.centroids_[i]))) {
+        std::cout << "centroids_[" << i << "] != rhs.centroids_[" << i << "]"
+                  << std::endl;
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * @brief Compare the distance table information between two flatpq_index
+   * @param rhs
+   * @return
+   */
+  auto compare_distance_tables(const flatpq_index& rhs) {
+    if (distance_tables_.size() != rhs.distance_tables_.size()) {
+      std::cout << "distance_tables_.size() " << distance_tables_.size()
+                << " != " << rhs.distance_tables_.size() << std::endl;
+      return false;
+    }
+    for (size_t i = 0; i < distance_tables_.size(); ++i) {
+      if (distance_tables_[i] != rhs.distance_tables_[i]) {
+        std::cout << "distance_tables_[" << i << "] != rhs.distance_tables_["
+                  << i << "]" << std::endl;
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+#endif  // TILEDB_FLATPQ_INDEX_

--- a/src/include/index/flatpq_index.h
+++ b/src/include/index/flatpq_index.h
@@ -118,7 +118,6 @@ auto sub_kmeans(
     size_t max_iter,
     size_t num_threads,
     float reassign_ratio = 0.05) {
-
   size_t sub_dimension_ = sub_end - sub_begin;
 
   std::vector<size_t> degrees(num_clusters, 0);
@@ -261,7 +260,6 @@ template <
     class shuffled_ids_type = size_t,
     class indices_type = size_t>
 class flatpq_index {
-
   using feature_type = T;
   using id_type = shuffled_ids_type;
   using score_type = float;
@@ -327,14 +325,12 @@ class flatpq_index {
           "Number of subspaces must evenly divide dimension of vector");
     }
     sub_dimension_ = dimension_ / num_subspaces_;
-
   }
 
   /**
    * Load constructor
    */
   flatpq_index(tiledb::Context ctx, const std::string& group_uri) {
-
     tiledb::Config cfg;
     auto read_group = tiledb::Group(ctx, group_uri, TILEDB_READ, cfg);
 
@@ -498,7 +494,6 @@ class flatpq_index {
   }
 
   auto make_pq_distance_asymmetric() {
-
     using A = std::span<feature_type>;  // @todo: Don't hardcode span
     using B = decltype(pq_vectors_[0]);
 

--- a/src/include/test/CMakeLists.txt
+++ b/src/include/test/CMakeLists.txt
@@ -80,6 +80,8 @@ kmeans_add_test(unit_execution_policy)
 
 kmeans_add_test(unit_fixed_min_heap)
 
+kmeans_add_test(unit_flatpq_index)
+
 kmeans_add_test(unit_flat_l2_index)
 
 kmeans_add_test(unit_flat_qv)

--- a/src/include/test/unit_flatpq_index.cc
+++ b/src/include/test/unit_flatpq_index.cc
@@ -1,0 +1,855 @@
+/**
+ * @file   unit_flatpq_index.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ */
+
+#include <catch2/catch_all.hpp>
+#include <cmath>
+
+#include "array_defs.h"
+#include "detail/flat/qv.h"
+#include "gen_graphs.h"
+#include "index/flatpq_index.h"
+#include "query_common.h"
+#include "scoring.h"
+
+TEST_CASE("flatpq_index: test test", "[flatpq_index]") {
+  REQUIRE(true);
+}
+
+TEST_CASE(
+    "flatpq_index: flat qv_partition with sub distance", "[flatpq_index]") {
+  {
+    auto sub_sift_base =
+        ColMajorMatrix<sift_feature_type>(2, num_vectors(sift_base));
+    for (size_t i = 0; i < num_vectors(sift_base); i++) {
+      for (size_t j = 0; j < 2; j++) {
+        sub_sift_base(j, i) = sift_base(j, i);
+      }
+    }
+    auto sub_sift_query =
+        ColMajorMatrix<sift_feature_type>(2, num_vectors(sift_query));
+    for (size_t i = 0; i < num_vectors(sift_query); i++) {
+      for (size_t j = 0; j < 2; j++) {
+        sub_sift_query(j, i) = sift_query(j, i);
+      }
+    }
+
+    auto aa = detail::flat::qv_partition(sub_sift_base, sub_sift_query, 1);
+    auto bb = detail::flat::qv_partition(
+        sub_sift_base, sub_sift_query, 1, sum_of_squares_distance{});
+    auto cc = detail::flat::qv_partition(
+        sift_base, sift_query, 1, sub_sum_of_squares_distance{0, 2});
+    CHECK(std::equal(aa.begin(), aa.end(), bb.begin()));
+    CHECK(std::equal(aa.begin(), aa.end(), cc.begin()));
+  }
+
+  {
+    auto sub_sift_base =
+        ColMajorMatrix<sift_feature_type>(2, num_vectors(sift_base));
+    for (size_t i = 0; i < num_vectors(sift_base); i++) {
+      for (size_t j = 1; j < 3; j++) {
+        sub_sift_base(j - 1, i) = sift_base(j, i);
+      }
+    }
+    auto sub_sift_query =
+        ColMajorMatrix<sift_feature_type>(2, num_vectors(sift_query));
+    for (size_t i = 0; i < num_vectors(sift_query); i++) {
+      for (size_t j = 1; j < 3; j++) {
+        sub_sift_query(j - 1, i) = sift_query(j, i);
+      }
+    }
+
+    auto aa = detail::flat::qv_partition(sub_sift_base, sub_sift_query, 1);
+    auto bb = detail::flat::qv_partition(
+        sub_sift_base, sub_sift_query, 1, sum_of_squares_distance{});
+    auto cc = detail::flat::qv_partition(
+        sift_base, sift_query, 1, sub_sum_of_squares_distance{1, 3});
+    CHECK(std::equal(aa.begin(), aa.end(), bb.begin()));
+    CHECK(std::equal(aa.begin(), aa.end(), cc.begin()));
+  }
+}
+
+TEST_CASE("flatpq_index: flat qv_partition hypercube", "[flatpq_index]") {
+  const bool debug = false;
+
+  size_t k_near = 8;
+  size_t k_far = 8;
+
+  auto hypercube0 = build_hypercube(k_near, k_far, 0xdeadbeef);
+  auto hypercube1 = build_hypercube(k_near, k_far, 0xdeadbeef);
+
+  auto init_centroids = ColMajorMatrix<float>(3, 8);
+  auto pre_centroids = ColMajorMatrix<float>(3, 8);
+  for (size_t i = 0; i < 8; i++) {
+    for (size_t j = 0; j < 3; j++) {
+      pre_centroids(j, i) = hypercube0(j, i) + 0.025 * (((i + j) % 2) - 0.5);
+      init_centroids(j, i) = pre_centroids(j, i);
+    }
+  }
+
+  auto hypercube2 = ColMajorMatrix<float>(6, num_vectors(hypercube0));
+  auto centroids2 = ColMajorMatrix<float>(6, 8);
+
+  for (size_t j = 0; j < 3; ++j) {
+    for (size_t i = 0; i < num_vectors(hypercube0); ++i) {
+      hypercube2(j, i) = hypercube0(j, i);
+      hypercube2(j + 3, i) = hypercube1(j, i);
+    }
+  }
+
+  for (size_t j = 0; j < 3; ++j) {
+    for (size_t i = 0; i < 8; ++i) {
+      centroids2(j, i) = init_centroids(j, i);
+      centroids2(j + 3, i) = init_centroids(j, i);
+    }
+  }
+
+  auto expected_centroids0 = ColMajorMatrix<float>(3, 8);
+  auto expected_centroids1 = ColMajorMatrix<float>(3, 8);
+  for (size_t i = 0; i < 8; i++) {
+    for (size_t j = 0; j < 3; j++) {
+      expected_centroids0(j, i) = init_centroids(j, i);
+      expected_centroids1(j, i) = init_centroids(j, i);
+    }
+  }
+
+  sub_kmeans(hypercube0, expected_centroids0, 0, 3, 8, 0.00, 10, 1);
+  sub_kmeans(hypercube1, expected_centroids1, 0, 3, 8, 0.00, 10, 1);
+
+  auto compare_centroids = [](auto&& a, auto&& b, size_t ba, size_t bb) {
+    for (size_t i = 0; i < 8; ++i) {
+      for (size_t j = 0; j < 3; ++j) {
+        CHECK(a(j + ba, i) == b(j + bb, i));
+      }
+    }
+  };
+
+  SECTION("print centroids2") {
+    if (debug) {
+      std::cout << "\ncentroids2" << std::endl;
+      for (size_t j = 0; j < 6; ++j) {
+        for (size_t i = 0; i < 8; ++i) {
+          std::cout << centroids2(j, i) << " ";
+        }
+        std::cout << std::endl;
+      }
+    }
+  }
+
+  SECTION("subspace = 3 (0)") {
+    sub_kmeans(hypercube0, init_centroids, 0, 3, 8, 0.00, 10, 1);
+    compare_centroids(expected_centroids0, init_centroids, 0, 0);
+
+    if (debug) {
+      std::cout << "\nsubspace = 3 (0)" << std::endl;
+
+      for (size_t j = 0; j < 3; ++j) {
+        for (size_t i = 0; i < 8; ++i) {
+          std::cout << init_centroids(j, i) << " ";
+        }
+        std::cout << std::endl;
+      }
+    }
+  }
+
+  SECTION("subspace = 3 (0) again") {
+    sub_kmeans(hypercube0, init_centroids, 0, 3, 8, 0.00, 10, 1);
+    compare_centroids(expected_centroids0, init_centroids, 0, 0);
+
+    if (debug) {
+      std::cout << "\nsubspace = 3 (0)" << std::endl;
+      for (size_t j = 0; j < 3; ++j) {
+        for (size_t i = 0; i < 8; ++i) {
+          std::cout << init_centroids(j, i) << " ";
+        }
+        std::cout << std::endl;
+      }
+    }
+  }
+
+  SECTION("subspace = 3 (1)") {
+    sub_kmeans(hypercube1, init_centroids, 0, 3, 8, 0.00, 10, 1);
+    compare_centroids(expected_centroids1, init_centroids, 0, 0);
+
+    if (debug) {
+      std::cout << "\nsubspace = 3 (1)" << std::endl;
+
+      for (size_t j = 0; j < 3; ++j) {
+        for (size_t i = 0; i < 8; ++i) {
+          std::cout << init_centroids(j, i) << " ";
+        }
+        std::cout << std::endl;
+      }
+    }
+  }
+
+  SECTION("subspace = 3,0") {
+    sub_kmeans(hypercube2, centroids2, 0, 3, 8, 0.000, 10, 1);
+    compare_centroids(expected_centroids0, centroids2, 0, 0);
+    compare_centroids(pre_centroids, centroids2, 0, 3);
+
+    if (debug) {
+      std::cout << "\nsubspace = 3,0" << std::endl;
+
+      for (size_t j = 0; j < 6; ++j) {
+        for (size_t i = 0; i < 8; ++i) {
+          std::cout << centroids2(j, i) << " ";
+        }
+        std::cout << std::endl;
+      }
+    }
+  }
+
+  SECTION("subspace = 0,3") {
+    sub_kmeans(hypercube2, centroids2, 3, 6, 8, 0.000, 10, 1);
+    compare_centroids(expected_centroids1, centroids2, 0, 3);
+    compare_centroids(pre_centroids, centroids2, 0, 0);
+
+    if (debug) {
+      std::cout << "\nsubspace = 0,3" << std::endl;
+      for (size_t j = 0; j < 6; ++j) {
+        for (size_t i = 0; i < 8; ++i) {
+          std::cout << centroids2(j, i) << " ";
+        }
+        std::cout << std::endl;
+      }
+    }
+  }
+
+  SECTION("subspace = 3,3") {
+    sub_kmeans(hypercube2, centroids2, 0, 3, 8, 0.000, 10, 1);
+    compare_centroids(pre_centroids, centroids2, 0, 3);
+    sub_kmeans(hypercube2, centroids2, 3, 6, 8, 0.000, 10, 1);
+    compare_centroids(expected_centroids0, centroids2, 0, 0);
+    compare_centroids(expected_centroids1, centroids2, 0, 3);
+
+    if (debug) {
+      std::cout << "\nsubspace = 3,3" << std::endl;
+
+      for (size_t j = 0; j < 6; ++j) {
+        for (size_t i = 0; i < 8; ++i) {
+          std::cout << centroids2(j, i) << " ";
+        }
+        std::cout << std::endl;
+      }
+    }
+  }
+
+  SECTION("subspace = 3,3 alt") {
+    sub_kmeans(hypercube2, centroids2, 3, 6, 8, 0.000, 10, 1);
+    compare_centroids(pre_centroids, centroids2, 0, 0);
+    sub_kmeans(hypercube2, centroids2, 0, 3, 8, 0.000, 10, 1);
+    compare_centroids(expected_centroids0, centroids2, 0, 0);
+    compare_centroids(expected_centroids1, centroids2, 0, 3);
+
+    if (debug) {
+      std::cout << "\nsubspace = 3,3" << std::endl;
+
+      for (size_t j = 0; j < 6; ++j) {
+        for (size_t i = 0; i < 8; ++i) {
+          std::cout << centroids2(j, i) << " ";
+        }
+        std::cout << std::endl;
+      }
+    }
+  }
+
+  SECTION("subspace = 6") {
+    sub_kmeans(hypercube2, centroids2, 0, 6, 8, 0.00, 10, 1);
+    compare_centroids(expected_centroids0, centroids2, 0, 0);
+    compare_centroids(expected_centroids1, centroids2, 0, 3);
+
+    if (debug) {
+      std::cout << "\nsubspace = 6" << std::endl;
+
+      for (size_t j = 0; j < 6; ++j) {
+        for (size_t i = 0; i < 8; ++i) {
+          std::cout << centroids2(j, i) << " ";
+        }
+        std::cout << std::endl;
+      }
+    }
+  }
+}
+
+TEST_CASE("normalize matrix", "[flatpq_index]") {
+  const bool debug = false;
+
+  auto hypercube = build_hypercube<float>(2, 2, 0xdeadbeef);
+  auto normalized = normalize_matrix(hypercube);
+
+  if (debug) {
+    debug_slice(hypercube);
+    debug_slice(normalized);
+  }
+}
+
+TEMPLATE_TEST_CASE(
+    "flatpq_index: create flatpq_index", "[flatpq_index]", float, uint8_t) {
+  auto pq_idx = flatpq_index<TestType, uint32_t, uint32_t>(128, 16, 8);
+  REQUIRE(true);
+}
+
+TEMPLATE_TEST_CASE(
+    "flatpq_index: train flatpq_index", "[flatpq_index]", float, uint8_t) {
+  size_t k_near = 32;
+  size_t k_far = 32;
+
+  auto hypercube = build_hypercube<TestType>(k_near, k_far, 0xdeadbeef);
+
+  auto pq_idx = flatpq_index<TestType, uint32_t, uint32_t>(3, 1, 8);
+  pq_idx.train(hypercube);
+
+  REQUIRE(true);
+}
+
+TEMPLATE_TEST_CASE(
+    "flatpq_index: add flatpq_index", "[flatpq_index]", float, uint8_t) {
+  size_t k_near = 32;
+  size_t k_far = 32;
+
+  auto hypercube = build_hypercube<TestType>(k_near, k_far, 0xdeadbeef);
+
+  auto pq_idx = flatpq_index<TestType, uint32_t, uint32_t>(3, 1, 8);
+  pq_idx.train(hypercube);
+  pq_idx.add(hypercube);
+
+  REQUIRE(true);
+}
+
+TEMPLATE_TEST_CASE(
+    "flatpq_index: verify flatpq_index encoding with hypercube",
+    "[flatpq_index]",
+    float,
+    uint8_t) {
+  size_t k_near = 0;
+  size_t k_far = 0;
+
+  auto hypercube = build_hypercube<TestType>(k_near, k_far, 0xdeadbeef);
+
+  auto pq_idx = flatpq_index<TestType, uint32_t, uint32_t>(3, 1, 8, 8);
+  pq_idx.train(hypercube);
+  pq_idx.add(hypercube);
+  auto avg_error = pq_idx.verify_pq_encoding(hypercube);
+
+  CHECK(avg_error < 0.05);
+}
+
+TEMPLATE_TEST_CASE(
+    "flatpq_index: verify flatpq_index encoding with stacked hypercube",
+    "[flatpq_index]",
+    float,
+    uint8_t) {
+  /*
+   * Note -- Reassignment breaks this small example if k_near and k_far
+   * are equal to zero because some of the centroids are duplicates of one
+   * another, and so the span of the centroid space is much less than the
+   * number of clusters
+   */
+  size_t k_near = 32;
+  size_t k_far = 32;
+
+  auto hypercube0 = build_hypercube<TestType>(k_near, k_far, 0xdeadbeef);
+  auto hypercube1 = build_hypercube<TestType>(k_near, k_far, 0xbeefdead);
+
+  auto hypercube2 = ColMajorMatrix<TestType>(6, num_vectors(hypercube0));
+  auto hypercube4 = ColMajorMatrix<TestType>(12, num_vectors(hypercube0));
+
+  for (size_t j = 0; j < 3; ++j) {
+    for (size_t i = 0; i < num_vectors(hypercube4); ++i) {
+      hypercube2(j, i) = hypercube0(j, i);
+      hypercube2(j + 3, i) = hypercube1(j, i);
+      hypercube4(j, i) = hypercube0(j, i);
+      hypercube4(j + 3, i) = hypercube1(j, i);
+      hypercube4(j + 6, i) = hypercube0(j, i);
+      hypercube4(j + 9, i) = hypercube1(j, i);
+    }
+  }
+
+  auto pq_idx2 = flatpq_index<TestType, uint32_t, uint32_t>(6, 2, 8, 32);
+  pq_idx2.train(hypercube2);
+  pq_idx2.add(hypercube2);
+  auto pq_idx4 = flatpq_index<TestType, uint32_t, uint32_t>(12, 4, 8, 32);
+  pq_idx4.train(hypercube4);
+  pq_idx4.add(hypercube4);
+
+  SECTION("pq_encoding") {
+    auto avg_error2 = pq_idx2.verify_pq_encoding(hypercube2);
+    CHECK(avg_error2 < 0.01);
+    auto avg_error4 = pq_idx4.verify_pq_encoding(hypercube4);
+    CHECK(avg_error4 < 0.01);
+  }
+
+  SECTION("pq_distances") {
+    auto avg_error2 = pq_idx2.verify_pq_distances(hypercube2);
+    CHECK(avg_error2 < 0.1);
+    auto avg_error4 = pq_idx4.verify_pq_distances(hypercube4);
+    CHECK(avg_error4 < 0.1);
+  }
+
+  SECTION("asymmetric_pq_distances") {
+    auto [max_error2, avg_error2] =
+        pq_idx2.verify_asymmetric_pq_distances(hypercube2);
+    CHECK(avg_error2 < 0.075);
+    auto [max_erro4, avg_error4] =
+        pq_idx4.verify_asymmetric_pq_distances(hypercube4);
+    CHECK(avg_error4 < 0.075);
+  }
+
+  SECTION("symmetric_pq_distances") {
+    auto [max_error2, avg_error2] =
+        pq_idx2.verify_symmetric_pq_distances(hypercube2);
+    CHECK(avg_error2 < 0.1);
+    auto [max_erro4, avg_error4] =
+        pq_idx4.verify_symmetric_pq_distances(hypercube4);
+    CHECK(avg_error4 < 0.1);
+  }
+}
+
+TEST_CASE(
+    "flatpq_index: verify pq_encoding and pq_distances with siftsmall",
+    "[flatpq_index]") {
+  tiledb::Context ctx;
+  auto training_set = tdbColMajorMatrix<siftsmall_feature_type>(
+      ctx, siftsmall_inputs_uri, 2500);
+  training_set.load();
+
+  auto pq_idx = flatpq_index<
+      siftsmall_feature_type,
+      siftsmall_ids_type,
+      siftsmall_indices_type>(128, 16, 8, 50);
+  pq_idx.train(training_set);
+  pq_idx.add(training_set);
+
+  SECTION("pq_encoding") {
+    auto avg_error = pq_idx.verify_pq_encoding(training_set);
+    CHECK(avg_error < 0.08);
+  }
+  SECTION("pq_distances") {
+    auto avg_error = pq_idx.verify_pq_distances(training_set);
+    CHECK(avg_error < 0.15);
+  }
+  SECTION("asymmetric_pq_distances") {
+    auto [max_error, avg_error] =
+        pq_idx.verify_asymmetric_pq_distances(training_set);
+    CHECK(avg_error < 0.08);
+  }
+  SECTION("symmetric_pq_distances") {
+    auto [max_error, avg_error] =
+        pq_idx.verify_symmetric_pq_distances(training_set);
+    CHECK(avg_error < 0.15);
+  }
+}
+
+TEMPLATE_TEST_CASE(
+    "flatpq_index: query stacked hypercube", "[flatpq_index]", float, uint8_t) {
+  size_t k_dist = GENERATE(/*0,*/ 32);
+  size_t k_near = k_dist;
+  size_t k_far = k_dist;
+
+  auto hypercube0 = build_hypercube<TestType>(k_near, k_far, 0xdeadbeef);
+  auto hypercube1 = build_hypercube<TestType>(k_near, k_far, 0xbeefdead);
+
+  auto hypercube2 = ColMajorMatrix<TestType>(6, num_vectors(hypercube0));
+  auto hypercube4 = ColMajorMatrix<TestType>(12, num_vectors(hypercube0));
+
+  for (size_t j = 0; j < 3; ++j) {
+    for (size_t i = 0; i < num_vectors(hypercube4); ++i) {
+      hypercube2(j, i) = hypercube0(j, i);
+      hypercube2(j + 3, i) = hypercube1(j, i);
+
+      hypercube4(j, i) = hypercube0(j, i);
+      hypercube4(j + 3, i) = hypercube1(j, i);
+      hypercube4(j + 6, i) = hypercube0(j, i);
+      hypercube4(j + 9, i) = hypercube1(j, i);
+    }
+  }
+
+  auto pq_idx2 =
+      flatpq_index<TestType, uint32_t, uint32_t>(6, 2, 8, k_dist == 0 ? 8 : 16);
+  pq_idx2.train(hypercube2);
+  pq_idx2.add(hypercube2);
+
+  auto pq_idx4 = flatpq_index<TestType, uint32_t, uint32_t>(
+      12, 4, 8, k_dist == 0 ? 8 : 16);
+  pq_idx4.train(hypercube4);
+  pq_idx4.add(hypercube4);
+
+  using enc_type = std::tuple<std::vector<TestType>, std::vector<uint8_t>>;
+  auto expected = std::vector<enc_type>{
+      {{127, 127, 127, 127, 127, 127}, {0, 0}},
+      {{127, 127, 127, 0, 0, 0}, {0, 1}},
+      {{127, 127, 0, 0, 0, 127}, {4, 2}},
+      {{0, 127, 0, 127, 127, 127}, {7, 0}},
+      {{127, 127, 127, 0, 127, 0}, {0, 7}},
+      {{127, 0, 0, 95, 31, 95}, {3, 6}},
+      {{95, 31, 95, 0, 127, 127}, {6, 5}},
+  };
+
+  SECTION("Test sub_distance_*symmetric, hypercube2") {
+    for (auto&& [vx, pqx] : expected) {
+      // asymmetric (vx, pqx)
+      // asymmetric (decode(pqx), encode(vx))
+      // symmetric (encode(vx), pqx)
+      // sum_of_squares(vx, decode(pqx))
+
+      // symmetric (encode(vx), decode(encode(pqx))
+      // asymmetric (decode(encode(vx)), pqx)
+      // sum_of_squares (decode(encode(vx)), decode(pqx))
+      // sum_of_squares (decode(encode(vx)), vx);
+
+      auto a_vx_pqx2 = pq_idx2.sub_distance_asymmetric(vx, pqx);
+      auto a_dpqx_evx2 = pq_idx2.sub_distance_asymmetric(
+          pq_idx2.decode(pqx), pq_idx2.encode(vx));
+      auto s_evx_pqx2 = pq_idx2.sub_distance_symmetric(pq_idx2.encode(vx), pqx);
+      auto ss_vx_dpqx2 = sum_of_squares(vx, pq_idx2.decode(pqx));
+      auto s_evx_edpqx2 = pq_idx2.sub_distance_symmetric(
+          pq_idx2.encode(vx), pq_idx2.encode(pq_idx2.decode(pqx)));
+      auto a_evx_edpqx2 = pq_idx2.sub_distance_asymmetric(
+          pq_idx2.decode(pq_idx2.encode(vx)), pqx);
+      auto ss_devx_dpqx2 = sum_of_squares(
+          pq_idx2.decode(pq_idx2.encode(vx)), pq_idx2.decode(pqx));
+      auto ss_devx_vx2 = sum_of_squares(pq_idx2.decode(pq_idx2.encode(vx)), vx);
+
+      auto scale = sum_of_squares(vx);
+      if (a_vx_pqx2 > 1) {
+        scale *= a_vx_pqx2;
+      }
+
+      CHECK(a_vx_pqx2 / scale < 0.00005);
+      CHECK(a_dpqx_evx2 / scale < 0.00005);
+      CHECK(s_evx_pqx2 / scale < 0.00005);
+      CHECK(ss_vx_dpqx2 / scale < 0.00005);
+      CHECK(s_evx_edpqx2 / scale < 0.00005);
+      CHECK(a_evx_edpqx2 / scale < 0.00005);
+      CHECK(ss_devx_dpqx2 / scale < 0.00005);
+      CHECK(ss_devx_vx2 / scale < 0.000075);
+    }
+  }
+
+  // Need to implement with its own expected four-element set
+#if 0
+  SECTION("Test sub_distance_*symmetric, hypercube4") {
+    for (auto&& [vx, pqx] : expected) {
+      auto a_vx_pqx4 = pq_idx4.sub_distance_asymmetric(vx, pqx);
+      auto a_dpqx_evx4 = pq_idx4.sub_distance_asymmetric(
+          pq_idx4.decode(pqx), pq_idx4.encode(vx));
+      auto s_evx_pqx4 = pq_idx4.sub_distance_symmetric(pq_idx4.encode(vx), pqx);
+      auto ss_vx_dpqx4 = sum_of_squares(vx, pq_idx4.decode(pqx));
+      auto s_evx_edpqx4 = pq_idx4.sub_distance_symmetric(
+          pq_idx4.encode(vx), pq_idx4.encode(pq_idx4.decode(pqx)));
+      auto a_evx_edpqx4 = pq_idx4.sub_distance_symmetric(
+          pq_idx4.decode(pq_idx4.encode(vx)), pqx);
+      auto ss_devx_dpqx4 = sum_of_squares(
+          pq_idx4.decode(pq_idx4.encode(vx)), pq_idx4.decode(pqx));
+      auto ss_devx_vx4 = sum_of_squares(pq_idx4.decode(pq_idx4.encode(vx)), vx);
+
+      auto scale = sum_of_squares(vx);
+      if (a_vx_pqx4 > 1) {
+        scale *= a_vx_pqx4;
+      }
+
+      REQUIRE(scale > 0);
+      REQUIRE(!std::isnan(scale));
+
+      CHECK(!std::isnan(a_vx_pqx4));
+      CHECK(!std::isnan(a_dpqx_evx4));
+      CHECK(!std::isnan(s_evx_pqx4));
+      CHECK(!std::isnan(ss_vx_dpqx4));
+      CHECK(!std::isnan(s_evx_edpqx4));
+      CHECK(!std::isnan(a_evx_edpqx4));
+      CHECK(!std::isnan(ss_devx_dpqx4));
+      CHECK(!std::isnan(ss_devx_vx4));
+
+      CHECK(!std::isnan(a_vx_pqx4 / scale));
+      CHECK(!std::isnan(a_dpqx_evx4 / scale));
+      CHECK(!std::isnan(s_evx_pqx4 / scale));
+      CHECK(!std::isnan(ss_vx_dpqx4 / scale));
+      CHECK(!std::isnan(s_evx_edpqx4 / scale));
+      CHECK(!std::isnan(a_evx_edpqx4 / scale));
+      CHECK(!std::isnan(ss_devx_dpqx4 / scale));
+      CHECK(!std::isnan(ss_devx_vx4 / scale));
+
+      CHECK(a_vx_pqx4 / scale < 0.0005);
+      CHECK(a_dpqx_evx4 / scale < 0.0005);
+      CHECK(s_evx_pqx4 / scale < 0.0005);
+      CHECK(ss_vx_dpqx4 / scale < 0.0005);
+      CHECK(s_evx_edpqx4 / scale < 0.0005);
+      CHECK(a_evx_edpqx4 / scale < 0.0005);
+      CHECK(ss_devx_dpqx4 / scale < 0.0005);
+      CHECK(ss_devx_vx4 / scale < 0.0005);
+    }
+  }
+#endif
+
+// Add CHECKs / REQUIREs?
+#if 0
+  SECTION("Test asymmetric query 2") {
+    auto query = ColMajorMatrix<TestType>{{0, 0, 0, 0, 0, 0}};
+    auto&& [top_k_pq_scores, top_k_pq] = pq_idx2.asymmetric_query(query, 4);
+
+    auto&& [top_k_scores, top_k] = detail::flat::qv_query_heap(
+        hypercube2, query, 4, 8, sum_of_squares_distance{});
+
+    for (size_t i = 0; i < num_vectors(top_k); ++i) {
+      std::sort(begin(top_k[i]), end(top_k[i]));
+      for (size_t j = 0; j < top_k.num_rows(); ++j) {
+        std::cout << top_k(j, i) << " ";
+      }
+      std::cout << std::endl;
+    }
+    for (size_t i = 0; i < num_vectors(top_k); ++i) {
+      std::sort(begin(top_k_pq[i]), end(top_k_pq[i]));
+      for (size_t j = 0; j < top_k.num_rows(); ++j) {
+        std::cout << top_k_pq(j, i) << " ";
+      }
+      std::cout << std::endl;
+    }
+    for (size_t i = 0; i < num_vectors(top_k); ++i) {
+      std::sort(begin(top_k_scores[i]), end(top_k_scores[i]));
+      for (size_t j = 0; j < top_k.num_rows(); ++j) {
+        std::cout << top_k_scores(j, i) << " ";
+      }
+      std::cout << std::endl;
+    }
+    for (size_t i = 0; i < num_vectors(top_k); ++i) {
+      std::sort(begin(top_k_pq_scores[i]), end(top_k_pq_scores[i]));
+      for (size_t j = 0; j < top_k.num_rows(); ++j) {
+        std::cout << top_k_pq_scores(j, i) << " ";
+      }
+      std::cout << std::endl;
+    }
+  }
+
+  SECTION("Test query 4") {
+    auto query =
+        ColMajorMatrix<TestType>{{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}};
+    auto&& [top_k_pq_scores, top_k_pq] = pq_idx4.query(query, 8);
+
+    auto&& [top_k_scores, top_k] = detail::flat::qv_query_heap(
+        hypercube4, query, 8, 8, sum_of_squares_distance{});
+
+    for (size_t i = 0; i < num_vectors(top_k); ++i) {
+      std::sort(begin(top_k[i]), end(top_k[i]));
+      for (size_t j = 0; j < top_k.num_rows(); ++j) {
+        std::cout << top_k(j, i) << " ";
+      }
+      std::cout << std::endl;
+    }
+    for (size_t i = 0; i < num_vectors(top_k); ++i) {
+      std::sort(begin(top_k_pq[i]), end(top_k_pq[i]));
+      for (size_t j = 0; j < top_k.num_rows(); ++j) {
+        std::cout << top_k_pq(j, i) << " ";
+      }
+      std::cout << std::endl;
+    }
+    for (size_t i = 0; i < num_vectors(top_k); ++i) {
+      std::sort(begin(top_k_scores[i]), end(top_k_scores[i]));
+      for (size_t j = 0; j < top_k.num_rows(); ++j) {
+        std::cout << top_k_scores(j, i) << " ";
+      }
+      std::cout << std::endl;
+    }
+    for (size_t i = 0; i < num_vectors(top_k); ++i) {
+      std::sort(begin(top_k_pq_scores[i]), end(top_k_pq_scores[i]));
+      for (size_t j = 0; j < top_k.num_rows(); ++j) {
+        std::cout << top_k_pq_scores(j, i) << " ";
+      }
+      std::cout << std::endl;
+    }
+  }
+#endif
+}
+
+TEST_CASE("flatpq_index: query siftsmall", "[flatpq_index]") {
+  const bool debug = false;
+
+  auto k_nn = 10;
+
+  tiledb::Context ctx;
+  auto training_set =
+      tdbColMajorMatrix<siftsmall_feature_type>(ctx, siftsmall_inputs_uri, 0);
+  training_set.load();
+
+  auto query_set =
+      tdbColMajorMatrix<siftsmall_feature_type>(ctx, siftsmall_query_uri, 0);
+  query_set.load();
+
+  auto groundtruth_set = tdbColMajorMatrix<siftsmall_groundtruth_type>(
+      ctx, siftsmall_groundtruth_uri, 0);
+  groundtruth_set.load();
+
+  auto&& [top_k_scores, top_k] = detail::flat::qv_query_heap(
+      training_set, query_set, k_nn, 1, sum_of_squares_distance{});
+
+  auto pq_idx = flatpq_index<
+      siftsmall_feature_type,
+      siftsmall_ids_type,
+      siftsmall_indices_type>(128, 16, 8, 256);
+  pq_idx.train(training_set);
+  pq_idx.add(training_set);
+
+  SECTION("asymmetric") {
+    auto&& [top_k_pq_scores, top_k_pq] = pq_idx.asymmetric_query(query_set, 10);
+
+    auto intersections0 = (long)count_intersections(top_k_pq, top_k, k_nn);
+    double recall0 = intersections0 / ((double)top_k.num_cols() * k_nn);
+    CHECK(recall0 > 0.7);
+
+    auto intersections1 =
+        (long)count_intersections(top_k_pq, groundtruth_set, k_nn);
+    double recall1 = intersections1 / ((double)top_k_pq.num_cols() * k_nn);
+    CHECK(recall1 > 0.7);
+
+    if (debug) {
+      std::cout << "Recall: " << recall0 << " " << recall1 << std::endl;
+    }
+  }
+
+  SECTION("symmetric") {
+    auto&& [top_k_pq_scores, top_k_pq] = pq_idx.symmetric_query(query_set, 10);
+
+    auto intersections0 = (long)count_intersections(top_k_pq, top_k, k_nn);
+    double recall0 = intersections0 / ((double)top_k.num_cols() * k_nn);
+    CHECK(recall0 > 0.6);
+
+    auto intersections1 =
+        (long)count_intersections(top_k_pq, groundtruth_set, k_nn);
+    double recall1 = intersections1 / ((double)top_k_pq.num_cols() * k_nn);
+    CHECK(recall1 > 0.6);
+
+    if (debug) {
+      std::cout << "Recall: " << recall0 << " " << recall1 << std::endl;
+    }
+  }
+}
+
+TEST_CASE("flatpq_index: query 1M", "[flatpq_index]") {
+  const bool debug = false;
+
+  auto num_vectors = num_bigann1M_vectors;
+  auto num_queries = 100;
+  auto k_nn = 10;
+
+  tiledb::Context ctx;
+  auto training_set = tdbColMajorMatrix<bigann1M_feature_type>(
+      ctx, bigann1M_inputs_uri, num_vectors);
+  training_set.load();
+
+  auto query_set = tdbColMajorMatrix<bigann1M_feature_type>(
+      ctx, bigann1M_query_uri, num_queries);
+  query_set.load();
+
+  auto groundtruth_set = tdbColMajorMatrix<bigann1M_groundtruth_type>(
+      ctx, siftsmall_groundtruth_uri, num_queries);
+  groundtruth_set.load();
+
+  auto&& [top_k_scores, top_k] = detail::flat::qv_query_heap(
+      training_set, query_set, k_nn, 8, sum_of_squares_distance{});
+
+  auto pq_idx = flatpq_index<
+      bigann1M_feature_type,
+      bigann1M_ids_type,
+      bigann1M_indices_type>(128, 16, 8, 256);
+  pq_idx.train(training_set);
+  pq_idx.add(training_set);
+
+  SECTION("asymmetric") {
+    auto&& [top_k_pq_scores, top_k_pq] = pq_idx.asymmetric_query(query_set, 10);
+
+    auto intersections0 = (long)count_intersections(top_k_pq, top_k, k_nn);
+    double recall0 = intersections0 / ((double)top_k.num_cols() * k_nn);
+
+    if (debug) {
+      std::cout << "Recall: " << recall0 << std::endl;
+    }
+    CHECK(recall0 > 0.65);
+  }
+
+  SECTION("symmetric") {
+    auto&& [top_k_pq_scores, top_k_pq] = pq_idx.symmetric_query(query_set, 10);
+
+    auto intersections0 = (long)count_intersections(top_k_pq, top_k, k_nn);
+    double recall0 = intersections0 / ((double)top_k.num_cols() * k_nn);
+
+    if (debug) {
+      std::cout << "Recall: " << recall0 << std::endl;
+    }
+    CHECK(recall0 > 0.55);
+  }
+
+  SECTION("asymmetric") {
+    auto&& [top_k_pq_scores, top_k_pq] = pq_idx.asymmetric_query(query_set, 10);
+
+    auto intersections0 = (long)count_intersections(top_k_pq, top_k, k_nn);
+    double recall0 = intersections0 / ((double)top_k.num_cols() * k_nn);
+
+    if (debug) {
+      std::cout << "Recall: " << recall0 << std::endl;
+    }
+    CHECK(recall0 > 0.65);
+  }
+}
+
+TEST_CASE("flatpq_index: flatpq_index write and read", "[flatpq_index]") {
+  const bool debug = false;
+
+  size_t dimension_{128};
+  size_t num_subspaces_{16};
+  size_t bits_per_subspace_{8};
+  size_t num_clusters_{256};
+
+  tiledb::Context ctx;
+  std::string flatpq_index_uri = "/tmp/tmp_flatpq_index";
+  auto training_set =
+      tdbColMajorMatrix<siftsmall_feature_type>(ctx, siftsmall_inputs_uri, 0);
+  load(training_set);
+
+  auto idx = flatpq_index<
+      siftsmall_feature_type,
+      siftsmall_ids_type,
+      siftsmall_indices_type>(
+      dimension_, num_subspaces_, bits_per_subspace_, num_clusters_);
+  idx.train(training_set);
+  idx.add(training_set);
+
+  idx.write_index(flatpq_index_uri, true);
+  auto idx2 = flatpq_index<
+      siftsmall_feature_type,
+      siftsmall_ids_type,
+      siftsmall_indices_type>(ctx, flatpq_index_uri);
+
+  CHECK(idx.compare_metadata(idx2));
+
+  CHECK(idx.compare_pq_vectors(idx2));
+  CHECK(idx.compare_centroids(idx2));
+  CHECK(idx.compare_distance_tables(idx2));
+  auto foo = 0;
+}


### PR DESCRIPTION
This PR moves over the initial implementation of the `flatpq_index` class as originally implemented in lums/[sc-32521](https://app.shortcut.com/tiledb-inc/story/32521)/pq and in PR #153.

### Product Quantization

Product quantization (pq) is a method for compressing vectors in a vector database.  The basic idea is to divide the vectors into some number of subvectors and then to use the nearest centroid to each subvector to represent the original vector.  Since there are a fixed number of actual centroids, we only need to store the index of the centroid.  
For example, if we have 256 centroids, we can represent each centroid with an 8-bit index.  If we subdivide a vector into, say, eight subvectors, we can represent each subvector with 8bits, for a total of 64bits for the entire vector.  If the original vector comprised 128 floats, this is a compression of (128 * 32 ) / 64 -- a factor of 64. 

In addition to space savings, distance computation can also be greatly accelerated.  If we are using the "L2" distance -- which is really the sum of squares -- the distance between two vectors is the sum of the distance between each of its subvectors.  Since each subvector is represented by the index of the nearest centroid, we can store those distances in a lookup table and access them with a simple lookup.

The tutorial at https://www.pinecone.io/learn/series/faiss/product-quantization/ explains the general idea of product quantization in more detail.

### `flatpq_index`

To realize PQ in TileDB-Vector-Search, we implement the following:
* The `flatpq_index` constructor defines the number of subvectors and bits per subvector (equivalent to the number of centroids).
* `train()` runs a kmeans algorithm to compute the centroids for each subspace.  Each subspace has its own set of centroids.  For each subspace, a 2D table is created holding the distance between each pair of centroids in the subspace.
* `add()` takes a set of input vectors and runs `qv_partition` on each subspace to obtain the codes.
* `symmetri_query()` first encodes the query vectors and then calls `flat::qv_query_heap` on the encoded queries, using the symmetric pq distance function defined in the class.  They symmetric distance function uses the lookup tables for computing distances.
* `asymmetric_query()` calls `flat::qv_query_heap` directly on the query vectors, using the asymmetric pq distance function defined in the class.  The asymmetric distance function decodes the encoded vector and computes the distance in the normal fashion.
* `write_index` saves the index information.  This needs to be brought up to speed by defining index group and index metadata classes.  
* The "loading" constructor reads an index -- it also needs to be brought up to speed.
