### PR TITLE
Add an API for `externals_ids` to `IndexVamana`

### DIFF
--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -254,10 +254,18 @@ void init_type_erased_module(py::module_& m) {
             auto args = kwargs_to_map(kwargs);
             new (&instance) IndexVamana(args);
           })
-      // TODO(paris): Update train()/add() to take `const std::optional<FeatureVectorArray>& external_ids`. Failing with this currently:
-      // TypeError: train(): incompatible function arguments. The following argument types are supported:
-      //     1. (self: tiledb.vector_search._tiledbvspy.IndexVamana, vectors: tiledb.vector_search._tiledbvspy.FeatureVectorArray, external_ids: std::__1::optional<FeatureVectorArray> = None) -> None
-      // Invoked with: <tiledb.vector_search._tiledbvspy.IndexVamana object at 0x10efbc330>, <tiledb.vector_search._tiledbvspy.FeatureVectorArray object at 0x10efbc370>, <tiledb.vector_search._tiledbvspy.FeatureVectorArray object at 0x10efbc370>
+      // TODO(paris): Update train()/add() to take `const
+      // std::optional<FeatureVectorArray>& external_ids`. Failing with this
+      // currently: TypeError: train(): incompatible function arguments. The
+      // following argument types are supported:
+      //     1. (self: tiledb.vector_search._tiledbvspy.IndexVamana, vectors:
+      //     tiledb.vector_search._tiledbvspy.FeatureVectorArray, external_ids:
+      //     std::__1::optional<FeatureVectorArray> = None) -> None
+      // Invoked with: <tiledb.vector_search._tiledbvspy.IndexVamana object at
+      // 0x10efbc330>, <tiledb.vector_search._tiledbvspy.FeatureVectorArray
+      // object at 0x10efbc370>,
+      // <tiledb.vector_search._tiledbvspy.FeatureVectorArray object at
+      // 0x10efbc370>
       .def(
           "train",
           [](IndexVamana& index, const FeatureVectorArray& vectors) {
@@ -266,7 +274,9 @@ void init_type_erased_module(py::module_& m) {
           py::arg("vectors"))
       .def(
           "train_with_ids",
-          [](IndexVamana& index, const FeatureVectorArray& vectors, const FeatureVector& external_ids) {
+          [](IndexVamana& index,
+             const FeatureVectorArray& vectors,
+             const FeatureVector& external_ids) {
             index.train_with_ids(vectors, external_ids);
           },
           py::arg("vectors"),
@@ -279,7 +289,9 @@ void init_type_erased_module(py::module_& m) {
           py::arg("vectors"))
       .def(
           "add_with_ids",
-          [](IndexVamana& index, const FeatureVectorArray& vectors, const FeatureVector& external_ids) {
+          [](IndexVamana& index,
+             const FeatureVectorArray& vectors,
+             const FeatureVector& external_ids) {
             index.add_with_ids(vectors, external_ids);
           },
           py::arg("vectors"),

--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -34,8 +34,6 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/complex.h>
-#include <pybind11/chrono.h>
 
 #include "api/feature_vector.h"
 #include "api/feature_vector_array.h"
@@ -222,7 +220,6 @@ void init_type_erased_module(py::module_& m) {
         return v;
       }));
 
-  // TODO(paris): Add support for external_ids.
   py::class_<IndexFlatL2>(m, "IndexFlatL2")
       .def(py::init<const tiledb::Context&, const std::string&>())
       .def("add", &IndexFlatL2::add)

--- a/src/include/api/feature_vector.h
+++ b/src/include/api/feature_vector.h
@@ -64,6 +64,16 @@ class FeatureVector {
    * @param size
    * @param dtype
    */
+  FeatureVector(size_t N, tiledb_datatype_t dtype) {
+    feature_type_ = dtype;
+    vector_from_datatype(N);
+  }
+
+  /**
+   * @brief Construct from a dtype string and size.
+   * @param size
+   * @param dtype
+   */
   FeatureVector(size_t N, const std::string& dtype) {
     feature_type_ = string_to_datatype(dtype);
     vector_from_datatype(N);

--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -216,13 +216,17 @@ class IndexVamana {
     dimension_ = index_->dimension();
   }
 
+  void train(const FeatureVectorArray& training_set) {
+    train_with_ids(training_set, FeatureVector(0, id_datatype_));
+  }
+
   /**
    * @brief Train the index based on the given training set.
    * @param training_set
    * @param init
    */
   // @todo -- infer feature type from input
-  void train(const FeatureVectorArray& training_set) {
+  void train_with_ids(const FeatureVectorArray& training_set, const FeatureVector& external_ids) {
     if (feature_datatype_ == TILEDB_ANY) {
       feature_datatype_ = training_set.feature_type();
     } else if (feature_datatype_ != training_set.feature_type()) {
@@ -299,11 +303,15 @@ class IndexVamana {
     dimension_ = index_->dimension();
   }
 
+  void add(const FeatureVectorArray& data_set) {
+    add_with_ids(data_set, FeatureVector(0, id_datatype_));
+  }
+
   /**
    * @brief Add a set of vectors to a trained index.
    * @param data_set
    */
-  void add(const FeatureVectorArray& data_set) {
+  void add_with_ids(const FeatureVectorArray& data_set, const FeatureVector& external_ids) {
     if (feature_datatype_ != data_set.feature_type()) {
       throw std::runtime_error(
           "Feature datatype mismatch: " +

--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -226,7 +226,9 @@ class IndexVamana {
    * @param init
    */
   // @todo -- infer feature type from input
-  void train_with_ids(const FeatureVectorArray& training_set, const FeatureVector& external_ids) {
+  void train_with_ids(
+      const FeatureVectorArray& training_set,
+      const FeatureVector& external_ids) {
     if (feature_datatype_ == TILEDB_ANY) {
       feature_datatype_ = training_set.feature_type();
     } else if (feature_datatype_ != training_set.feature_type()) {
@@ -311,7 +313,8 @@ class IndexVamana {
    * @brief Add a set of vectors to a trained index.
    * @param data_set
    */
-  void add_with_ids(const FeatureVectorArray& data_set, const FeatureVector& external_ids) {
+  void add_with_ids(
+      const FeatureVectorArray& data_set, const FeatureVector& external_ids) {
     if (feature_datatype_ != data_set.feature_type()) {
       throw std::runtime_error(
           "Feature datatype mismatch: " +

--- a/src/include/index/ivf_flat_index.h
+++ b/src/include/index/ivf_flat_index.h
@@ -60,7 +60,7 @@
 #include "linalg.h"
 
 #include "detail/flat/qv.h"
-#include "detail/ivf/index.h"
+// #include "detail/ivf/index.h"
 #include "detail/ivf/partition.h"
 #include "detail/ivf/qv.h"
 

--- a/src/include/index/ivf_flat_index.h
+++ b/src/include/index/ivf_flat_index.h
@@ -60,7 +60,6 @@
 #include "linalg.h"
 
 #include "detail/flat/qv.h"
-// #include "detail/ivf/index.h"
 #include "detail/ivf/partition.h"
 #include "detail/ivf/qv.h"
 


### PR DESCRIPTION
### What
Follows the pattern of `IndexIVFFlat` and `IndexFlatL2` and adds a `add_with_ids` method to `IndexVamana`, as well as a `train_with_ids` method. The implementation is not done, but opening up this PR to see if we like this API. Next step will be the implementation.

Note that I actually wanted the API to be this:
```
.def("train",
    [](IndexVamana& index, const FeatureVectorArray& vectors, const std::optional<FeatureVectorArray>& external_ids) {
            index.train(vectors, external_ids);
          },
          py::arg("vectors"),
          py::arg_v("external_ids", std::nullopt, "None"))
```
But when I do that:
```
TypeError: train(): incompatible function arguments. The following argument types are supported:
       1. (self: tiledb.vector_search._tiledbvspy.IndexVamana, vectors: tiledb.vector_search._tiledbvspy.FeatureVectorArray, external_ids: std::__1::optional<FeatureVectorArray> = None) -> None
Invoked with: <tiledb.vector_search._tiledbvspy.IndexVamana object at 0x10efbc330>, <tiledb.vector_search._tiledbvspy.FeatureVectorArray object at 0x10efbc370>, <tiledb.vector_search._tiledbvspy.FeatureVectorArray object at 0x10efbc370>
```

So I figured I might as well keep moving forward, and if I figure out how to do this I can update the API.

Note that we also update `IndexVamana@query` to take in a `std::optional<size_t> opt_l`.

### Testing
* Adds a unit test.