### PR TITLE
Replace switch-case statements in type-erased `api/vamana_index.h` API with a lookup table

### DIFF
--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -279,7 +279,9 @@ void init_type_erased_module(py::module_& m) {
           py::arg("opt_l"))
       .def("feature_type_string", &IndexVamana::feature_type_string)
       .def("id_type_string", &IndexVamana::id_type_string)
-      .def("px_type_string", &IndexVamana::px_type_string)
+      .def(
+          "adjacency_row_index_type_string",
+          &IndexVamana::adjacency_row_index_type_string)
       .def("dimension", &IndexVamana::dimension);
 
   py::class_<IndexIVFFlat>(m, "IndexIVFFlat")

--- a/apis/python/test/test_type_erased_module.py
+++ b/apis/python/test/test_type_erased_module.py
@@ -161,25 +161,25 @@ def test_construct_IndexVamana():
     a = vspy.IndexVamana()
     assert a.feature_type_string() == "any"
     assert a.id_type_string() == "uint32"
-    assert a.px_type_string() == "uint32"
+    assert a.adjacency_row_index_type_string() == "uint32"
     assert a.dimension() == 0
 
     a = vspy.IndexVamana(feature_type="float32")
     assert a.feature_type_string() == "float32"
     assert a.id_type_string() == "uint32"
-    assert a.px_type_string() == "uint32"
+    assert a.adjacency_row_index_type_string() == "uint32"
     assert a.dimension() == 0
 
-    a = vspy.IndexVamana(feature_type="uint8", id_type="uint64", px_type="int64")
+    a = vspy.IndexVamana(feature_type="uint8", id_type="uint64", adjacency_row_index_type="int64")
     assert a.feature_type_string() == "uint8"
     assert a.id_type_string() == "uint64"
-    assert a.px_type_string() == "int64"
+    assert a.adjacency_row_index_type_string() == "int64"
     assert a.dimension() == 0
 
-    a = vspy.IndexVamana(feature_type="float32", id_type="int64", px_type="uint64")
+    a = vspy.IndexVamana(feature_type="float32", id_type="int64", adjacency_row_index_type="uint64")
     assert a.feature_type_string() == "float32"
     assert a.id_type_string() == "int64"
-    assert a.px_type_string() == "uint64"
+    assert a.adjacency_row_index_type_string() == "uint64"
     assert a.dimension() == 0
 
 
@@ -187,7 +187,7 @@ def test_inplace_build_query_IndexVamana():
     opt_l = 100
     k_nn = 10
 
-    a = vspy.IndexVamana(id_type="uint32", px_type="uint32", feature_type="float32")
+    a = vspy.IndexVamana(id_type="uint32", adjacency_row_index_type="uint32", feature_type="float32")
 
     training_set = vspy.FeatureVectorArray(ctx, siftsmall_inputs_uri)
     assert training_set.feature_type_string() == "float32"

--- a/src/include/api/ivf_flat_index.h
+++ b/src/include/api/ivf_flat_index.h
@@ -165,9 +165,9 @@ class IndexIVFFlat {
     /**
      * We support all combinations of the following types for feature,
      * id, and px datatypes:
-     *   feature_type: uint8 or float
-     *   id_type: uint32 or uint64
-     *   px_type: uint32 or uint64
+     *   feature_type (partitioned_vectors_feature_type): uint8 or float
+     *   id_type (partitioned_ids_type): uint32 or uint64
+     *   px_type (partitioning_index_type): uint32 or uint64
      *
      *   @todo Unify the type-based switch-case statements in a manner
      *   similar to what was done in query_condition
@@ -257,9 +257,9 @@ class IndexIVFFlat {
     /**
      * We support all combinations of the following types for feature,
      * id, and px datatypes:
-     *   feature_type: uint8 or float
-     *   id_type: uint32 or uint64
-     *   px_type: uint32 or uint64
+     *   feature_type (partitioned_vectors_feature_type): uint8 or float
+     *   id_type (partitioned_ids_type): uint32 or uint64
+     *   px_type (partitioning_index_type): uint32 or uint64
      */
     if (feature_datatype_ == TILEDB_UINT8 && id_datatype_ == TILEDB_UINT32 &&
         px_datatype_ == TILEDB_UINT32) {

--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -62,7 +62,7 @@
  * datatypes:
  *   - feature_type: uint8 or float
  *   - id_type: uint32 or uint64
- *   - px_type: uint32 or uint64
+ *   - adjacency_row_index_type: uint32 or uint64
  */
 class IndexVamana {
  public:
@@ -90,7 +90,7 @@ class IndexVamana {
       const std::optional<IndexOptions>& config = std::nullopt) {
     feature_datatype_ = TILEDB_ANY;
     id_datatype_ = TILEDB_UINT32;
-    px_datatype_ = TILEDB_UINT32;
+    adjacency_row_index_datatype_ = TILEDB_UINT32;
 
     if (config) {
       for (auto&& c : *config) {
@@ -106,8 +106,8 @@ class IndexVamana {
           feature_datatype_ = string_to_datatype(value);
         } else if (key == "id_type") {
           id_datatype_ = string_to_datatype(value);
-        } else if (key == "px_type") {
-          px_datatype_ = string_to_datatype(value);
+        } else if (key == "adjacency_row_index_type") {
+          adjacency_row_index_datatype_ = string_to_datatype(value);
         } else {
           throw std::runtime_error("Invalid index config key: " + key);
         }
@@ -133,7 +133,9 @@ class IndexVamana {
     std::vector<metadata_element> metadata{
         {"feature_datatype", &feature_datatype_, TILEDB_UINT32},
         {"id_datatype", &id_datatype_, TILEDB_UINT32},
-        {"px_datatype", &px_datatype_, TILEDB_UINT32}};
+        {"adjacency_row_index_datatype",
+         &adjacency_row_index_datatype_,
+         TILEDB_UINT32}};
 
     tiledb::Config cfg;
     tiledb::Group read_group(ctx, group_uri, TILEDB_READ, cfg);
@@ -153,7 +155,8 @@ class IndexVamana {
       }
     }
 
-    auto type = std::tuple{feature_datatype_, id_datatype_, px_datatype_};
+    auto type = std::tuple{
+        feature_datatype_, id_datatype_, adjacency_row_index_datatype_};
     if (uri_dispatch_table.find(type) == uri_dispatch_table.end()) {
       throw std::runtime_error("Unsupported datatype combination");
     }
@@ -183,7 +186,8 @@ class IndexVamana {
           " != " + datatype_to_string(training_set.feature_type()));
     }
 
-    auto type = std::tuple{feature_datatype_, id_datatype_, px_datatype_};
+    auto type = std::tuple{
+        feature_datatype_, id_datatype_, adjacency_row_index_datatype_};
     if (dispatch_table.find(type) == dispatch_table.end()) {
       throw std::runtime_error("Unsupported datatype combination");
     }
@@ -249,12 +253,12 @@ class IndexVamana {
     return datatype_to_string(id_datatype_);
   }
 
-  constexpr auto px_type() const {
-    return px_datatype_;
+  constexpr auto adjacency_row_index_type() const {
+    return adjacency_row_index_datatype_;
   }
 
-  inline auto px_type_string() const {
-    return datatype_to_string(px_datatype_);
+  inline auto adjacency_row_index_type_string() const {
+    return datatype_to_string(adjacency_row_index_datatype_);
   }
 
  private:
@@ -407,7 +411,7 @@ class IndexVamana {
   size_t R_max_degree_ = 64;
   tiledb_datatype_t feature_datatype_{TILEDB_ANY};
   tiledb_datatype_t id_datatype_{TILEDB_ANY};
-  tiledb_datatype_t px_datatype_{TILEDB_ANY};
+  tiledb_datatype_t adjacency_row_index_datatype_{TILEDB_ANY};
   std::unique_ptr<index_base> index_;
 };
 

--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -58,6 +58,9 @@
  *   - An add method
  *   - A query method
  *
+ * We support all combinations of the following types for feature, id, and px
+ * datatypes: feature_type: uint8 or float id_type: uint32 or uint64 px_type:
+ * uint32 or uint64
  */
 class IndexVamana {
  public:
@@ -67,8 +70,8 @@ class IndexVamana {
   IndexVamana& operator=(IndexVamana&&) = default;
 
   /**
-   * @brief Create an index with the given configuration.  The index in this
-   * state is ready to be trained.  The sequence for creating an index in this
+   * @brief Create an index with the given configuration. The index in this
+   * state must next be trained. The sequence for creating an index in this
    * fashion is:
    *  - Create an IndexVamana object with the desired configuration (using this
    *  constructor
@@ -148,66 +151,12 @@ class IndexVamana {
       }
     }
 
-    /**
-     * We support all combinations of the following types for feature,
-     * id, and px datatypes:
-     *   feature_type: uint8 or float
-     *   id_type: uint32 or uint64
-     *   px_type: uint32 or uint64
-     *
-     *   @todo Unify the type-based switch-case statements in a manner
-     *   similar to what was done in query_condition
-     */
-    if (feature_datatype_ == TILEDB_UINT8 && id_datatype_ == TILEDB_UINT32 &&
-        px_datatype_ == TILEDB_UINT32) {
-      index_ = std::make_unique<
-          index_impl<vamana_index<uint8_t, uint32_t, uint32_t>>>(
-          ctx, group_uri);
-    } else if (
-        feature_datatype_ == TILEDB_FLOAT32 && id_datatype_ == TILEDB_UINT32 &&
-        px_datatype_ == TILEDB_UINT32) {
-      index_ =
-          std::make_unique<index_impl<vamana_index<float, uint32_t, uint32_t>>>(
-              ctx, group_uri);
-    } else if (
-        feature_datatype_ == TILEDB_UINT8 && id_datatype_ == TILEDB_UINT32 &&
-        px_datatype_ == TILEDB_UINT64) {
-      index_ = std::make_unique<
-          index_impl<vamana_index<uint8_t, uint32_t, uint64_t>>>(
-          ctx, group_uri);
-    } else if (
-        feature_datatype_ == TILEDB_FLOAT32 && id_datatype_ == TILEDB_UINT32 &&
-        px_datatype_ == TILEDB_UINT64) {
-      index_ =
-          std::make_unique<index_impl<vamana_index<float, uint32_t, uint64_t>>>(
-              ctx, group_uri);
-    } else if (
-        feature_datatype_ == TILEDB_UINT8 && id_datatype_ == TILEDB_UINT64 &&
-        px_datatype_ == TILEDB_UINT32) {
-      index_ = std::make_unique<
-          index_impl<vamana_index<uint8_t, uint64_t, uint32_t>>>(
-          ctx, group_uri);
-    } else if (
-        feature_datatype_ == TILEDB_FLOAT32 && id_datatype_ == TILEDB_UINT64 &&
-        px_datatype_ == TILEDB_UINT32) {
-      index_ =
-          std::make_unique<index_impl<vamana_index<float, uint64_t, uint32_t>>>(
-              ctx, group_uri);
-    } else if (
-        feature_datatype_ == TILEDB_UINT8 && id_datatype_ == TILEDB_UINT64 &&
-        px_datatype_ == TILEDB_UINT64) {
-      index_ = std::make_unique<
-          index_impl<vamana_index<uint8_t, uint64_t, uint64_t>>>(
-          ctx, group_uri);
-    } else if (
-        feature_datatype_ == TILEDB_FLOAT32 && id_datatype_ == TILEDB_UINT64 &&
-        px_datatype_ == TILEDB_UINT64) {
-      index_ =
-          std::make_unique<index_impl<vamana_index<float, uint64_t, uint64_t>>>(
-              ctx, group_uri);
-    } else {
+    auto type = std::tuple{feature_datatype_, id_datatype_, px_datatype_};
+    if (uri_dispatch_table.find(type) == uri_dispatch_table.end()) {
       throw std::runtime_error("Unsupported datatype combination");
     }
+    index_ = uri_dispatch_table.at(type)(ctx, group_uri);
+
     if (dimension_ != 0 && dimension_ != index_->dimension()) {
       throw std::runtime_error(
           "Dimension mismatch: " + std::to_string(dimension_) +
@@ -232,62 +181,12 @@ class IndexVamana {
           " != " + datatype_to_string(training_set.feature_type()));
     }
 
-    /**
-     * We support all combinations of the following types for feature,
-     * id, and px datatypes:
-     *   feature_type: uint8 or float
-     *   id_type: uint32 or uint64
-     *   px_type: uint32 or uint64
-     */
-    // TODO(paris): Add support for B_backtrack_.
-    if (feature_datatype_ == TILEDB_UINT8 && id_datatype_ == TILEDB_UINT32 &&
-        px_datatype_ == TILEDB_UINT32) {
-      index_ = std::make_unique<
-          index_impl<vamana_index<uint8_t, uint32_t, uint32_t>>>(
-          training_set.num_vectors(), L_build_, R_max_degree_);
-    } else if (
-        feature_datatype_ == TILEDB_FLOAT32 && id_datatype_ == TILEDB_UINT32 &&
-        px_datatype_ == TILEDB_UINT32) {
-      index_ =
-          std::make_unique<index_impl<vamana_index<float, uint32_t, uint32_t>>>(
-              training_set.num_vectors(), L_build_, R_max_degree_);
-    } else if (
-        feature_datatype_ == TILEDB_UINT8 && id_datatype_ == TILEDB_UINT32 &&
-        px_datatype_ == TILEDB_UINT64) {
-      index_ = std::make_unique<
-          index_impl<vamana_index<uint8_t, uint32_t, uint64_t>>>(
-          training_set.num_vectors(), L_build_, R_max_degree_);
-    } else if (
-        feature_datatype_ == TILEDB_FLOAT32 && id_datatype_ == TILEDB_UINT32 &&
-        px_datatype_ == TILEDB_UINT64) {
-      index_ =
-          std::make_unique<index_impl<vamana_index<float, uint32_t, uint64_t>>>(
-              training_set.num_vectors(), L_build_, R_max_degree_);
-    } else if (
-        feature_datatype_ == TILEDB_UINT8 && id_datatype_ == TILEDB_UINT64 &&
-        px_datatype_ == TILEDB_UINT32) {
-      index_ = std::make_unique<
-          index_impl<vamana_index<uint8_t, uint64_t, uint32_t>>>(
-          training_set.num_vectors(), L_build_, R_max_degree_);
-    } else if (
-        feature_datatype_ == TILEDB_FLOAT32 && id_datatype_ == TILEDB_UINT64 &&
-        px_datatype_ == TILEDB_UINT32) {
-      index_ =
-          std::make_unique<index_impl<vamana_index<float, uint64_t, uint32_t>>>(
-              training_set.num_vectors(), L_build_, R_max_degree_);
-    } else if (
-        feature_datatype_ == TILEDB_UINT8 && id_datatype_ == TILEDB_UINT64 &&
-        px_datatype_ == TILEDB_UINT64) {
-      index_ = std::make_unique<
-          index_impl<vamana_index<uint8_t, uint64_t, uint64_t>>>(
-          training_set.num_vectors(), L_build_, R_max_degree_);
-    } else if (
-        feature_datatype_ == TILEDB_FLOAT32 && id_datatype_ == TILEDB_UINT64 &&
-        px_datatype_ == TILEDB_UINT64) {
-      index_ =
-          std::make_unique<index_impl<vamana_index<float, uint64_t, uint64_t>>>(
-              training_set.num_vectors(), L_build_, R_max_degree_);
+    auto type = std::tuple{feature_datatype_, id_datatype_, px_datatype_};
+    if (dispatch_table.find(type) == dispatch_table.end()) {
+      throw std::runtime_error("Unsupported datatype combination");
     }
+    index_ = dispatch_table.at(type)(
+        training_set.num_vectors(), L_build_, R_max_degree_);
 
     index_->train(training_set);
 
@@ -317,7 +216,7 @@ class IndexVamana {
   [[nodiscard]] auto query(
       const QueryVectorArray& vectors,
       size_t top_k,
-      std::optional<size_t> opt_L) {
+      std::optional<size_t> opt_L = std::nullopt) {
     return index_->query(vectors, top_k, opt_L);
   }
 
@@ -356,6 +255,7 @@ class IndexVamana {
     return datatype_to_string(px_datatype_);
   }
 
+ private:
   /**
    * Non-type parameterized base class (for type erasure).
    */
@@ -486,6 +386,20 @@ class IndexVamana {
     T impl_index_;
   };
 
+  using constructor_function =
+      std::function<std::unique_ptr<index_base>(size_t, size_t, size_t)>;
+  using table_type = std::map<
+      std::tuple<tiledb_datatype_t, tiledb_datatype_t, tiledb_datatype_t>,
+      constructor_function>;
+  static const table_type dispatch_table;
+
+  using uri_constructor_function = std::function<std::unique_ptr<index_base>(
+      const tiledb::Context&, const std::string&)>;
+  using uri_table_type = std::map<
+      std::tuple<tiledb_datatype_t, tiledb_datatype_t, tiledb_datatype_t>,
+      uri_constructor_function>;
+  static const uri_table_type uri_dispatch_table;
+
   size_t dimension_ = 0;
   size_t L_build_ = 100;
   size_t R_max_degree_ = 64;
@@ -494,5 +408,97 @@ class IndexVamana {
   tiledb_datatype_t px_datatype_{TILEDB_ANY};
   std::unique_ptr<index_base> index_;
 };
+
+const IndexVamana::table_type IndexVamana::dispatch_table = {
+    {{TILEDB_UINT8, TILEDB_UINT32, TILEDB_UINT32},
+     [](size_t num_vectors, size_t L_build, size_t R_max_degree) {
+       return std::make_unique<
+           index_impl<vamana_index<uint8_t, uint32_t, uint32_t>>>(
+           num_vectors, L_build, R_max_degree);
+     }},
+    {{TILEDB_FLOAT32, TILEDB_UINT32, TILEDB_UINT32},
+     [](size_t num_vectors, size_t L_build, size_t R_max_degree) {
+       return std::make_unique<
+           index_impl<vamana_index<float, uint32_t, uint32_t>>>(
+           num_vectors, L_build, R_max_degree);
+     }},
+    {{TILEDB_UINT8, TILEDB_UINT32, TILEDB_UINT64},
+     [](size_t num_vectors, size_t L_build, size_t R_max_degree) {
+       return std::make_unique<
+           index_impl<vamana_index<uint8_t, uint32_t, uint64_t>>>(
+           num_vectors, L_build, R_max_degree);
+     }},
+    {{TILEDB_FLOAT32, TILEDB_UINT32, TILEDB_UINT64},
+     [](size_t num_vectors, size_t L_build, size_t R_max_degree) {
+       return std::make_unique<
+           index_impl<vamana_index<float, uint32_t, uint64_t>>>(
+           num_vectors, L_build, R_max_degree);
+     }},
+    {{TILEDB_UINT8, TILEDB_UINT64, TILEDB_UINT32},
+     [](size_t num_vectors, size_t L_build, size_t R_max_degree) {
+       return std::make_unique<
+           index_impl<vamana_index<uint8_t, uint64_t, uint32_t>>>(
+           num_vectors, L_build, R_max_degree);
+     }},
+    {{TILEDB_FLOAT32, TILEDB_UINT64, TILEDB_UINT32},
+     [](size_t num_vectors, size_t L_build, size_t R_max_degree) {
+       return std::make_unique<
+           index_impl<vamana_index<float, uint64_t, uint32_t>>>(
+           num_vectors, L_build, R_max_degree);
+     }},
+    {{TILEDB_UINT8, TILEDB_UINT64, TILEDB_UINT64},
+     [](size_t num_vectors, size_t L_build, size_t R_max_degree) {
+       return std::make_unique<
+           index_impl<vamana_index<uint8_t, uint64_t, uint64_t>>>(
+           num_vectors, L_build, R_max_degree);
+     }},
+    {{TILEDB_FLOAT32, TILEDB_UINT64, TILEDB_UINT64},
+     [](size_t num_vectors, size_t L_build, size_t R_max_degree) {
+       return std::make_unique<
+           index_impl<vamana_index<float, uint64_t, uint64_t>>>(
+           num_vectors, L_build, R_max_degree);
+     }}};
+
+const IndexVamana::uri_table_type IndexVamana::uri_dispatch_table = {
+    {{TILEDB_UINT8, TILEDB_UINT32, TILEDB_UINT32},
+     [](const tiledb::Context& ctx, const std::string& uri) {
+       return std::make_unique<
+           index_impl<vamana_index<uint8_t, uint32_t, uint32_t>>>(ctx, uri);
+     }},
+    {{TILEDB_FLOAT32, TILEDB_UINT32, TILEDB_UINT32},
+     [](const tiledb::Context& ctx, const std::string& uri) {
+       return std::make_unique<
+           index_impl<vamana_index<float, uint32_t, uint32_t>>>(ctx, uri);
+     }},
+    {{TILEDB_UINT8, TILEDB_UINT32, TILEDB_UINT64},
+     [](const tiledb::Context& ctx, const std::string& uri) {
+       return std::make_unique<
+           index_impl<vamana_index<uint8_t, uint32_t, uint64_t>>>(ctx, uri);
+     }},
+    {{TILEDB_FLOAT32, TILEDB_UINT32, TILEDB_UINT64},
+     [](const tiledb::Context& ctx, const std::string& uri) {
+       return std::make_unique<
+           index_impl<vamana_index<float, uint32_t, uint64_t>>>(ctx, uri);
+     }},
+    {{TILEDB_UINT8, TILEDB_UINT64, TILEDB_UINT32},
+     [](const tiledb::Context& ctx, const std::string& uri) {
+       return std::make_unique<
+           index_impl<vamana_index<uint8_t, uint64_t, uint32_t>>>(ctx, uri);
+     }},
+    {{TILEDB_FLOAT32, TILEDB_UINT64, TILEDB_UINT32},
+     [](const tiledb::Context& ctx, const std::string& uri) {
+       return std::make_unique<
+           index_impl<vamana_index<float, uint64_t, uint32_t>>>(ctx, uri);
+     }},
+    {{TILEDB_UINT8, TILEDB_UINT64, TILEDB_UINT64},
+     [](const tiledb::Context& ctx, const std::string& uri) {
+       return std::make_unique<
+           index_impl<vamana_index<uint8_t, uint64_t, uint64_t>>>(ctx, uri);
+     }},
+    {{TILEDB_FLOAT32, TILEDB_UINT64, TILEDB_UINT64},
+     [](const tiledb::Context& ctx, const std::string& uri) {
+       return std::make_unique<
+           index_impl<vamana_index<float, uint64_t, uint64_t>>>(ctx, uri);
+     }}};
 
 #endif  // TILEDB_API_VAMANA_INDEX_H

--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -58,9 +58,10 @@
  *   - An add method
  *   - A query method
  *
- * We support all combinations of the following types for feature, id, and px
- * datatypes: feature_type: uint8 or float id_type: uint32 or uint64 px_type:
- * uint32 or uint64
+ * We support all combinations of the following types for feature, id, and px datatypes:
+ *   - feature_type: uint8 or float
+ *   - id_type: uint32 or uint64
+ *   - px_type: uint32 or uint64
  */
 class IndexVamana {
  public:

--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -58,7 +58,8 @@
  *   - An add method
  *   - A query method
  *
- * We support all combinations of the following types for feature, id, and px datatypes:
+ * We support all combinations of the following types for feature, id, and px
+ * datatypes:
  *   - feature_type: uint8 or float
  *   - id_type: uint32 or uint64
  *   - px_type: uint32 or uint64

--- a/src/include/index/vamana_group.h
+++ b/src/include/index/vamana_group.h
@@ -222,6 +222,8 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
     metadata_.feature_datatype_ =
         type_to_tiledb_v<typename index_type::feature_type>;
     metadata_.id_datatype_ = type_to_tiledb_v<typename index_type::id_type>;
+    metadata_.px_datatype_ =
+        type_to_tiledb_v<typename index_type::adjacency_row_index_type>;
 
     metadata_.feature_type_str_ =
         type_to_string_v<typename index_type::feature_type>;

--- a/src/include/index/vamana_group.h
+++ b/src/include/index/vamana_group.h
@@ -222,8 +222,6 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
     metadata_.feature_datatype_ =
         type_to_tiledb_v<typename index_type::feature_type>;
     metadata_.id_datatype_ = type_to_tiledb_v<typename index_type::id_type>;
-    metadata_.px_datatype_ =
-        type_to_tiledb_v<typename index_type::adjacency_row_index_type>;
 
     metadata_.feature_type_str_ =
         type_to_string_v<typename index_type::feature_type>;

--- a/src/include/index/vamana_metadata.h
+++ b/src/include/index/vamana_metadata.h
@@ -69,7 +69,6 @@ class vamana_index_metadata
 
   // public for now in interest of time
  public:
-  tiledb_datatype_t px_datatype_{TILEDB_ANY};
   std::string index_type_{"Vamana"};
 
   /** Record number of partitions at each write at a given timestamp */
@@ -118,7 +117,10 @@ class vamana_index_metadata
       {"alpha_min", &alpha_min_, TILEDB_FLOAT32, false},
       {"alpha_max", &alpha_max_, TILEDB_FLOAT32, false},
       {"medoid", &medoid_, TILEDB_UINT64, false},
-      {"px_datatype", &px_datatype_, TILEDB_UINT32, false},
+      {"adjacency_row_index_datatype",
+       &adjacency_row_index_datatype_,
+       TILEDB_UINT32,
+       false},
   };
 
   auto json_to_vector_impl() {

--- a/src/include/index/vamana_metadata.h
+++ b/src/include/index/vamana_metadata.h
@@ -69,6 +69,7 @@ class vamana_index_metadata
 
   // public for now in interest of time
  public:
+  tiledb_datatype_t px_datatype_{TILEDB_ANY};
   std::string index_type_{"Vamana"};
 
   /** Record number of partitions at each write at a given timestamp */
@@ -117,6 +118,7 @@ class vamana_index_metadata
       {"alpha_min", &alpha_min_, TILEDB_FLOAT32, false},
       {"alpha_max", &alpha_max_, TILEDB_FLOAT32, false},
       {"medoid", &medoid_, TILEDB_UINT64, false},
+      {"px_datatype", &px_datatype_, TILEDB_UINT32, false},
   };
 
   auto json_to_vector_impl() {

--- a/src/include/test/CMakeLists.txt
+++ b/src/include/test/CMakeLists.txt
@@ -71,6 +71,8 @@ kmeans_add_test(unit_api_flat_l2_index)
 
 kmeans_add_test(unit_api_ivf_flat_index)
 
+kmeans_add_test(unit_api_vamana_index)
+
 kmeans_add_test(unit_array_defs)
 
 kmeans_add_test(unit_concepts)

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -41,8 +41,13 @@ TEST_CASE("api_vamana_index: init constructor", "[api_vamana_index]") {
   SECTION("default") {
     auto a = IndexVamana();
     CHECK(a.feature_type() == TILEDB_ANY);
+    CHECK(a.feature_type_string() == datatype_to_string(TILEDB_ANY));
     CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.px_type() == TILEDB_UINT32);
+    CHECK(a.id_type_string() == datatype_to_string(TILEDB_UINT32));
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+    CHECK(
+        a.adjacency_row_index_type_string() ==
+        datatype_to_string(TILEDB_UINT32));
     CHECK(dimension(a) == 0);
   }
 
@@ -50,10 +55,10 @@ TEST_CASE("api_vamana_index: init constructor", "[api_vamana_index]") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
         {{"feature_type", "float32"},
          {"id_type", "uint32"},
-         {"px_type", "uint32"}}));
+         {"adjacency_row_index_type", "uint32"}}));
     CHECK(a.feature_type() == TILEDB_FLOAT32);
     CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.px_type() == TILEDB_UINT32);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
     CHECK(dimension(a) == 0);
   }
 
@@ -61,94 +66,94 @@ TEST_CASE("api_vamana_index: init constructor", "[api_vamana_index]") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
         {{"feature_type", "uint8"},
          {"id_type", "uint32"},
-         {"px_type", "uint32"}}));
+         {"adjacency_row_index_type", "uint32"}}));
     CHECK(a.feature_type() == TILEDB_UINT8);
     CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.px_type() == TILEDB_UINT32);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
   }
 
   SECTION("float uint64 uint32") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
         {{"feature_type", "float32"},
          {"id_type", "uint64"},
-         {"px_type", "uint32"}}));
+         {"adjacency_row_index_type", "uint32"}}));
     CHECK(a.feature_type() == TILEDB_FLOAT32);
     CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.px_type() == TILEDB_UINT32);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
   }
 
   SECTION("float uint32 uint64") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
         {{"feature_type", "float32"},
          {"id_type", "uint32"},
-         {"px_type", "uint64"}}));
+         {"adjacency_row_index_type", "uint64"}}));
     CHECK(a.feature_type() == TILEDB_FLOAT32);
     CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.px_type() == TILEDB_UINT64);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
   }
 
   SECTION("uint8 uint64 uint32") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
         {{"feature_type", "uint8"},
          {"id_type", "uint64"},
-         {"px_type", "uint32"}}));
+         {"adjacency_row_index_type", "uint32"}}));
     CHECK(a.feature_type() == TILEDB_UINT8);
     CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.px_type() == TILEDB_UINT32);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
   }
 
   SECTION("uint8 uint32 uint64") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
         {{"feature_type", "uint8"},
          {"id_type", "uint32"},
-         {"px_type", "uint64"}}));
+         {"adjacency_row_index_type", "uint64"}}));
     CHECK(a.feature_type() == TILEDB_UINT8);
     CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.px_type() == TILEDB_UINT64);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
   }
 
   SECTION("float uint64 uint64") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
         {{"feature_type", "float32"},
          {"id_type", "uint64"},
-         {"px_type", "uint64"}}));
+         {"adjacency_row_index_type", "uint64"}}));
     CHECK(a.feature_type() == TILEDB_FLOAT32);
     CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.px_type() == TILEDB_UINT64);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
   }
 
   SECTION("uint8 uint64 uint64") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
         {{"feature_type", "uint8"},
          {"id_type", "uint64"},
-         {"px_type", "uint64"}}));
+         {"adjacency_row_index_type", "uint64"}}));
     CHECK(a.feature_type() == TILEDB_UINT8);
     CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.px_type() == TILEDB_UINT64);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
   }
 }
 
 TEST_CASE("api_vamana_index: infer feature type", "[api_vamana_index]") {
   auto a = IndexVamana(std::make_optional<IndexOptions>(
-      {{"id_type", "uint32"}, {"px_type", "uint32"}}));
+      {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
   auto ctx = tiledb::Context{};
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   a.train(training_set);
   CHECK(a.feature_type() == TILEDB_FLOAT32);
   CHECK(a.id_type() == TILEDB_UINT32);
-  CHECK(a.px_type() == TILEDB_UINT32);
+  CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
 }
 
 TEST_CASE("api_vamana_index: infer dimension", "[api_vamana_index]") {
   auto a = IndexVamana(std::make_optional<IndexOptions>(
-      {{"id_type", "uint32"}, {"px_type", "uint32"}}));
+      {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
   auto ctx = tiledb::Context{};
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   CHECK(dimension(a) == 0);
   a.train(training_set);
   CHECK(a.feature_type() == TILEDB_FLOAT32);
   CHECK(a.id_type() == TILEDB_UINT32);
-  CHECK(a.px_type() == TILEDB_UINT32);
+  CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
   CHECK(dimension(a) == 128);
 }
 
@@ -161,7 +166,7 @@ TEST_CASE(
   auto a = IndexVamana(std::make_optional<IndexOptions>(
       {{"feature_type", "float32"},
        {"id_type", "uint32"},
-       {"px_type", "uint32"}}));
+       {"adjacency_row_index_type", "uint32"}}));
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   a.train(training_set);
   a.add(training_set);
@@ -172,7 +177,7 @@ TEST_CASE(
   CHECK(dimension(a) == dimension(b));
   CHECK(a.feature_type() == b.feature_type());
   CHECK(a.id_type() == b.id_type());
-  CHECK(a.px_type() == b.px_type());
+  CHECK(a.adjacency_row_index_type() == b.adjacency_row_index_type());
 }
 
 TEST_CASE(
@@ -183,7 +188,7 @@ TEST_CASE(
   size_t nprobe = GENERATE(8, 32);
 
   auto a = IndexVamana(std::make_optional<IndexOptions>(
-      {{"id_type", "uint32"}, {"px_type", "uint32"}}));
+      {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
   auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
@@ -210,7 +215,7 @@ TEST_CASE(
   auto a = IndexVamana(std::make_optional<IndexOptions>(
       {{"feature_type", "float32"},
        {"id_type", "uint32"},
-       {"px_type", "uint32"}}));
+       {"adjacency_row_index_type", "uint32"}}));
 
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   a.train(training_set);

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -33,125 +33,124 @@
 #include "catch2/catch_all.hpp"
 #include "test/query_common.h"
 
-//TEST_CASE("api_vamana_index: test test", "[api_vamana_index]") {
-//  REQUIRE(true);
-//}
-//
-//TEST_CASE("api_vamana_index: init constructor", "[api_vamana_index]") {
-//  SECTION("default") {
-//    auto a = IndexVamana();
-//    CHECK(a.feature_type() == TILEDB_ANY);
-//    CHECK(a.id_type() == TILEDB_UINT32);
-//    CHECK(a.px_type() == TILEDB_UINT32);
-//    CHECK(dimension(a) == 0);
-//  }
-//
-//  SECTION("float uint32 uint32") {
-//    auto a = IndexVamana(std::make_optional<IndexOptions>(
-//        {{"feature_type", "float32"},
-//         {"id_type", "uint32"},
-//         {"px_type", "uint32"}}));
-//    CHECK(a.feature_type() == TILEDB_FLOAT32);
-//    CHECK(a.id_type() == TILEDB_UINT32);
-//    CHECK(a.px_type() == TILEDB_UINT32);
-//    CHECK(dimension(a) == 0);
-//  }
-//
-//  SECTION("uint8 uint32 uint32") {
-//    auto a = IndexVamana(std::make_optional<IndexOptions>(
-//        {{"feature_type", "uint8"},
-//         {"id_type", "uint32"},
-//         {"px_type", "uint32"}}));
-//    CHECK(a.feature_type() == TILEDB_UINT8);
-//    CHECK(a.id_type() == TILEDB_UINT32);
-//    CHECK(a.px_type() == TILEDB_UINT32);
-//  }
-//
-//  SECTION("float uint64 uint32") {
-//    auto a = IndexVamana(std::make_optional<IndexOptions>(
-//        {{"feature_type", "float32"},
-//         {"id_type", "uint64"},
-//         {"px_type", "uint32"}}));
-//    CHECK(a.feature_type() == TILEDB_FLOAT32);
-//    CHECK(a.id_type() == TILEDB_UINT64);
-//    CHECK(a.px_type() == TILEDB_UINT32);
-//  }
-//
-//  SECTION("float uint32 uint64") {
-//    auto a = IndexVamana(std::make_optional<IndexOptions>(
-//        {{"feature_type", "float32"},
-//         {"id_type", "uint32"},
-//         {"px_type", "uint64"}}));
-//    CHECK(a.feature_type() == TILEDB_FLOAT32);
-//    CHECK(a.id_type() == TILEDB_UINT32);
-//    CHECK(a.px_type() == TILEDB_UINT64);
-//  }
-//
-//  SECTION("uint8 uint64 uint32") {
-//    auto a = IndexVamana(std::make_optional<IndexOptions>(
-//        {{"feature_type", "uint8"},
-//         {"id_type", "uint64"},
-//         {"px_type", "uint32"}}));
-//    CHECK(a.feature_type() == TILEDB_UINT8);
-//    CHECK(a.id_type() == TILEDB_UINT64);
-//    CHECK(a.px_type() == TILEDB_UINT32);
-//  }
-//
-//  SECTION("uint8 uint32 uint64") {
-//    auto a = IndexVamana(std::make_optional<IndexOptions>(
-//        {{"feature_type", "uint8"},
-//         {"id_type", "uint32"},
-//         {"px_type", "uint64"}}));
-//    CHECK(a.feature_type() == TILEDB_UINT8);
-//    CHECK(a.id_type() == TILEDB_UINT32);
-//    CHECK(a.px_type() == TILEDB_UINT64);
-//  }
-//
-//  SECTION("float uint64 uint64") {
-//    auto a = IndexVamana(std::make_optional<IndexOptions>(
-//        {{"feature_type", "float32"},
-//         {"id_type", "uint64"},
-//         {"px_type", "uint64"}}));
-//    CHECK(a.feature_type() == TILEDB_FLOAT32);
-//    CHECK(a.id_type() == TILEDB_UINT64);
-//    CHECK(a.px_type() == TILEDB_UINT64);
-//  }
-//
-//  SECTION("uint8 uint64 uint64") {
-//    auto a = IndexVamana(std::make_optional<IndexOptions>(
-//        {{"feature_type", "uint8"},
-//         {"id_type", "uint64"},
-//         {"px_type", "uint64"}}));
-//    CHECK(a.feature_type() == TILEDB_UINT8);
-//    CHECK(a.id_type() == TILEDB_UINT64);
-//    CHECK(a.px_type() == TILEDB_UINT64);
-//  }
-//}
-//
-//TEST_CASE("api_vamana_index: infer feature type", "[api_vamana_index]") {
-//  auto a = IndexVamana(std::make_optional<IndexOptions>(
-//      {{"id_type", "uint32"}, {"px_type", "uint32"}}));
-//  auto ctx = tiledb::Context{};
-//  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-//  a.train(training_set);
-//  CHECK(a.feature_type() == TILEDB_FLOAT32);
-//  CHECK(a.id_type() == TILEDB_UINT32);
-//  CHECK(a.px_type() == TILEDB_UINT32);
-//}
-//
-//TEST_CASE("api_vamana_index: infer dimension", "[api_vamana_index]") {
-//  auto a = IndexVamana(std::make_optional<IndexOptions>(
-//      {{"id_type", "uint32"}, {"px_type", "uint32"}}));
-//  auto ctx = tiledb::Context{};
-//  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-//  CHECK(dimension(a) == 0);
-//  a.train(training_set);
-//  CHECK(a.feature_type() == TILEDB_FLOAT32);
-//  CHECK(a.id_type() == TILEDB_UINT32);
-//  CHECK(a.px_type() == TILEDB_UINT32);
-//  CHECK(dimension(a) == 128);
-//}
+TEST_CASE("api_vamana_index: test test", "[api_vamana_index]") {
+  REQUIRE(true);
+}
 
+TEST_CASE("api_vamana_index: init constructor", "[api_vamana_index]") {
+  SECTION("default") {
+    auto a = IndexVamana();
+    CHECK(a.feature_type() == TILEDB_ANY);
+    CHECK(a.id_type() == TILEDB_UINT32);
+    CHECK(a.px_type() == TILEDB_UINT32);
+    CHECK(dimension(a) == 0);
+  }
+
+  SECTION("float uint32 uint32") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "float32"},
+         {"id_type", "uint32"},
+         {"px_type", "uint32"}}));
+    CHECK(a.feature_type() == TILEDB_FLOAT32);
+    CHECK(a.id_type() == TILEDB_UINT32);
+    CHECK(a.px_type() == TILEDB_UINT32);
+    CHECK(dimension(a) == 0);
+  }
+
+  SECTION("uint8 uint32 uint32") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "uint8"},
+         {"id_type", "uint32"},
+         {"px_type", "uint32"}}));
+    CHECK(a.feature_type() == TILEDB_UINT8);
+    CHECK(a.id_type() == TILEDB_UINT32);
+    CHECK(a.px_type() == TILEDB_UINT32);
+  }
+
+  SECTION("float uint64 uint32") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "float32"},
+         {"id_type", "uint64"},
+         {"px_type", "uint32"}}));
+    CHECK(a.feature_type() == TILEDB_FLOAT32);
+    CHECK(a.id_type() == TILEDB_UINT64);
+    CHECK(a.px_type() == TILEDB_UINT32);
+  }
+
+  SECTION("float uint32 uint64") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "float32"},
+         {"id_type", "uint32"},
+         {"px_type", "uint64"}}));
+    CHECK(a.feature_type() == TILEDB_FLOAT32);
+    CHECK(a.id_type() == TILEDB_UINT32);
+    CHECK(a.px_type() == TILEDB_UINT64);
+  }
+
+  SECTION("uint8 uint64 uint32") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "uint8"},
+         {"id_type", "uint64"},
+         {"px_type", "uint32"}}));
+    CHECK(a.feature_type() == TILEDB_UINT8);
+    CHECK(a.id_type() == TILEDB_UINT64);
+    CHECK(a.px_type() == TILEDB_UINT32);
+  }
+
+  SECTION("uint8 uint32 uint64") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "uint8"},
+         {"id_type", "uint32"},
+         {"px_type", "uint64"}}));
+    CHECK(a.feature_type() == TILEDB_UINT8);
+    CHECK(a.id_type() == TILEDB_UINT32);
+    CHECK(a.px_type() == TILEDB_UINT64);
+  }
+
+  SECTION("float uint64 uint64") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "float32"},
+         {"id_type", "uint64"},
+         {"px_type", "uint64"}}));
+    CHECK(a.feature_type() == TILEDB_FLOAT32);
+    CHECK(a.id_type() == TILEDB_UINT64);
+    CHECK(a.px_type() == TILEDB_UINT64);
+  }
+
+  SECTION("uint8 uint64 uint64") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "uint8"},
+         {"id_type", "uint64"},
+         {"px_type", "uint64"}}));
+    CHECK(a.feature_type() == TILEDB_UINT8);
+    CHECK(a.id_type() == TILEDB_UINT64);
+    CHECK(a.px_type() == TILEDB_UINT64);
+  }
+}
+
+TEST_CASE("api_vamana_index: infer feature type", "[api_vamana_index]") {
+  auto a = IndexVamana(std::make_optional<IndexOptions>(
+      {{"id_type", "uint32"}, {"px_type", "uint32"}}));
+  auto ctx = tiledb::Context{};
+  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+  a.train(training_set);
+  CHECK(a.feature_type() == TILEDB_FLOAT32);
+  CHECK(a.id_type() == TILEDB_UINT32);
+  CHECK(a.px_type() == TILEDB_UINT32);
+}
+
+TEST_CASE("api_vamana_index: infer dimension", "[api_vamana_index]") {
+  auto a = IndexVamana(std::make_optional<IndexOptions>(
+      {{"id_type", "uint32"}, {"px_type", "uint32"}}));
+  auto ctx = tiledb::Context{};
+  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+  CHECK(dimension(a) == 0);
+  a.train(training_set);
+  CHECK(a.feature_type() == TILEDB_FLOAT32);
+  CHECK(a.id_type() == TILEDB_UINT32);
+  CHECK(a.px_type() == TILEDB_UINT32);
+  CHECK(dimension(a) == 128);
+}
 
  TEST_CASE(
     "api_vamana_index: api_vamana_index write and read",
@@ -175,137 +174,62 @@
   CHECK(a.id_type() == b.id_type());
   CHECK(a.px_type() == b.px_type());
 }
-//
-// TEST_CASE(
-//    "api_vamana_index: build index and query in place infinite",
-//    "[api_vamana_index][ci-skip]") {
-//  auto ctx = tiledb::Context{};
-//  size_t k_nn = 10;
-//  size_t nprobe = GENERATE(8, 32);
-//
-//  auto a = IndexVamana(std::make_optional<IndexOptions>(
-//      {{"id_type", "uint32"}, {"px_type", "uint32"}}));
-//  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-//  auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
-//  auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
-//  a.train(training_set);
-//  a.add(training_set);
-//
-//  SECTION("infinite, nprobe = " + std::to_string(nprobe)) {
-//    INFO("infinite, nprobe = " + std::to_string(nprobe));
-//    auto&& [s, t] = a.query(query_set, k_nn);
-//
-//    auto intersections = count_intersections(t, groundtruth_set, k_nn);
-//    auto nt = num_vectors(t);
-//    auto recall = ((double)intersections) / ((double)nt * k_nn);
-//    if (nprobe == 32) {
-//      CHECK(recall == 1.0);
-//    } else if (nprobe == 8) {
-//      CHECK(recall > 0.925);
-//    }
-//  }
-//
-//// Catch2 isn't catching this exception
-// #if 0
-//   SECTION("finite, nprobe = std::to_string(nprobe) " + std::to_string(nprobe)
-//   + " throws") {
-//     INFO("finite, nprobe = std::to_string(nprobe)" + std::to_string(nprobe) +
-//     "throws"); CHECK_THROWS(a.query_finite_ram(query_set, k_nn, nprobe));
-//   }
-// #endif
-// }
-//
-// TEST_CASE(
-//     "api_vamana_index: read index and query infinite and finite",
-//     "[api_vamana_index][ci-skip]") {
-//   auto ctx = tiledb::Context{};
-//   size_t k_nn = 10;
-//   size_t nprobe = GENERATE(8, 32);
-//   size_t max_iter = GENERATE(4, 8);
-//
-//   std::string api_vamana_index_uri = "/tmp/api_vamana_index";
-//
-//   auto a = IndexVamana(std::make_optional<IndexOptions>(
-//       {{"feature_type", "float32"},
-//        {"id_type", "uint32"},
-//        {"px_type", "uint32"},
-//        {"max_iter", std::to_string(max_iter)}}));
-//
-//   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-//   a.train(training_set);
-//   a.add(training_set);
-//   a.write_index(ctx, api_vamana_index_uri, true);
-//   auto b = IndexVamana(ctx, api_vamana_index_uri);
-//
-//   auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
-//   auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
-//
-//   SECTION(
-//       "finite all in core, default, nprobe = std::to_string(nprobe)" +
-//       std::to_string(nprobe)) {
-//     INFO(
-//         "finite all in core, default, nprobe = std::to_string(nprobe)" +
-//         std::to_string(nprobe));
-//     auto&& [s, t] = a.query(query_set, k_nn);
-//     auto&& [u, v] = b.query(query_set, k_nn);
-//
-//     auto intersections_a = count_intersections(t, groundtruth_set, k_nn);
-//     auto intersections_b = count_intersections(v, groundtruth_set, k_nn);
-//     CHECK(intersections_a == intersections_b);
-//     auto nt = num_vectors(t);
-//     auto nv = num_vectors(v);
-//     CHECK(nt == nv);
-//     auto recall = ((double)intersections_a) / ((double)nt * k_nn);
-//     if (nprobe == 32) {
-//       CHECK(recall == 1.0);
-//     } else if (nprobe == 8) {
-//       CHECK(recall > 0.925);
-//     }
-//   }
-//
-//   SECTION(
-//       "finite all in core, 0, nprobe = std::to_string(nprobe)" +
-//       std::to_string(nprobe)) {
-//     INFO(
-//         "finite all in core, 0, nprobe = std::to_string(nprobe)" +
-//         std::to_string(nprobe));
-//     auto&& [s, t] = a.query(query_set, k_nn);
-//     auto&& [u, v] = b.query(query_set, k_nn);
-//
-//     auto intersections_a = count_intersections(t, groundtruth_set, k_nn);
-//     auto intersections_b = count_intersections(v, groundtruth_set, k_nn);
-//     CHECK(intersections_a == intersections_b);
-//     auto nt = num_vectors(t);
-//     auto nv = num_vectors(v);
-//     CHECK(nt == nv);
-//     auto recall = ((double)intersections_a) / ((double)nt * k_nn);
-//     if (nprobe == 32) {
-//       CHECK(recall == 1.0);
-//     } else if (nprobe == 8) {
-//       CHECK(recall > 0.925);
-//     }
-//   }
-//
-//   SECTION(
-//       "finite out of core, 1000, nprobe = std::to_string(nprobe)" +
-//       std::to_string(nprobe)) {
-//     INFO(
-//         "finite out of core, 1000, nprobe = std::to_string(nprobe)" +
-//         std::to_string(nprobe));
-//     auto&& [s, t] = a.query(query_set, k_nn);
-//     auto&& [u, v] = b.query(query_set, k_nn);
-//
-//     auto intersections_a = count_intersections(t, groundtruth_set, k_nn);
-//     auto intersections_b = count_intersections(v, groundtruth_set, k_nn);
-//     CHECK(intersections_a == intersections_b);
-//     auto nt = num_vectors(t);
-//     auto nv = num_vectors(v);
-//     CHECK(nt == nv);
-//     auto recall = ((double)intersections_a) / ((double)nt * k_nn);
-//     if (nprobe == 32) {
-//       CHECK(recall == 1.0);
-//     } else if (nprobe == 8) {
-//       CHECK(recall > 0.925);
-//     }
-//   }
-// }
+
+ TEST_CASE(
+    "api_vamana_index: build index and query in place infinite",
+    "[api_vamana_index][ci-skip]") {
+    auto ctx = tiledb::Context{};
+    size_t k_nn = 10;
+    size_t nprobe = GENERATE(8, 32);
+
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+      {{"id_type", "uint32"}, {"px_type", "uint32"}}));
+    auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+    auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
+    auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
+    a.train(training_set);
+    a.add(training_set);
+
+    auto&& [s, t] = a.query(query_set, k_nn);
+
+    auto intersections = count_intersections(t, groundtruth_set, k_nn);
+    auto nt = num_vectors(t);
+    auto recall = ((double)intersections) / ((double)nt * k_nn);
+    CHECK(recall == 1.0);
+ }
+
+ TEST_CASE(
+     "api_vamana_index: read index and query infinite and finite",
+     "[api_vamana_index][ci-skip]") {
+    auto ctx = tiledb::Context{};
+    size_t k_nn = 10;
+    size_t nprobe = GENERATE(8, 32);
+
+    std::string api_vamana_index_uri = "/tmp/api_vamana_index";
+
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+       {{"feature_type", "float32"},
+        {"id_type", "uint32"},
+        {"px_type", "uint32"}}));
+
+    auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+    a.train(training_set);
+    a.add(training_set);
+    a.write_index(ctx, api_vamana_index_uri, true);
+    auto b = IndexVamana(ctx, api_vamana_index_uri);
+
+    auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
+    auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
+
+    auto&& [s, t] = a.query(query_set, k_nn);
+    auto&& [u, v] = b.query(query_set, k_nn);
+
+    auto intersections_a = count_intersections(t, groundtruth_set, k_nn);
+    auto intersections_b = count_intersections(v, groundtruth_set, k_nn);
+    CHECK(intersections_a == intersections_b);
+    auto nt = num_vectors(t);
+    auto nv = num_vectors(v);
+    CHECK(nt == nv);
+    auto recall = ((double)intersections_a) / ((double)nt * k_nn);
+    CHECK(recall == 1.0);
+ }

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -152,7 +152,7 @@ TEST_CASE("api_vamana_index: infer dimension", "[api_vamana_index]") {
   CHECK(dimension(a) == 128);
 }
 
- TEST_CASE(
+TEST_CASE(
     "api_vamana_index: api_vamana_index write and read",
     "[api_vamana_index][ci-skip]") {
   auto ctx = tiledb::Context{};
@@ -175,61 +175,61 @@ TEST_CASE("api_vamana_index: infer dimension", "[api_vamana_index]") {
   CHECK(a.px_type() == b.px_type());
 }
 
- TEST_CASE(
+TEST_CASE(
     "api_vamana_index: build index and query in place infinite",
     "[api_vamana_index][ci-skip]") {
-    auto ctx = tiledb::Context{};
-    size_t k_nn = 10;
-    size_t nprobe = GENERATE(8, 32);
+  auto ctx = tiledb::Context{};
+  size_t k_nn = 10;
+  size_t nprobe = GENERATE(8, 32);
 
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
+  auto a = IndexVamana(std::make_optional<IndexOptions>(
       {{"id_type", "uint32"}, {"px_type", "uint32"}}));
-    auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-    auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
-    auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
-    a.train(training_set);
-    a.add(training_set);
+  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+  auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
+  auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
+  a.train(training_set);
+  a.add(training_set);
 
-    auto&& [s, t] = a.query(query_set, k_nn);
+  auto&& [s, t] = a.query(query_set, k_nn);
 
-    auto intersections = count_intersections(t, groundtruth_set, k_nn);
-    auto nt = num_vectors(t);
-    auto recall = ((double)intersections) / ((double)nt * k_nn);
-    CHECK(recall == 1.0);
- }
+  auto intersections = count_intersections(t, groundtruth_set, k_nn);
+  auto nt = num_vectors(t);
+  auto recall = ((double)intersections) / ((double)nt * k_nn);
+  CHECK(recall == 1.0);
+}
 
- TEST_CASE(
-     "api_vamana_index: read index and query infinite and finite",
-     "[api_vamana_index][ci-skip]") {
-    auto ctx = tiledb::Context{};
-    size_t k_nn = 10;
-    size_t nprobe = GENERATE(8, 32);
+TEST_CASE(
+    "api_vamana_index: read index and query infinite and finite",
+    "[api_vamana_index][ci-skip]") {
+  auto ctx = tiledb::Context{};
+  size_t k_nn = 10;
+  size_t nprobe = GENERATE(8, 32);
 
-    std::string api_vamana_index_uri = "/tmp/api_vamana_index";
+  std::string api_vamana_index_uri = "/tmp/api_vamana_index";
 
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
-       {{"feature_type", "float32"},
-        {"id_type", "uint32"},
-        {"px_type", "uint32"}}));
+  auto a = IndexVamana(std::make_optional<IndexOptions>(
+      {{"feature_type", "float32"},
+       {"id_type", "uint32"},
+       {"px_type", "uint32"}}));
 
-    auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-    a.train(training_set);
-    a.add(training_set);
-    a.write_index(ctx, api_vamana_index_uri, true);
-    auto b = IndexVamana(ctx, api_vamana_index_uri);
+  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+  a.train(training_set);
+  a.add(training_set);
+  a.write_index(ctx, api_vamana_index_uri, true);
+  auto b = IndexVamana(ctx, api_vamana_index_uri);
 
-    auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
-    auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
+  auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
+  auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
 
-    auto&& [s, t] = a.query(query_set, k_nn);
-    auto&& [u, v] = b.query(query_set, k_nn);
+  auto&& [s, t] = a.query(query_set, k_nn);
+  auto&& [u, v] = b.query(query_set, k_nn);
 
-    auto intersections_a = count_intersections(t, groundtruth_set, k_nn);
-    auto intersections_b = count_intersections(v, groundtruth_set, k_nn);
-    CHECK(intersections_a == intersections_b);
-    auto nt = num_vectors(t);
-    auto nv = num_vectors(v);
-    CHECK(nt == nv);
-    auto recall = ((double)intersections_a) / ((double)nt * k_nn);
-    CHECK(recall == 1.0);
- }
+  auto intersections_a = count_intersections(t, groundtruth_set, k_nn);
+  auto intersections_b = count_intersections(v, groundtruth_set, k_nn);
+  CHECK(intersections_a == intersections_b);
+  auto nt = num_vectors(t);
+  auto nv = num_vectors(v);
+  CHECK(nt == nv);
+  auto recall = ((double)intersections_a) / ((double)nt * k_nn);
+  CHECK(recall == 1.0);
+}

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -1,0 +1,311 @@
+/**
+ * @file   unit_api_vamana_index.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ */
+
+#include "api/vamana_index.h"
+#include "catch2/catch_all.hpp"
+#include "test/query_common.h"
+
+//TEST_CASE("api_vamana_index: test test", "[api_vamana_index]") {
+//  REQUIRE(true);
+//}
+//
+//TEST_CASE("api_vamana_index: init constructor", "[api_vamana_index]") {
+//  SECTION("default") {
+//    auto a = IndexVamana();
+//    CHECK(a.feature_type() == TILEDB_ANY);
+//    CHECK(a.id_type() == TILEDB_UINT32);
+//    CHECK(a.px_type() == TILEDB_UINT32);
+//    CHECK(dimension(a) == 0);
+//  }
+//
+//  SECTION("float uint32 uint32") {
+//    auto a = IndexVamana(std::make_optional<IndexOptions>(
+//        {{"feature_type", "float32"},
+//         {"id_type", "uint32"},
+//         {"px_type", "uint32"}}));
+//    CHECK(a.feature_type() == TILEDB_FLOAT32);
+//    CHECK(a.id_type() == TILEDB_UINT32);
+//    CHECK(a.px_type() == TILEDB_UINT32);
+//    CHECK(dimension(a) == 0);
+//  }
+//
+//  SECTION("uint8 uint32 uint32") {
+//    auto a = IndexVamana(std::make_optional<IndexOptions>(
+//        {{"feature_type", "uint8"},
+//         {"id_type", "uint32"},
+//         {"px_type", "uint32"}}));
+//    CHECK(a.feature_type() == TILEDB_UINT8);
+//    CHECK(a.id_type() == TILEDB_UINT32);
+//    CHECK(a.px_type() == TILEDB_UINT32);
+//  }
+//
+//  SECTION("float uint64 uint32") {
+//    auto a = IndexVamana(std::make_optional<IndexOptions>(
+//        {{"feature_type", "float32"},
+//         {"id_type", "uint64"},
+//         {"px_type", "uint32"}}));
+//    CHECK(a.feature_type() == TILEDB_FLOAT32);
+//    CHECK(a.id_type() == TILEDB_UINT64);
+//    CHECK(a.px_type() == TILEDB_UINT32);
+//  }
+//
+//  SECTION("float uint32 uint64") {
+//    auto a = IndexVamana(std::make_optional<IndexOptions>(
+//        {{"feature_type", "float32"},
+//         {"id_type", "uint32"},
+//         {"px_type", "uint64"}}));
+//    CHECK(a.feature_type() == TILEDB_FLOAT32);
+//    CHECK(a.id_type() == TILEDB_UINT32);
+//    CHECK(a.px_type() == TILEDB_UINT64);
+//  }
+//
+//  SECTION("uint8 uint64 uint32") {
+//    auto a = IndexVamana(std::make_optional<IndexOptions>(
+//        {{"feature_type", "uint8"},
+//         {"id_type", "uint64"},
+//         {"px_type", "uint32"}}));
+//    CHECK(a.feature_type() == TILEDB_UINT8);
+//    CHECK(a.id_type() == TILEDB_UINT64);
+//    CHECK(a.px_type() == TILEDB_UINT32);
+//  }
+//
+//  SECTION("uint8 uint32 uint64") {
+//    auto a = IndexVamana(std::make_optional<IndexOptions>(
+//        {{"feature_type", "uint8"},
+//         {"id_type", "uint32"},
+//         {"px_type", "uint64"}}));
+//    CHECK(a.feature_type() == TILEDB_UINT8);
+//    CHECK(a.id_type() == TILEDB_UINT32);
+//    CHECK(a.px_type() == TILEDB_UINT64);
+//  }
+//
+//  SECTION("float uint64 uint64") {
+//    auto a = IndexVamana(std::make_optional<IndexOptions>(
+//        {{"feature_type", "float32"},
+//         {"id_type", "uint64"},
+//         {"px_type", "uint64"}}));
+//    CHECK(a.feature_type() == TILEDB_FLOAT32);
+//    CHECK(a.id_type() == TILEDB_UINT64);
+//    CHECK(a.px_type() == TILEDB_UINT64);
+//  }
+//
+//  SECTION("uint8 uint64 uint64") {
+//    auto a = IndexVamana(std::make_optional<IndexOptions>(
+//        {{"feature_type", "uint8"},
+//         {"id_type", "uint64"},
+//         {"px_type", "uint64"}}));
+//    CHECK(a.feature_type() == TILEDB_UINT8);
+//    CHECK(a.id_type() == TILEDB_UINT64);
+//    CHECK(a.px_type() == TILEDB_UINT64);
+//  }
+//}
+//
+//TEST_CASE("api_vamana_index: infer feature type", "[api_vamana_index]") {
+//  auto a = IndexVamana(std::make_optional<IndexOptions>(
+//      {{"id_type", "uint32"}, {"px_type", "uint32"}}));
+//  auto ctx = tiledb::Context{};
+//  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+//  a.train(training_set);
+//  CHECK(a.feature_type() == TILEDB_FLOAT32);
+//  CHECK(a.id_type() == TILEDB_UINT32);
+//  CHECK(a.px_type() == TILEDB_UINT32);
+//}
+//
+//TEST_CASE("api_vamana_index: infer dimension", "[api_vamana_index]") {
+//  auto a = IndexVamana(std::make_optional<IndexOptions>(
+//      {{"id_type", "uint32"}, {"px_type", "uint32"}}));
+//  auto ctx = tiledb::Context{};
+//  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+//  CHECK(dimension(a) == 0);
+//  a.train(training_set);
+//  CHECK(a.feature_type() == TILEDB_FLOAT32);
+//  CHECK(a.id_type() == TILEDB_UINT32);
+//  CHECK(a.px_type() == TILEDB_UINT32);
+//  CHECK(dimension(a) == 128);
+//}
+
+
+ TEST_CASE(
+    "api_vamana_index: api_vamana_index write and read",
+    "[api_vamana_index][ci-skip]") {
+  auto ctx = tiledb::Context{};
+  std::string api_vamana_index_uri = "/tmp/api_vamana_index";
+
+  auto a = IndexVamana(std::make_optional<IndexOptions>(
+      {{"feature_type", "float32"},
+       {"id_type", "uint32"},
+       {"px_type", "uint32"}}));
+  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+  a.train(training_set);
+  a.add(training_set);
+  a.write_index(ctx, api_vamana_index_uri, true);
+
+  auto b = IndexVamana(ctx, api_vamana_index_uri);
+
+  CHECK(dimension(a) == dimension(b));
+  CHECK(a.feature_type() == b.feature_type());
+  CHECK(a.id_type() == b.id_type());
+  CHECK(a.px_type() == b.px_type());
+}
+//
+// TEST_CASE(
+//    "api_vamana_index: build index and query in place infinite",
+//    "[api_vamana_index][ci-skip]") {
+//  auto ctx = tiledb::Context{};
+//  size_t k_nn = 10;
+//  size_t nprobe = GENERATE(8, 32);
+//
+//  auto a = IndexVamana(std::make_optional<IndexOptions>(
+//      {{"id_type", "uint32"}, {"px_type", "uint32"}}));
+//  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+//  auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
+//  auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
+//  a.train(training_set);
+//  a.add(training_set);
+//
+//  SECTION("infinite, nprobe = " + std::to_string(nprobe)) {
+//    INFO("infinite, nprobe = " + std::to_string(nprobe));
+//    auto&& [s, t] = a.query(query_set, k_nn);
+//
+//    auto intersections = count_intersections(t, groundtruth_set, k_nn);
+//    auto nt = num_vectors(t);
+//    auto recall = ((double)intersections) / ((double)nt * k_nn);
+//    if (nprobe == 32) {
+//      CHECK(recall == 1.0);
+//    } else if (nprobe == 8) {
+//      CHECK(recall > 0.925);
+//    }
+//  }
+//
+//// Catch2 isn't catching this exception
+// #if 0
+//   SECTION("finite, nprobe = std::to_string(nprobe) " + std::to_string(nprobe)
+//   + " throws") {
+//     INFO("finite, nprobe = std::to_string(nprobe)" + std::to_string(nprobe) +
+//     "throws"); CHECK_THROWS(a.query_finite_ram(query_set, k_nn, nprobe));
+//   }
+// #endif
+// }
+//
+// TEST_CASE(
+//     "api_vamana_index: read index and query infinite and finite",
+//     "[api_vamana_index][ci-skip]") {
+//   auto ctx = tiledb::Context{};
+//   size_t k_nn = 10;
+//   size_t nprobe = GENERATE(8, 32);
+//   size_t max_iter = GENERATE(4, 8);
+//
+//   std::string api_vamana_index_uri = "/tmp/api_vamana_index";
+//
+//   auto a = IndexVamana(std::make_optional<IndexOptions>(
+//       {{"feature_type", "float32"},
+//        {"id_type", "uint32"},
+//        {"px_type", "uint32"},
+//        {"max_iter", std::to_string(max_iter)}}));
+//
+//   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+//   a.train(training_set);
+//   a.add(training_set);
+//   a.write_index(ctx, api_vamana_index_uri, true);
+//   auto b = IndexVamana(ctx, api_vamana_index_uri);
+//
+//   auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
+//   auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
+//
+//   SECTION(
+//       "finite all in core, default, nprobe = std::to_string(nprobe)" +
+//       std::to_string(nprobe)) {
+//     INFO(
+//         "finite all in core, default, nprobe = std::to_string(nprobe)" +
+//         std::to_string(nprobe));
+//     auto&& [s, t] = a.query(query_set, k_nn);
+//     auto&& [u, v] = b.query(query_set, k_nn);
+//
+//     auto intersections_a = count_intersections(t, groundtruth_set, k_nn);
+//     auto intersections_b = count_intersections(v, groundtruth_set, k_nn);
+//     CHECK(intersections_a == intersections_b);
+//     auto nt = num_vectors(t);
+//     auto nv = num_vectors(v);
+//     CHECK(nt == nv);
+//     auto recall = ((double)intersections_a) / ((double)nt * k_nn);
+//     if (nprobe == 32) {
+//       CHECK(recall == 1.0);
+//     } else if (nprobe == 8) {
+//       CHECK(recall > 0.925);
+//     }
+//   }
+//
+//   SECTION(
+//       "finite all in core, 0, nprobe = std::to_string(nprobe)" +
+//       std::to_string(nprobe)) {
+//     INFO(
+//         "finite all in core, 0, nprobe = std::to_string(nprobe)" +
+//         std::to_string(nprobe));
+//     auto&& [s, t] = a.query(query_set, k_nn);
+//     auto&& [u, v] = b.query(query_set, k_nn);
+//
+//     auto intersections_a = count_intersections(t, groundtruth_set, k_nn);
+//     auto intersections_b = count_intersections(v, groundtruth_set, k_nn);
+//     CHECK(intersections_a == intersections_b);
+//     auto nt = num_vectors(t);
+//     auto nv = num_vectors(v);
+//     CHECK(nt == nv);
+//     auto recall = ((double)intersections_a) / ((double)nt * k_nn);
+//     if (nprobe == 32) {
+//       CHECK(recall == 1.0);
+//     } else if (nprobe == 8) {
+//       CHECK(recall > 0.925);
+//     }
+//   }
+//
+//   SECTION(
+//       "finite out of core, 1000, nprobe = std::to_string(nprobe)" +
+//       std::to_string(nprobe)) {
+//     INFO(
+//         "finite out of core, 1000, nprobe = std::to_string(nprobe)" +
+//         std::to_string(nprobe));
+//     auto&& [s, t] = a.query(query_set, k_nn);
+//     auto&& [u, v] = b.query(query_set, k_nn);
+//
+//     auto intersections_a = count_intersections(t, groundtruth_set, k_nn);
+//     auto intersections_b = count_intersections(v, groundtruth_set, k_nn);
+//     CHECK(intersections_a == intersections_b);
+//     auto nt = num_vectors(t);
+//     auto nv = num_vectors(v);
+//     CHECK(nt == nv);
+//     auto recall = ((double)intersections_a) / ((double)nt * k_nn);
+//     if (nprobe == 32) {
+//       CHECK(recall == 1.0);
+//     } else if (nprobe == 8) {
+//       CHECK(recall > 0.925);
+//     }
+//   }
+// }


### PR DESCRIPTION
### What
A few changes:
1. Replace switch-case statements in type-erased `api/vamana_index.h` API with a lookup table 
2. Add a unit test for `src/include/api/vamana_index.h`
3. While adding this test I found a error because we expect `px_datatype` to be in the metadata. So we add it:
```
IndexVamana(
      const tiledb::Context& ctx,
      const URI& group_uri,
      const std::optional<IndexOptions>& config = std::nullopt) {
    using metadata_element = std::tuple<std::string, void*, tiledb_datatype_t>;
    std::vector<metadata_element> metadata{
        {"feature_datatype", &feature_datatype_, TILEDB_UINT32},
        {"id_datatype", &id_datatype_, TILEDB_UINT32},
        {"px_datatype", &px_datatype_, TILEDB_UINT32}};

    tiledb::Config cfg;
    tiledb::Group read_group(ctx, group_uri, TILEDB_READ, cfg);

    for (auto& [name, value, datatype] : metadata) {
      if (!read_group.has_metadata(name, &datatype)) {
        throw std::runtime_error("Missing metadata: " + name);
      }
```

### Testing
Adds a unit test.