### PR TITLE
Fixes the `Generate Backwards Compatibility Data` job

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -57,7 +57,7 @@ jobs:
           git add backwards-compatibility-data/data/
           git commit -m "[automated] Update backwards-compatibility-data for release $release_tag"
           git push origin "$branch_name"
-          gh pr create --base main --head "$branch_name" --title "[automated] Update backwards-compatibility-data for release $release_tag"
+          gh pr create --base main --head "$branch_name" --title "[automated] Update backwards-compatibility-data for release $release_tag" --body "This PR contains backwards compatibility indexes generated for release $release_tag."
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
### What
In this job: https://github.com/TileDB-Inc/TileDB-Vector-Search/actions/runs/7935942796/job/21670159062#step:6:330 we failed with:
```
must provide `--title` and `--body` (or `--fill` or `fill-first`) when not running interactively
```
So here we do that.

### Testing
None, but the error is simple enough.