### PR TITLE
Fix `pip install` in the `generate_backwards_compatibility_data` CI job

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -44,7 +44,7 @@ jobs:
           echo $release_tag
 
           # Install dependencies.
-          cd apis/python && pip install . && cd ../..
+          pip install .
 
           # Generate data.
           python backwards-compatibility-data/generate_data.py $release_tag


### PR DESCRIPTION
### What
We don't change to `apis/python` now when we run `pip install .`. Fix that in the `generate_backwards_compatibility_data` CI job.

### Testing
None, but I think it will work.