### PR TITLE
Draft: Fix Path to String conversions

### DIFF
--- a/src/include/api/feature_vector_array.h
+++ b/src/include/api/feature_vector_array.h
@@ -68,6 +68,12 @@ class FeatureVectorArray {
     feature_size_ = datatype_to_size(feature_type_);
   }
 
+    FeatureVectorArray(
+      const tiledb::Context& ctx,
+      const std::filesystem::path& uri,
+      size_t num_vectors = 0) : FeatureVectorArray(ctx, uri.string(), num_vectors) {
+    }
+
   FeatureVectorArray(
       const tiledb::Context& ctx,
       const std::string& uri,

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -66,6 +66,7 @@
 #include <type_traits>
 #include <vector>
 #include <version>
+#include <algorithm>
 
 #include <tiledb/tiledb>
 #include "mdspan/mdspan.hpp"

--- a/src/include/index/index_group.h
+++ b/src/include/index/index_group.h
@@ -130,8 +130,8 @@ class base_index_group {
     }
     for (auto&& [array_key, array_name] : storage_formats[version_]) {
       valid_key_names_.insert(array_key);
-      valid_array_names_.insert(array_name);
-      array_name_map_[array_key] = array_name;
+      valid_array_names_.insert(array_name.string());
+      array_name_map_[array_key] = array_name.string();
     }
     static_cast<group_type*>(this)->append_valid_array_names_impl();
   }
@@ -166,11 +166,12 @@ class base_index_group {
    */
   void init_for_open(const tiledb::Config& cfg) {
     tiledb::VFS vfs(cached_ctx_);
-    if (!vfs.is_dir(group_uri_)) {
+    if (!vfs.is_dir(group_uri_.string())) {
       throw std::runtime_error(
-          "Group uri " + std::string(group_uri_) + " does not exist.");
+          "Group uri " + group_uri_.string() + " does not exist.");
     }
-    auto read_group = tiledb::Group(cached_ctx_, group_uri_, TILEDB_READ, cfg);
+    auto read_group =
+        tiledb::Group(cached_ctx_, group_uri_.string(), TILEDB_READ, cfg);
 
     // Load the metadata and check the version.  We need to do this before
     // we can check the array names.
@@ -249,7 +250,7 @@ class base_index_group {
   void open_for_write(const tiledb::Config& cfg) {
     tiledb::VFS vfs(cached_ctx_);
 
-    if (vfs.is_dir(group_uri_)) {
+    if (vfs.is_dir(group_uri_.string())) {
       /** Load the current group metadata */
       init_for_open(cfg);
       if (index_timestamp_ < metadata_.ingestion_timestamps_.back()) {
@@ -282,7 +283,7 @@ class base_index_group {
 
   /** Convert an array key to a uri. */
   constexpr std::string array_key_to_uri(const std::string& array_key) const {
-    return group_uri_ / array_key_to_array_name(array_key);
+    return (group_uri_ / array_key_to_array_name(array_key)).string();
   }
 
  public:
@@ -351,7 +352,7 @@ class base_index_group {
     if (opened_for_ == TILEDB_WRITE) {
       auto cfg = tiledb::Config();
       auto write_group =
-          tiledb::Group(cached_ctx_, group_uri_, TILEDB_WRITE, cfg);
+          tiledb::Group(cached_ctx_, group_uri_.string(), TILEDB_WRITE, cfg);
       metadata_.store_metadata(write_group);
     }
   }

--- a/src/include/index/ivf_flat_group.h
+++ b/src/include/index/ivf_flat_group.h
@@ -97,8 +97,8 @@ class ivf_flat_index_group
   void append_valid_array_names_impl() {
     for (auto&& [array_key, array_name] : ivf_flat_storage_formats[version_]) {
       valid_key_names_.insert(array_key);
-      valid_array_names_.insert(array_name);
-      array_name_map_[array_key] = array_name;
+      valid_array_names_.insert(array_name.string());
+      array_name_map_[array_key] = array_name.string();
     }
   }
 
@@ -137,11 +137,11 @@ class ivf_flat_index_group
         (int32_t)(tile_size_bytes / sizeof(typename index_type::feature_type) /
                   this->get_dimension())};
     static const tiledb_filter_type_t default_compression{
-        string_to_filter(storage_formats[version_]["default_attr_filters"])};
+        string_to_filter(storage_formats[version_]["default_attr_filters"].string())};
 
-    tiledb::Group::create(cached_ctx_, group_uri_);
+    tiledb::Group::create(cached_ctx_, group_uri_.string());
     auto write_group =
-        tiledb::Group(cached_ctx_, group_uri_, TILEDB_WRITE, cfg);
+        tiledb::Group(cached_ctx_, group_uri_.string(), TILEDB_WRITE, cfg);
 
     this->metadata_.storage_version_ = version_;
 

--- a/src/include/test/unit_api_feature_vector_array.cc
+++ b/src/include/test/unit_api_feature_vector_array.cc
@@ -46,22 +46,22 @@ TEST_CASE("api_feature_vector_array: test test", "[api_feature_vector_array]") {
 TEST_CASE("api: feature vector array open", "[api]") {
   tiledb::Context ctx;
 
-  auto a = FeatureVectorArray(ctx, sift_inputs_uri);
+  auto a = FeatureVectorArray(ctx, sift_inputs_uri.string());
   CHECK(a.feature_type() == TILEDB_FLOAT32);
   CHECK(dimension(a) == 128);
   CHECK(num_vectors(a) == num_sift_vectors);
 
-  auto b = FeatureVectorArray(ctx, bigann1M_inputs_uri);
+  auto b = FeatureVectorArray(ctx, bigann1M_inputs_uri.string());
   CHECK(b.feature_type() == TILEDB_UINT8);
   CHECK(dimension(b) == 128);
   CHECK(num_vectors(b) == num_bigann1M_vectors);
 
-  auto c = FeatureVectorArray(ctx, fmnist_inputs_uri);
+  auto c = FeatureVectorArray(ctx, fmnist_inputs_uri.string());
   CHECK(c.feature_type() == TILEDB_FLOAT32);
   CHECK(dimension(c) == 784);
   CHECK(num_vectors(c) == num_fmnist_vectors);
 
-  auto d = FeatureVectorArray(ctx, sift_inputs_uri);
+  auto d = FeatureVectorArray(ctx, sift_inputs_uri.string());
   CHECK(d.feature_type() == TILEDB_FLOAT32);
   CHECK(dimension(d) == 128);
   CHECK(num_vectors(d) == num_sift_vectors);
@@ -199,7 +199,7 @@ TEST_CASE("api: query checks", "[api][index]") {
   size_t num_queries = 50;
 
   SECTION("simple check") {
-    auto z = FeatureVectorArray(ctx, sift_inputs_uri);
+    auto z = FeatureVectorArray(ctx, sift_inputs_uri.string());
     auto nn = dimension(z);
     auto nnn = num_vectors(z);
     CHECK(dimension(z) == 128);
@@ -207,17 +207,18 @@ TEST_CASE("api: query checks", "[api][index]") {
   }
 
   SECTION("tdbMatrix") {
-    auto ck = tdbColMajorMatrix<float>(ctx, sift_inputs_uri);
+    auto ck = tdbColMajorMatrix<float>(ctx, sift_inputs_uri.string());
     ck.load();
 
-    auto qk = tdbColMajorMatrix<float>(ctx, sift_query_uri, num_queries);
+    auto qk =
+        tdbColMajorMatrix<float>(ctx, sift_query_uri.string(), num_queries);
     load(qk);
 
     auto [ck_scores, ck_top_k] =
         detail::flat::qv_query_heap(ck, qk, k_nn, nthreads);
 
     auto gk =
-        tdbColMajorMatrix<test_groundtruth_type>(ctx, sift_groundtruth_uri);
+        tdbColMajorMatrix<test_groundtruth_type>(ctx, sift_groundtruth_uri.string());
     load(gk);
 
     auto ok = validate_top_k(ck_top_k, gk);

--- a/src/include/test/unit_api_flat_l2_index.cc
+++ b/src/include/test/unit_api_flat_l2_index.cc
@@ -43,7 +43,7 @@ TEST_CASE("api_flat_l2_index: test test", "[api_flat_l2_index]") {
 
 TEST_CASE("api: flat_l2_index", "[api][flat_l2_index]") {
   tiledb::Context ctx;
-  auto a = IndexFlatL2(ctx, fmnist_inputs_uri);
+  auto a = IndexFlatL2(ctx, fmnist_inputs_uri.string());
   // auto b = Index(ctx, fmnist_inputs_uri, IndexKind::FlatL2);
   // auto c = Index(ctx, fmnist_inputs_uri, IndexKind::IVFFlat);
 }
@@ -52,27 +52,27 @@ TEST_CASE(
     "api: uri flat_l2_index constructors, context", "[api][flat_l2_index]") {
   tiledb::Context ctx;
 
-  auto a = IndexFlatL2(ctx, sift_inputs_uri);
+  auto a = IndexFlatL2(ctx, sift_inputs_uri.string());
   CHECK(a.feature_type() == TILEDB_FLOAT32);
   CHECK(dimension(a) == sift_dimension);
   CHECK(num_vectors(a) == num_sift_vectors);
 
-  auto b = IndexFlatL2(ctx, bigann1M_inputs_uri);
+  auto b = IndexFlatL2(ctx, bigann1M_inputs_uri.string());
   CHECK(b.feature_type() == TILEDB_UINT8);
   CHECK(dimension(b) == bigann1M_dimension);
   CHECK(num_vectors(b) == num_bigann1M_vectors);
 
-  auto c = IndexFlatL2(ctx, fmnist_inputs_uri);
+  auto c = IndexFlatL2(ctx, fmnist_inputs_uri.string());
   CHECK(c.feature_type() == TILEDB_FLOAT32);
   CHECK(dimension(c) == fmnist_dimension);
   CHECK(num_vectors(c) == num_fmnist_vectors);
 
-  auto d = IndexFlatL2(ctx, sift_inputs_uri);
+  auto d = IndexFlatL2(ctx, sift_inputs_uri.string());
   CHECK(d.feature_type() == TILEDB_FLOAT32);
   CHECK(dimension(d) == sift_dimension);
   CHECK(num_vectors(d) == num_sift_vectors);
 
-  auto e = IndexFlatL2(ctx, siftsmall_inputs_uri);
+  auto e = IndexFlatL2(ctx, siftsmall_inputs_uri.string());
   CHECK(d.feature_type() == TILEDB_FLOAT32);
   CHECK(dimension(d) == siftsmall_dimension);
   CHECK(num_vectors(d) == num_siftsmall_vectors);
@@ -81,27 +81,27 @@ TEST_CASE(
 TEST_CASE(
     "api: uri flat_l2_index constructors, no context", "[api][flat_l2_index]") {
   tiledb::Context ctx;
-  auto a = IndexFlatL2(ctx, sift_inputs_uri);
+  auto a = IndexFlatL2(ctx, sift_inputs_uri.string());
   CHECK(a.feature_type() == TILEDB_FLOAT32);
   CHECK(dimension(a) == sift_dimension);
   CHECK(num_vectors(a) == num_sift_vectors);
 
-  auto b = IndexFlatL2(ctx, bigann1M_inputs_uri);
+  auto b = IndexFlatL2(ctx, bigann1M_inputs_uri.string());
   CHECK(b.feature_type() == TILEDB_UINT8);
   CHECK(dimension(b) == bigann1M_dimension);
   CHECK(num_vectors(b) == num_bigann1M_vectors);
 
-  auto c = IndexFlatL2(ctx, fmnist_inputs_uri);
+  auto c = IndexFlatL2(ctx, fmnist_inputs_uri.string());
   CHECK(c.feature_type() == TILEDB_FLOAT32);
   CHECK(dimension(c) == fmnist_dimension);
   CHECK(num_vectors(c) == num_fmnist_vectors);
 
-  auto d = IndexFlatL2(ctx, sift_inputs_uri);
+  auto d = IndexFlatL2(ctx, sift_inputs_uri.string());
   CHECK(d.feature_type() == TILEDB_FLOAT32);
   CHECK(dimension(d) == sift_dimension);
   CHECK(num_vectors(d) == num_sift_vectors);
 
-  auto e = IndexFlatL2(ctx, siftsmall_inputs_uri);
+  auto e = IndexFlatL2(ctx, siftsmall_inputs_uri.string());
   CHECK(e.feature_type() == TILEDB_FLOAT32);
   CHECK(dimension(e) == siftsmall_dimension);
   CHECK(num_vectors(e) == num_siftsmall_vectors);
@@ -113,25 +113,25 @@ TEST_CASE("api: queries", "[api][flat_l2_index]") {
   size_t nthreads = 8;
   size_t num_queries = 50;
   auto sift_test_tuple = std::make_tuple(
-      sift_inputs_uri,
-      sift_groundtruth_uri,
-      sift_query_uri,
+      sift_inputs_uri.string(),
+      sift_groundtruth_uri.string(),
+      sift_query_uri.string(),
       TILEDB_FLOAT32,
       sift_dimension,
       num_sift_vectors);
 
   auto bigann1M_tuple = std::make_tuple(
-      bigann1M_inputs_uri,
-      bigann1M_groundtruth_uri,
-      bigann1M_query_uri,
+      bigann1M_inputs_uri.string(),
+      bigann1M_groundtruth_uri.string(),
+      bigann1M_query_uri.string(),
       TILEDB_UINT8,
       bigann1M_dimension,
       num_bigann1M_vectors);
 
   auto fmnist_tuple = std::make_tuple(
-      fmnist_inputs_uri,
-      fmnist_groundtruth_uri,
-      fmnist_query_uri,
+      fmnist_inputs_uri.string(),
+      fmnist_groundtruth_uri.string(),
+      fmnist_query_uri.string(),
       TILEDB_FLOAT32,
       fmnist_dimension,
       num_fmnist_vectors);

--- a/src/include/test/unit_api_ivf_flat_index.cc
+++ b/src/include/test/unit_api_ivf_flat_index.cc
@@ -135,7 +135,7 @@ TEST_CASE(
   auto a = IndexIVFFlat(std::make_optional<IndexOptions>(
       {{"id_type", "uint32"}, {"px_type", "uint32"}}));
   auto ctx = tiledb::Context{};
-  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri.string());
   a.train(training_set, kmeans_init::random);
   CHECK(a.feature_type() == TILEDB_FLOAT32);
   CHECK(a.id_type() == TILEDB_UINT32);
@@ -147,7 +147,7 @@ TEST_CASE(
   auto a = IndexIVFFlat(std::make_optional<IndexOptions>(
       {{"id_type", "uint32"}, {"px_type", "uint32"}}));
   auto ctx = tiledb::Context{};
-  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri.string());
   CHECK(dimension(a) == 0);
   a.train(training_set, kmeans_init::random);
   CHECK(a.feature_type() == TILEDB_FLOAT32);
@@ -166,7 +166,7 @@ TEST_CASE(
       {{"feature_type", "float32"},
        {"id_type", "uint32"},
        {"px_type", "uint32"}}));
-  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri.string());
   a.train(training_set, kmeans_init::random);
   a.add(training_set);
   a.write_index(ctx, api_ivf_flat_index_uri, true);
@@ -188,9 +188,9 @@ TEST_CASE(
 
   auto a = IndexIVFFlat(std::make_optional<IndexOptions>(
       {{"id_type", "uint32"}, {"px_type", "uint32"}}));
-  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-  auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
-  auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
+  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri.string());
+  auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri.string());
+  auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri.string());
   a.train(training_set, kmeans_init::random);
   a.add(training_set);
 

--- a/src/include/test/unit_vamana.cc
+++ b/src/include/test/unit_vamana.cc
@@ -65,7 +65,7 @@ TEST_CASE("vamana: diskann", "[vamana]") {
         diskann_mem_index,
         diskann_truth_disk_layout,
         diskann_truth_index_data}) {
-    CHECK(local_file_exists(s));
+    CHECK(local_file_exists(s.string()));
   }
 
   std::ifstream binary_file(diskann_mem_index, std::ios::binary);
@@ -96,7 +96,7 @@ TEST_CASE("vamana: diskann", "[vamana]") {
 
   binary_file.close();
 
-  auto g = read_diskann_mem_index(diskann_mem_index);
+  auto g = read_diskann_mem_index(diskann_mem_index.string());
   CHECK(g.size() == 256);
 
   for (size_t i = 0; i < g.size(); ++i) {
@@ -104,7 +104,7 @@ TEST_CASE("vamana: diskann", "[vamana]") {
   }
 
   auto h = read_diskann_mem_index_with_scores(
-      diskann_mem_index, diskann_test_data_file);
+      diskann_mem_index.string(), diskann_test_data_file.string());
   CHECK(h.size() == 256);
 
   for (size_t i = 0; i < h.size(); ++i) {
@@ -118,7 +118,7 @@ TEST_CASE("vamana: diskann", "[vamana]") {
         [](auto&& a, auto&& b) { return a == std::get<1>(b); }));
   }
 
-  auto f = read_diskann_data(diskann_test_data_file);
+  auto f = read_diskann_data(diskann_test_data_file.string());
   CHECK(f.num_cols() == 256);
   CHECK(f.num_rows() == 128);
   auto med = detail::graph::medioid(f);
@@ -128,9 +128,9 @@ TEST_CASE("vamana: diskann", "[vamana]") {
 
 TEST_CASE("vamana: small256 build index", "[vamana]") {
   auto vindex = detail::graph::vamana_index<float, uint32_t>(256, 50, 0);
-  auto x = read_diskann_data(diskann_test_data_file);
+  auto x = read_diskann_data(diskann_test_data_file.string());
   auto graph = read_diskann_mem_index_with_scores(
-      diskann_mem_index, diskann_test_data_file);
+      diskann_mem_index.string(), diskann_test_data_file.string());
 
   vindex.train(x);
 
@@ -499,7 +499,8 @@ TEST_CASE("vamana: fmnist", "[vamana]") {
   size_t N = 5000;
 
   tiledb::Context ctx;
-  auto db = tdbColMajorMatrix<test_feature_type>(ctx, fmnist_inputs_uri, N);
+  auto db =
+      tdbColMajorMatrix<test_feature_type>(ctx, fmnist_inputs_uri.string(), N);
   db.load();
   auto g = detail::graph::init_random_nn_graph<score_type, id_type>(db, L);
 
@@ -720,7 +721,8 @@ TEST_CASE("vamana: robust prune fmnist", "[vamana]") {
   float alpha = 1.0;
 
   tiledb::Context ctx;
-  auto db = tdbColMajorMatrix<test_feature_type>(ctx, fmnist_inputs_uri, N);
+  auto db =
+      tdbColMajorMatrix<test_feature_type>(ctx, fmnist_inputs_uri.string(), N);
   db.load();
   auto g = detail::graph::init_random_nn_graph<float, uint64_t>(db, L);
 
@@ -998,10 +1000,10 @@ TEST_CASE("vamana: vamana_index siftsmall", "[vamana]") {
 
   tiledb::Context ctx;
   auto training_set =
-      tdbColMajorMatrix<float>(ctx, siftsmall_inputs_uri, num_nodes);
+      tdbColMajorMatrix<float>(ctx, siftsmall_inputs_uri.string(), num_nodes);
   training_set.load();
   auto queries =
-      tdbColMajorMatrix<float>(ctx, siftsmall_query_uri, num_queries);
+      tdbColMajorMatrix<float>(ctx, siftsmall_query_uri.string(), num_queries);
   queries.load();
 
   auto idx = detail::graph::vamana_index<float, uint64_t>(
@@ -1034,7 +1036,8 @@ TEST_CASE("vamana: vamana_index write and read", "[vamana]") {
 
   tiledb::Context ctx;
   std::string vamana_index_uri = "/tmp/tmp_vamana_index";
-  auto training_set = tdbColMajorMatrix<float>(ctx, siftsmall_inputs_uri, 0);
+  auto training_set =
+      tdbColMajorMatrix<float>(ctx, siftsmall_inputs_uri.string(), 0);
   load(training_set);
 
   auto idx = detail::graph::vamana_index<float, uint64_t>(


### PR DESCRIPTION
This PR demonstrates how we could fix all path to string conversions since windows uses a different underlying string container for `std::filesystem::path` class.

This PR is just a draft, if this is something we want to include in the next release I will clean it up and simplify all changes.