### PR TITLE
Add a `MatrixWithIds` class

### DIFF
--- a/src/include/detail/linalg/matrix_with_ids.h
+++ b/src/include/detail/linalg/matrix_with_ids.h
@@ -31,19 +31,9 @@
  *
  */
 
-#ifndef TILEDB_MATRIX_WITH_ID_H
-#define TILEDB_MATRIX_WITH_ID_H
+#ifndef TILEDB_MATRIX_WITH_IDS_H
+#define TILEDB_MATRIX_WITH_IDS_H
 
-#include <cstddef>
-#include <initializer_list>
-#include <iostream>
-#include "concepts.h"
-#include "mdspan/mdspan.hpp"
-#include "tdb_defs.h"
-
-#include "utils/timer.h"
-
-#include <version>
 #include "detail/linalg/linalg_defs.h"
 #include "detail/linalg/matrix.h"
 
@@ -217,4 +207,4 @@ using RowMajorMatrixWithIds = MatrixWithIds<T, stdx::layout_right, I, IdsType>;
 template <class T, class I = size_t, class IdsType = size_t>
 using ColMajorMatrixWithIds = MatrixWithIds<T, stdx::layout_left, I, IdsType>;
 
-#endif  // TILEDB_MATRIX_WITH_ID_H
+#endif  // TILEDB_MATRIX_WITH_IDS_H

--- a/src/include/detail/linalg/matrix_with_ids.h
+++ b/src/include/detail/linalg/matrix_with_ids.h
@@ -1,0 +1,220 @@
+/**
+ * @file   matrix.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * A child class of Matrix that also holds IDs.
+ *
+ */
+
+#ifndef TILEDB_MATRIX_WITH_ID_H
+#define TILEDB_MATRIX_WITH_ID_H
+
+#include <cstddef>
+#include <initializer_list>
+#include <iostream>
+#include "concepts.h"
+#include "mdspan/mdspan.hpp"
+#include "tdb_defs.h"
+
+#include "utils/timer.h"
+
+#include <version>
+#include "detail/linalg/linalg_defs.h"
+#include "detail/linalg/matrix.h"
+
+/**
+ * @brief A 2-D matrix class that owns its storage and has an ID for either each
+ * row (if row-major) or each column (if column-major). The interface is that of
+ * mdspan.
+ *
+ * @tparam T
+ * @tparam LayoutPolicy
+ * @tparam I
+ *
+ */
+template <
+    class T,
+    class LayoutPolicy = stdx::layout_right,
+    class I = size_t,
+    class IdsType = size_t>
+class MatrixWithIds : public Matrix<T, LayoutPolicy, I> {
+ protected:
+  size_t num_ids_ = 0;
+  std::unique_ptr<IdsType[]> idsStorage_;
+
+ public:
+  MatrixWithIds() noexcept = default;
+
+  MatrixWithIds(const MatrixWithIds&) = delete;
+  MatrixWithIds& operator=(const MatrixWithIds&) = delete;
+
+  MatrixWithIds(MatrixWithIds&&) = default;
+
+  MatrixWithIds& operator=(MatrixWithIds&& rhs) = default;
+  virtual ~MatrixWithIds() = default;
+
+  MatrixWithIds(
+      Matrix<T, LayoutPolicy, I>::size_type nrows,
+      Matrix<T, LayoutPolicy, I>::size_type ncols,
+      LayoutPolicy policy = LayoutPolicy()) noexcept
+    requires(std::is_same_v<LayoutPolicy, stdx::layout_right>)
+      : Matrix<T, LayoutPolicy, I>(nrows, ncols, policy)
+      , num_ids_(this->num_rows_)
+#ifdef __cpp_lib_smart_ptr_for_overwrite
+      , idsStorage_{std::make_unique_for_overwrite<T[]>(this->num_rows_)}
+#else
+      , idsStorage_{new T[this->num_rows_]}
+#endif
+  {
+  }
+
+  MatrixWithIds(
+      Matrix<T, LayoutPolicy, I>::size_type nrows,
+      Matrix<T, LayoutPolicy, I>::size_type ncols,
+      LayoutPolicy policy = LayoutPolicy()) noexcept
+    requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
+      : Matrix<T, LayoutPolicy, I>(nrows, ncols, policy)
+      , num_ids_(this->num_cols_)
+#ifdef __cpp_lib_smart_ptr_for_overwrite
+      , idsStorage_{std::make_unique_for_overwrite<T[]>(this->num_cols_)}
+#else
+      , idsStorage_{new T[this->num_cols_]}
+#endif
+  {
+  }
+
+  MatrixWithIds(
+      std::unique_ptr<T[]>&& storage,
+      std::unique_ptr<T[]>&& ids_storage,
+      Matrix<T, LayoutPolicy, I>::size_type nrows,
+      Matrix<T, LayoutPolicy, I>::size_type ncols,
+      LayoutPolicy policy = LayoutPolicy()) noexcept
+      : Matrix<T, LayoutPolicy, I>(storage, nrows, ncols, policy)
+      , idsStorage_{std::move(ids_storage)}
+      , num_ids_{
+            std::is_same<LayoutPolicy, stdx::layout_right>::value ?
+                this->num_rows_ :
+                this->num_cols_} {
+    std::cout << "ctor 1" << std::endl;
+  }
+
+  /**
+   * Initializer list constructor. Useful for testing and for examples.
+   * The initializer list is assumed to be in row-major order.
+   */
+  MatrixWithIds(
+      std::initializer_list<std::initializer_list<T>> matrix,
+      std::initializer_list<T> ids) noexcept
+    requires(std::is_same_v<LayoutPolicy, stdx::layout_right>)
+      : Matrix<T, LayoutPolicy, I>(matrix)
+      , num_ids_(this->num_rows_)
+#ifdef __cpp_lib_smart_ptr_for_overwrite
+      , idsStorage_{std::make_unique_for_overwrite<IdsType[]>(this->num_rows_)}
+#else
+      , idsStorage_{new IdsType[this->num_rows_]}
+#endif
+  {
+    std::copy(ids.begin(), ids.end(), idsStorage_.get());
+  }
+
+  /**
+   * Initializer list constructor. Useful for testing and for examples.
+   * The initializer list is assumed to be in column-major order.
+   */
+  MatrixWithIds(
+      std::initializer_list<std::initializer_list<T>> matrix,
+      std::initializer_list<T> ids) noexcept
+    requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
+      : Matrix<T, LayoutPolicy, I>(matrix)
+      , num_ids_(this->num_cols_)
+#ifdef __cpp_lib_smart_ptr_for_overwrite
+      , idsStorage_{std::make_unique_for_overwrite<IdsType[]>(this->num_cols_)}
+#else
+      , idsStorage_{new IdsType[this->num_cols_]}
+#endif
+  {
+    std::copy(ids.begin(), ids.end(), idsStorage_.get());
+  }
+
+  size_t num_ids() const {
+    return num_ids_;
+  }
+
+  auto ids() {
+    return idsStorage_.get();
+  }
+
+  auto ids() const {
+    return idsStorage_.get();
+  }
+
+  auto raveledIds() {
+    return std::span(idsStorage_.get(), num_ids_);
+  }
+
+  auto raveledIds() const {
+    return std::span(idsStorage_.get(), num_ids_);
+  }
+
+  auto id(Matrix<T, LayoutPolicy, I>::index_type i) const {
+    return idsStorage_[i];
+  }
+
+  auto swap(MatrixWithIds& rhs) noexcept {
+    Matrix<T, LayoutPolicy, I>::swap(rhs);
+    std::swap(idsStorage_, rhs.idsStorage_);
+  }
+
+  template <
+      class T_,
+      class LayoutPolicy_ = stdx::layout_right,
+      class I_ = size_t>
+  bool operator==(
+      const MatrixWithIds<T_, LayoutPolicy_, I_>& rhs) const noexcept {
+    return Matrix<T_, LayoutPolicy_, I_>::operator==(rhs) &&
+           ((void*)this->ids() == (void*)rhs.ids() ||
+            std::equal(
+                raveledIds().begin(),
+                raveledIds().end(),
+                rhs.raveledIds().begin()));
+  }
+};
+
+/**
+ * Convenience class for row-major matrices.
+ */
+template <class T, class I = size_t, class IdsType = size_t>
+using RowMajorMatrixWithIds = MatrixWithIds<T, stdx::layout_right, I, IdsType>;
+
+/**
+ * Convenience class for column-major matrices.
+ */
+template <class T, class I = size_t, class IdsType = size_t>
+using ColMajorMatrixWithIds = MatrixWithIds<T, stdx::layout_left, I, IdsType>;
+
+#endif  // TILEDB_MATRIX_WITH_ID_H

--- a/src/include/test/CMakeLists.txt
+++ b/src/include/test/CMakeLists.txt
@@ -115,6 +115,8 @@ kmeans_add_test(unit_logging)
 
 kmeans_add_test(unit_matrix)
 
+kmeans_add_test(unit_matrix_with_ids)
+
 kmeans_add_test(unit_mdspan)
 
 kmeans_add_test(unit_memory)

--- a/src/include/test/unit_matrix_with_ids.cc
+++ b/src/include/test/unit_matrix_with_ids.cc
@@ -47,65 +47,55 @@ TEMPLATE_TEST_CASE(
     "[matrix_with_ids]",
     stdx::layout_right,
     stdx::layout_left) {
-  auto matrix = MatrixWithIds<float, TestType>{
+  auto A = MatrixWithIds<float, TestType>{
       {{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}}, {1, 2, 3, 4}};
 
-  auto matrixData = std::vector<float>{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8};
+  auto a = std::vector<float>{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8};
   auto idsData = std::vector<float>{1, 2, 3, 4};
-  auto matrixRaveled = matrix.raveled();
-  auto matrixRaveledIds = matrix.raveledIds();
+  auto raveled = A.raveled();
+  auto raveledIds = A.raveledIds();
 
-  CHECK(matrix.num_rows() * matrix.num_cols() == matrixData.size());
-  CHECK(std::equal(
-      matrix.data(),
-      matrix.data() + matrix.num_rows() * matrix.num_cols(),
-      matrixData.begin()));
-  CHECK(std::equal(
-      matrixRaveled.begin(), matrixRaveled.end(), matrixData.begin()));
+  CHECK(A.num_rows() * A.num_cols() == a.size());
+  CHECK(
+      std::equal(A.data(), A.data() + A.num_rows() * A.num_cols(), a.begin()));
+  CHECK(std::equal(raveled.begin(), raveled.end(), a.begin()));
 
-  CHECK(matrix.num_ids() == idsData.size());
-  CHECK(std::equal(
-      matrix.ids(), matrix.ids() + matrix.num_rows(), idsData.begin()));
-  CHECK(std::equal(
-      matrixRaveledIds.begin(), matrixRaveledIds.end(), idsData.begin()));
-  CHECK(matrix.id(0) == 1);
-  CHECK(matrix.id(1) == 2);
-  CHECK(matrix.id(2) == 3);
-  CHECK(matrix.id(3) == 4);
+  CHECK(A.num_ids() == idsData.size());
+  CHECK(std::equal(A.ids(), A.ids() + A.num_rows(), idsData.begin()));
+  CHECK(std::equal(raveledIds.begin(), raveledIds.end(), idsData.begin()));
+  CHECK(A.id(0) == 1);
+  CHECK(A.id(1) == 2);
+  CHECK(A.id(2) == 3);
+  CHECK(A.id(3) == 4);
 }
 
 TEST_CASE("matrix_with_ids: copy", "[matrix_with_ids]") {
-  auto matrixA = MatrixWithIds<float>{
+  auto A = MatrixWithIds<float>{
       {{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}}, {1, 2, 3, 4}};
 
-  auto matrixAPtr = matrixA.data();
-  auto matrixAPtrIds = matrixA.ids();
+  auto aptr = A.data();
+  auto ptrIds = A.ids();
   auto matrixData = std::vector<float>{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8};
   auto idsData = std::vector<float>{1, 2, 3, 4};
 
-  auto matrixB{std::move(matrixA)};
-  auto matrixBRaveled = matrixB.raveled();
-  auto matrixBRaveledIds = matrixB.raveledIds();
+  auto B{std::move(A)};
+  auto raveled = B.raveled();
+  auto raveledIds = B.raveledIds();
 
-  CHECK(matrixAPtr == matrixB.data());
-  CHECK(matrixA.data() == nullptr);
-  CHECK(matrixAPtrIds == matrixB.ids());
-  CHECK(matrixA.ids() == nullptr);
+  CHECK(aptr == B.data());
+  CHECK(A.data() == nullptr);
+  CHECK(ptrIds == B.ids());
+  CHECK(A.ids() == nullptr);
 
   CHECK(std::equal(
-      matrixB.data(),
-      matrixB.data() + matrixB.num_rows() * matrixB.num_cols(),
-      matrixData.begin()));
-  CHECK(std::equal(
-      matrixBRaveled.begin(), matrixBRaveled.end(), matrixData.begin()));
+      B.data(), B.data() + B.num_rows() * B.num_cols(), matrixData.begin()));
+  CHECK(std::equal(raveled.begin(), raveled.end(), matrixData.begin()));
 
-  CHECK(matrixB.num_ids() == idsData.size());
-  CHECK(std::equal(
-      matrixB.ids(), matrixB.ids() + matrixB.num_rows(), idsData.begin()));
-  CHECK(std::equal(
-      matrixBRaveledIds.begin(), matrixBRaveledIds.end(), idsData.begin()));
-  CHECK(matrixB.id(0) == 1);
-  CHECK(matrixB.id(3) == 4);
+  CHECK(B.num_ids() == idsData.size());
+  CHECK(std::equal(B.ids(), B.ids() + B.num_rows(), idsData.begin()));
+  CHECK(std::equal(raveledIds.begin(), raveledIds.end(), idsData.begin()));
+  CHECK(B.id(0) == 1);
+  CHECK(B.id(3) == 4);
 }
 
 TEST_CASE("matrix_with_ids: assign", "[matrix_with_ids]") {
@@ -230,9 +220,9 @@ TEMPLATE_TEST_CASE(
           t, major, minor);
   CHECK(b.extent(0) == major);
   CHECK(b.extent(1) == minor);
-  CHECK(b(0, 0) == 0);  // M(0, 0)
-  CHECK(b(1, 0) == 1);  // M(1,0)
-  CHECK(b(0, 1) == 7);  // M(1,0)
+  CHECK(b(0, 0) == 0);
+  CHECK(b(1, 0) == 1);
+  CHECK(b(0, 1) == 7);
 
   auto ids = std::vector<TestType>(major);
   std::iota(ids.begin(), ids.end(), 0);

--- a/src/include/test/unit_matrix_with_ids.cc
+++ b/src/include/test/unit_matrix_with_ids.cc
@@ -36,8 +36,6 @@
 #include "detail/linalg/matrix_with_ids.h"
 #include "mdspan/mdspan.hpp"
 
-using TestTypes = std::tuple<float, double, int, char, size_t, uint32_t>;
-
 TEST_CASE("matrix_with_ids: test test", "[matrix_with_ids]") {
   REQUIRE(true);
 }
@@ -69,8 +67,12 @@ TEMPLATE_TEST_CASE(
   CHECK(A.id(3) == 4);
 }
 
-TEST_CASE("matrix_with_ids: copy", "[matrix_with_ids]") {
-  auto A = MatrixWithIds<float>{
+TEMPLATE_TEST_CASE(
+    "matrix_with_ids: copy",
+    "[matrix_with_ids]",
+    stdx::layout_right,
+    stdx::layout_left) {
+  auto A = MatrixWithIds<float, TestType>{
       {{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}}, {1, 2, 3, 4}};
 
   auto aptr = A.data();
@@ -92,19 +94,23 @@ TEST_CASE("matrix_with_ids: copy", "[matrix_with_ids]") {
   CHECK(std::equal(raveled.begin(), raveled.end(), matrixData.begin()));
 
   CHECK(B.num_ids() == idsData.size());
-  CHECK(std::equal(B.ids(), B.ids() + B.num_rows(), idsData.begin()));
+  CHECK(std::equal(B.ids(), B.ids() + B.num_ids(), idsData.begin()));
   CHECK(std::equal(raveledIds.begin(), raveledIds.end(), idsData.begin()));
   CHECK(B.id(0) == 1);
   CHECK(B.id(3) == 4);
 }
 
-TEST_CASE("matrix_with_ids: assign", "[matrix_with_ids]") {
-  auto A = MatrixWithIds<float>{
+TEMPLATE_TEST_CASE(
+    "matrix_with_ids: assign",
+    "[matrix_with_ids]",
+    stdx::layout_right,
+    stdx::layout_left) {
+  auto A = MatrixWithIds<float, TestType>{
       {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}, {0, 1, 2, 3}};
   auto a = std::vector<float>{8, 6, 7, 5, 3, 0, 9, 5, 0, 2, 7, 3};
   auto ids = std::vector<float>{0, 1, 2, 3};
 
-  auto B = MatrixWithIds<float>{
+  auto B = MatrixWithIds<float, TestType>{
       {{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}}, {100, 101, 102, 103}};
 
   auto aptr = A.data();
@@ -115,7 +121,7 @@ TEST_CASE("matrix_with_ids: assign", "[matrix_with_ids]") {
   CHECK(
       std::equal(B.data(), B.data() + B.num_rows() * B.num_cols(), a.begin()));
   CHECK(B.num_ids() == ids.size());
-  CHECK(std::equal(B.ids(), B.ids() + B.num_rows(), ids.begin()));
+  CHECK(std::equal(B.ids(), B.ids() + B.num_ids(), ids.begin()));
   auto raveledIds = B.raveledIds();
   CHECK(std::equal(raveledIds.begin(), raveledIds.end(), ids.begin()));
 
@@ -124,11 +130,13 @@ TEST_CASE("matrix_with_ids: assign", "[matrix_with_ids]") {
   CHECK(A.data() == nullptr);
 }
 
-TEST_CASE("matrix_with_ids: vector of matrix", "[matrix_with_ids]") {
-  std::vector<MatrixWithIds<float>> v;
+TEMPLATE_TEST_CASE("matrix_with_ids: vector of matrix", "[matrix_with_ids]",
+    stdx::layout_right,
+    stdx::layout_left) {
+  std::vector<MatrixWithIds<float, TestType>> v;
 
   auto numIds = 3;
-  auto A = MatrixWithIds<float>{{{8, 6, 7}, {5, 3, 0}, {9, 5, 0}}, {0, 1, 2}};
+  auto A = MatrixWithIds<float, TestType>{{{8, 6, 7}, {5, 3, 0}, {9, 5, 0}}, {0, 1, 2}};
   auto aptr = A.data();
   auto aptrIds = A.ids();
 
@@ -163,10 +171,10 @@ TEST_CASE("matrix_with_ids: vector of matrix", "[matrix_with_ids]") {
   }
 
   SECTION("operator[]") {
-    std::vector<MatrixWithIds<float>> x;
+    std::vector<MatrixWithIds<float, TestType>> x;
 
     SECTION("operator[]") {
-      std::vector<MatrixWithIds<float>> w;
+      std::vector<MatrixWithIds<float, TestType>> w;
       w.reserve(10);
       w.emplace_back();
       // w[0] = A; // Error: no matching construct_at


### PR DESCRIPTION
### What
To support external ids we want to have `FeatureVectorArray` hold a `MatrixWithIds` or a `TdbMatrixWithIds`. These should hold (or load in the `TdbMatrixWithIds` case) the vectors as well as the ids. 

Note that there were three designs we could have used here:
1. We just add in IDs to the `Matrix` class (i.e. add `idsStorage_`, `hasIds()`, `id(int index)`, and new constructor arguments). This is the simplest code-wise, but was decided against because it means the `Matrix` class is not just a raw matrix.
2. This approach, where we hav a child class of `Matrix`.
3. We have `MatrixWithIds` hold `Matrix` as a member variable and provide access to it with a `matrix()` method.

In a follow-up I will add `TdbMatrixWithIds`.

### Testing
* Adds a unit test - we follow the same pattern as `unit_matrix.cc` but add in `TEMPLATE_TEST_CASE` for `stdx::layout_right` and `stdx::layout_left` in several places. It would be good to also do that in `unit_matrix.cc`, so I'll do that in a follow-up.