### PR TITLE
Additional checking of local file I/O

### DIFF
--- a/src/include/detail/graph/diskann.h
+++ b/src/include/detail/graph/diskann.h
@@ -56,7 +56,7 @@ auto read_diskann_data(const std::string& path) {
   auto x = ColMajorMatrix<float>(ndim, npoints);
 
   binary_file.read((char*)x.data(), npoints * ndim * sizeof(float));
-  if((size_t)binary_file.gcount() != (size_t)npoints * ndim * sizeof(float)) {
+  if ((size_t)binary_file.gcount() != (size_t)npoints * ndim * sizeof(float)) {
     throw std::runtime_error("Could not read all data from " + path);
   }
 

--- a/src/include/detail/graph/diskann.h
+++ b/src/include/detail/graph/diskann.h
@@ -45,6 +45,7 @@ auto read_diskann_data(const std::string& path) {
   uint32_t ndim{0};
 
   std::ifstream binary_file(path, std::ios::binary);
+  binary_file.exceptions(std::ifstream::failbit);
   if (!binary_file.is_open()) {
     throw std::runtime_error("Could not open file " + path);
   }
@@ -55,6 +56,10 @@ auto read_diskann_data(const std::string& path) {
   auto x = ColMajorMatrix<float>(ndim, npoints);
 
   binary_file.read((char*)x.data(), npoints * ndim * sizeof(float));
+  if((size_t)binary_file.gcount() != (size_t)npoints * ndim * sizeof(float)) {
+    throw std::runtime_error("Could not read all data from " + path);
+  }
+
   binary_file.close();
 
   return x;

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -392,6 +392,8 @@ template <class Distance = sum_of_squares_distance>
 auto medoid(auto&& P, Distance distance = Distance{}) {
   auto n = num_vectors(P);
   auto centroid = Vector<float>(P[0].size());
+  std::fill(begin(centroid), end(centroid), 0.0);
+
   for (size_t j = 0; j < n; ++j) {
     auto p = P[j];
     for (size_t i = 0; i < p.size(); ++i) {

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -133,6 +133,39 @@ TEST_CASE("vamana: diskann", "[vamana]") {
       f.data(), f.data() + 256 * 128, std::vector<float>(128 * 256, 0).data()));
 
   CHECK(sum_of_squares(f[0], f[72]) == 125678);
+  {
+    auto n = num_vectors(f);
+    CHECK(n != 0);
+    CHECK(n == 256);
+    CHECK(f[0].size() == 128);
+    CHECK(dimension(f) == 128);
+
+    auto centroid = Vector<float>(f[0].size());
+    for (size_t j = 0; j < n; ++j) {
+      auto p = f[j];
+      for (size_t i = 0; i < p.size(); ++i) {
+        centroid[i] += p[i];
+      }
+    }
+    float sum = 0.0;
+    for (size_t i = 0; i < centroid.size(); ++i) {
+      sum += abs(centroid[i]);
+      centroid[i] /= (float)num_vectors(f);
+    }
+    CHECK(sum > 0);
+
+    std::vector<float> tmp{begin(centroid), end(centroid)};
+    auto min_score = std::numeric_limits<float>::max();
+    auto med = std::numeric_limits<size_t>::max();
+    for (size_t i = 0; i < n; ++i) {
+      auto score = sum_of_squares(f[i], centroid);
+      if (score < min_score) {
+        min_score = score;
+        med = i;
+      }
+    }
+    CHECK(med != std::numeric_limits<size_t>::max());
+  }
 
   auto med = ::medoid(f);
 

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -128,6 +128,9 @@ TEST_CASE("vamana: diskann", "[vamana]") {
   auto f = read_diskann_data(diskann_test_data_file);
   CHECK(num_vectors(f) == 256);
   CHECK(dimension(f) == 128);
+  CHECK(f.data() != nullptr);
+  CHECK(!std::equal(f.data(), f.data() + 256 * 128, std::vector<float>(128*256, 0).data()));
+
   auto med = ::medoid(f);
 
   if (debug) {

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -132,6 +132,9 @@ TEST_CASE("vamana: diskann", "[vamana]") {
   CHECK(!std::equal(
       f.data(), f.data() + 256 * 128, std::vector<float>(128 * 256, 0).data()));
 
+  CHECK(f.num_rows() == 128);
+  CHECK(f.num_cols() == 256);
+
   CHECK(sum_of_squares(f[0], f[72]) == 125678);
   {
     auto n = num_vectors(f);
@@ -141,6 +144,7 @@ TEST_CASE("vamana: diskann", "[vamana]") {
     CHECK(dimension(f) == 128);
 
     auto centroid = Vector<float>(f[0].size());
+    std::fill(begin(centroid), end(centroid), 0.0);
     for (size_t j = 0; j < n; ++j) {
       auto p = f[j];
       for (size_t i = 0; i < p.size(); ++i) {
@@ -176,10 +180,10 @@ TEST_CASE("vamana: diskann", "[vamana]") {
 
   CHECK(med == 72);
 
-//  if (debug) {
-//    tiledb::Context ctx;
-//    write_matrix(ctx, f, "/tmp/diskann_test_data_file.tdb");
-//  }
+  //  if (debug) {
+  //    tiledb::Context ctx;
+  //    write_matrix(ctx, f, "/tmp/diskann_test_data_file.tdb");
+  //  }
 }
 
 TEST_CASE("vamana: small256 build index", "[vamana]") {

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -132,18 +132,21 @@ TEST_CASE("vamana: diskann", "[vamana]") {
   CHECK(!std::equal(
       f.data(), f.data() + 256 * 128, std::vector<float>(128 * 256, 0).data()));
 
+  CHECK(sum_of_squares(f[0], f[72]) == 125678);
+
   auto med = ::medoid(f);
 
   if (debug) {
     std::cout << "med " << med << std::endl;
+    std::cout << "f[0] - f[72] = " << sum_of_squares(f[0], f[72]) << std::endl;
   }
 
   CHECK(med == 72);
 
-  if (debug) {
-    tiledb::Context ctx;
-    write_matrix(ctx, f, "/tmp/diskann_test_data_file.tdb");
-  }
+//  if (debug) {
+//    tiledb::Context ctx;
+//    write_matrix(ctx, f, "/tmp/diskann_test_data_file.tdb");
+//  }
 }
 
 TEST_CASE("vamana: small256 build index", "[vamana]") {

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -129,7 +129,8 @@ TEST_CASE("vamana: diskann", "[vamana]") {
   CHECK(num_vectors(f) == 256);
   CHECK(dimension(f) == 128);
   CHECK(f.data() != nullptr);
-  CHECK(!std::equal(f.data(), f.data() + 256 * 128, std::vector<float>(128*256, 0).data()));
+  CHECK(!std::equal(
+      f.data(), f.data() + 256 * 128, std::vector<float>(128 * 256, 0).data()));
 
   auto med = ::medoid(f);
 


### PR DESCRIPTION
A test in `unit_vamana_index` was failing in CI but not locally due to an uninitialized `Vector` in `medoid()`.  In addition to properly initializing the `Vector`, this PR adds some additional unit testing to `unit_vamana_index`, which was used to diagnose this problem.