### PR TITLE
Fix all MSVC compilation issues

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [windows-2022]
         # `windows-2022, ` blocked by https://github.com/pybind/pybind11/issues/3445#issuecomment-1525500927
 
     steps:
@@ -81,7 +81,7 @@ jobs:
           brew install automake pkg-config ninja
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
           CIBW_SKIP: "*-win32 cp27-* cp35-* cp36-* cp37-* pp* *_i686 *musllinux*"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,7 +103,9 @@ endif()
 # Control compiler-specific flags.
 include(CompilerFlags)
 
-add_compile_options(/bigobj)
+if (MSVC)
+    add_compile_options(/bigobj)
+endif()
 
 if (NOT $ENV{CIBUILDWHEEL} EQUAL 1 AND NOT $ENV{CONDA_BUILD} EQUAL 1)
   if(MSVC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,8 @@ endif()
 # Control compiler-specific flags.
 include(CompilerFlags)
 
+add_compile_options(/bigobj)
+
 if (NOT $ENV{CIBUILDWHEEL} EQUAL 1 AND NOT $ENV{CONDA_BUILD} EQUAL 1)
   if(MSVC)
       set(CMAKE_CXX_FLAGS_DEBUG "/Od /Zi /EHsc /RTC1" CACHE STRING "" FORCE)

--- a/src/include/detail/graph/vamana.h
+++ b/src/include/detail/graph/vamana.h
@@ -222,7 +222,7 @@ auto greedy_search(
         // @todo (actually it does, but shouldn't need it -- need to
         // investigate) if (result.template insert /*<unique_id>*/ (score, p)) {
         if (result.template insert<unique_id>(score, p)) {
-          q2.template insert /*<unique_id>*/ (score, p);
+          q2.template insert<unique_id>(score, p);
         }
       }
     }

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -66,6 +66,7 @@
 #include <type_traits>
 #include <vector>
 #include <version>
+#include <algorithm>
 
 #include <tiledb/tiledb>
 #include "mdspan/mdspan.hpp"
@@ -373,8 +374,8 @@ class tdbPartitionedMatrix
     }
 
     // auto max_resident_parts = 0UL;
-    auto running_resident_parts = 0UL;
-    auto running_resident_size = 0UL;
+    size_t running_resident_parts = 0UL;
+    size_t running_resident_size = 0UL;
     for (size_t i = 0; i < total_num_parts_; ++i) {
       auto part_size = master_indices_[relevant_parts_[i] + 1] -
                        master_indices_[relevant_parts_[i]];

--- a/src/include/index/index_defs.h
+++ b/src/include/index/index_defs.h
@@ -80,7 +80,7 @@ enum class IndexKind {
 
 // @todo Use enum for key rather than string?
 using StorageFormat =
-    std::map<std::string, std::map<std::string, std::filesystem::path>>;
+    std::map<std::string, std::map<std::string, std::string>>;
 [[maybe_unused]] static StorageFormat storage_formats = {
     {"0.1",
      {

--- a/src/include/index/ivf_flat_group.h
+++ b/src/include/index/ivf_flat_group.h
@@ -60,7 +60,7 @@ class ivf_flat_index_group {
   // Index* index_ {nullptr};
 
   std::reference_wrapper<const tiledb::Context> cached_ctx_;
-  std::filesystem::path group_uri_;
+  std::string group_uri_;
   size_t index_timestamp_{0};
   size_t group_timestamp_{0};
   size_t timetravel_index_{0};
@@ -136,7 +136,7 @@ class ivf_flat_index_group {
     }
     active_array_names_.insert(array_name);
 
-    std::filesystem::path uri = array_name_to_uri(array_name);
+    std::string uri = array_name_to_uri(array_name);
 
     return uri;
   }
@@ -628,7 +628,7 @@ class ivf_flat_index_group {
       std::cout << "# " + msg << std::endl;
     }
     std::cout << "-------------------------------------------------------\n";
-    std::cout << "Stored in " + group_uri_.string() + ":" << std::endl;
+    std::cout << "Stored in " + group_uri_ + ":" << std::endl;
     auto cfg = tiledb::Config();
     auto read_group = tiledb::Group(cached_ctx_, group_uri_, TILEDB_READ, cfg);
     for (size_t i = 0; i < read_group.member_count(); ++i) {

--- a/src/include/index/ivf_flat_group.h
+++ b/src/include/index/ivf_flat_group.h
@@ -336,12 +336,12 @@ class ivf_flat_index_group {
   /** Convert an array name to a uri. */
   constexpr std::string array_name_to_uri(
       const std::string& array_name) const noexcept {
-    return group_uri_ / array_name;
+    return (std::filesystem::path{group_uri_} / array_name).string();
   }
 
   /** Convert an array key to a uri. */
   constexpr std::string array_key_to_uri(const std::string& array_key) const {
-    return group_uri_ / array_key_to_array_name(array_key);
+    return (std::filesystem::path{group_uri_} / array_key_to_array_name(array_key)).string();
   }
 
  public:

--- a/src/include/test/array_defs.h
+++ b/src/include/test/array_defs.h
@@ -38,6 +38,14 @@
 
 #include "config.h"
 
+namespace {
+
+    std::string operator/(const std::string& lhs, const std::string& rhs) {
+        return (std::filesystem::path{lhs} / rhs).string();
+    }
+
+}
+
 /**
  * @brief  Some default types used in unit tests.
  */
@@ -56,10 +64,10 @@ using test_indices_type = uint64_t;  // Should be same as groundtruth_type
  * so we put it in CMAKE_SOURCE_DIR/external/test_arrays.
  */
 static std::filesystem::path cmake_source_dir{CMAKE_SOURCE_DIR};
-static std::filesystem::path test_data_root{
-    cmake_source_dir.parent_path() / "external" / "test_data"};
-static std::filesystem::path test_array_root{test_data_root / "arrays"};
-static std::filesystem::path test_file_root{test_data_root / "files"};
+static std::string test_data_root =
+    (cmake_source_dir.parent_path() / "external" / "test_data").string();
+static std::string test_array_root{test_data_root / "arrays"};
+static std::string test_file_root{test_data_root / "files"};
 
 /**
  * @brief  Array URIs for arrays used for unit testing of IVF indexes.
@@ -92,21 +100,21 @@ using sift_ids_type = uint64_t;
 using sift_indices_type = uint64_t;
 #ifdef USE_1M_UNIT_TEST_ARRAYS
 constexpr size_t num_sift_vectors = 1'000'000;
-static std::filesystem::path sift_root{test_array_root / "sift"};
+static std::string sift_root{test_array_root / "sift"};
 #else
 constexpr size_t num_sift_vectors = 10'000;
-static std::filesystem::path sift_root{test_array_root / "siftsmall"};
+static std::string sift_root{test_array_root / "siftsmall"};
 #endif
 constexpr size_t sift_dimension = 128;
-static std::filesystem::path sift_group_uri{sift_root / "group"};
-static std::filesystem::path sift_inputs_uri{sift_root / "input_vectors"};
-static std::filesystem::path sift_centroids_uri{
+static std::string sift_group_uri{sift_root / "group"};
+static std::string sift_inputs_uri{sift_root / "input_vectors"};
+static std::string sift_centroids_uri{
     sift_root / "partition_centroids"};
-static std::filesystem::path sift_index_uri{sift_root / "partition_indexes"};
-static std::filesystem::path sift_ids_uri{sift_root / "shuffled_vector_ids"};
-static std::filesystem::path sift_parts_uri{sift_root / "shuffled_vectors"};
-static std::filesystem::path sift_query_uri{sift_root / "queries"};
-static std::filesystem::path sift_groundtruth_uri{sift_root / "groundtruth"};
+static std::string sift_index_uri{sift_root / "partition_indexes"};
+static std::string sift_ids_uri{sift_root / "shuffled_vector_ids"};
+static std::string sift_parts_uri{sift_root / "shuffled_vectors"};
+static std::string sift_query_uri{sift_root / "queries"};
+static std::string sift_groundtruth_uri{sift_root / "groundtruth"};
 
 using siftsmall_feature_type = float;
 using siftsmall_groundtruth_type = uint64_t;  // int32?
@@ -115,20 +123,20 @@ using siftsmall_ids_type = uint64_t;
 using siftsmall_indices_type = uint64_t;
 constexpr size_t num_siftsmall_vectors = 10'000;
 constexpr size_t siftsmall_dimension = 128;
-static std::filesystem::path siftsmall_root{test_array_root / "siftsmall"};
-static std::filesystem::path siftsmall_group_uri{siftsmall_root / "group"};
-static std::filesystem::path siftsmall_inputs_uri{
+static std::string siftsmall_root{test_array_root / "siftsmall"};
+static std::string siftsmall_group_uri{siftsmall_root / "group"};
+static std::string siftsmall_inputs_uri{
     siftsmall_root / "input_vectors"};
-static std::filesystem::path siftsmall_centroids_uri{
+static std::string siftsmall_centroids_uri{
     siftsmall_root / "partition_centroids"};
-static std::filesystem::path siftsmall_index_uri{
+static std::string siftsmall_index_uri{
     siftsmall_root / "partition_indexes"};
-static std::filesystem::path siftsmall_ids_uri{
+static std::string siftsmall_ids_uri{
     siftsmall_root / "shuffled_vector_ids"};
-static std::filesystem::path siftsmall_parts_uri{
+static std::string siftsmall_parts_uri{
     siftsmall_root / "shuffled_vectors"};
-static std::filesystem::path siftsmall_query_uri{siftsmall_root / "queries"};
-static std::filesystem::path siftsmall_groundtruth_uri{
+static std::string siftsmall_query_uri{siftsmall_root / "queries"};
+static std::string siftsmall_groundtruth_uri{
     siftsmall_root / "groundtruth"};
 
 using siftsmall_uint8_feature_type = uint8_t;
@@ -138,23 +146,23 @@ using siftsmall_uint8_ids_type = uint64_t;
 using siftsmall_uint8_indices_type = uint64_t;
 constexpr size_t num_siftsmall_uint8_vectors = 10'000;
 constexpr size_t siftsmall_uint8_dimension = 128;
-static std::filesystem::path siftsmall_uint8_root{
+static std::string siftsmall_uint8_root{
     test_array_root / "siftsmall_uint8"};
-static std::filesystem::path siftsmall_uint8_group_uri{
+static std::string siftsmall_uint8_group_uri{
     siftsmall_uint8_root / "group"};
-static std::filesystem::path siftsmall_uint8_inputs_uri{
+static std::string siftsmall_uint8_inputs_uri{
     siftsmall_uint8_root / "input_vectors"};
-static std::filesystem::path siftsmall_uint8_centroids_uri{
+static std::string siftsmall_uint8_centroids_uri{
     siftsmall_uint8_root / "partition_centroids"};
-static std::filesystem::path siftsmall_uint8_index_uri{
+static std::string siftsmall_uint8_index_uri{
     siftsmall_uint8_root / "partition_indexes"};
-static std::filesystem::path siftsmall_uint8_ids_uri{
+static std::string siftsmall_uint8_ids_uri{
     siftsmall_uint8_root / "shuffled_vector_ids"};
-static std::filesystem::path siftsmall_uint8_parts_uri{
+static std::string siftsmall_uint8_parts_uri{
     siftsmall_uint8_root / "shuffled_vectors"};
-static std::filesystem::path siftsmall_uint8_query_uri{
+static std::string siftsmall_uint8_query_uri{
     siftsmall_uint8_root / "queries"};
-static std::filesystem::path siftsmall_uint8_groundtruth_uri{
+static std::string siftsmall_uint8_groundtruth_uri{
     siftsmall_uint8_root / "groundtruth"};
 
 using bigann1M_feature_type = uint8_t;
@@ -164,25 +172,25 @@ using bigann1M_ids_type = uint64_t;
 using bigann1M_indices_type = uint64_t;
 #ifdef USE_1M_UNIT_TEST_ARRAYS
 constexpr size_t num_bigann1M_vectors = 1'000'000;
-static std::filesystem::path bigann1M_root{test_array_root / "bigann1M"};
+static std::string bigann1M_root{test_array_root / "bigann1M"};
 #else
-static std::filesystem::path bigann1M_root{test_array_root / "bigann10k"};
+static std::string bigann1M_root{test_array_root / "bigann10k"};
 constexpr size_t num_bigann1M_vectors = 10'000;
 #endif
 constexpr size_t bigann1M_dimension = 128;
-static std::filesystem::path bigann1M_group_uri{bigann1M_root / "group"};
-static std::filesystem::path bigann1M_inputs_uri{
+static std::string bigann1M_group_uri{bigann1M_root / "group"};
+static std::string bigann1M_inputs_uri{
     bigann1M_root / "input_vectors"};
-static std::filesystem::path bigann1M_centroids_uri{
+static std::string bigann1M_centroids_uri{
     bigann1M_root / "partition_centroids"};
-static std::filesystem::path bigann1M_index_uri{
+static std::string bigann1M_index_uri{
     bigann1M_root / "partition_indexes"};
-static std::filesystem::path bigann1M_ids_uri{
+static std::string bigann1M_ids_uri{
     bigann1M_root / "shuffled_vector_ids"};
-static std::filesystem::path bigann1M_parts_uri{
+static std::string bigann1M_parts_uri{
     bigann1M_root / "shuffled_vectors"};
-static std::filesystem::path bigann1M_query_uri{bigann1M_root / "queries"};
-static std::filesystem::path bigann1M_groundtruth_uri{
+static std::string bigann1M_query_uri{bigann1M_root / "queries"};
+static std::string bigann1M_groundtruth_uri{
     bigann1M_root / "groundtruth"};
 
 using bigann10k_feature_type = uint8_t;
@@ -192,20 +200,20 @@ using bigann10k_ids_type = uint64_t;
 using bigann10k_indices_type = uint64_t;
 constexpr size_t num_bigann10k_vectors = 10'000;
 constexpr size_t bigann10k_dimension = 128;
-static std::filesystem::path bigann10k_root{test_array_root / "bigann10k"};
-static std::filesystem::path bigann10k_group_uri{bigann10k_root / "group"};
-static std::filesystem::path bigann10k_inputs_uri{
+static std::string bigann10k_root{test_array_root / "bigann10k"};
+static std::string bigann10k_group_uri{bigann10k_root / "group"};
+static std::string bigann10k_inputs_uri{
     bigann10k_root / "input_vectors"};
-static std::filesystem::path bigann10k_centroids_uri{
+static std::string bigann10k_centroids_uri{
     bigann10k_root / "partition_centroids"};
-static std::filesystem::path bigann10k_index_uri{
+static std::string bigann10k_index_uri{
     bigann10k_root / "partition_indexes"};
-static std::filesystem::path bigann10k_ids_uri{
+static std::string bigann10k_ids_uri{
     bigann10k_root / "shuffled_vector_ids"};
-static std::filesystem::path bigann10k_parts_uri{
+static std::string bigann10k_parts_uri{
     bigann10k_root / "shuffled_vectors"};
-static std::filesystem::path bigann10k_query_uri{bigann10k_root / "queries"};
-static std::filesystem::path bigann10k_groundtruth_uri{
+static std::string bigann10k_query_uri{bigann10k_root / "queries"};
+static std::string bigann10k_groundtruth_uri{
     bigann10k_root / "groundtruth"};
 
 using fmnistsmall_feature_type = float;
@@ -215,21 +223,21 @@ using fmnistsmall_ids_type = uint64_t;
 using fmnistsmall_indices_type = uint64_t;
 constexpr size_t num_fmnistsmall_vectors = 1'000;
 constexpr size_t fmnistsmall_dimension = 784;
-static std::filesystem::path fmnistsmall_root{test_array_root / "fmnistsmall"};
-static std::filesystem::path fmnistsmall_group_uri{fmnistsmall_root / "group"};
-static std::filesystem::path fmnistsmall_inputs_uri{
+static std::string fmnistsmall_root{test_array_root / "fmnistsmall"};
+static std::string fmnistsmall_group_uri{fmnistsmall_root / "group"};
+static std::string fmnistsmall_inputs_uri{
     fmnistsmall_root / "input_vectors"};
-static std::filesystem::path fmnistsmall_centroids_uri{
+static std::string fmnistsmall_centroids_uri{
     fmnistsmall_root / "partition_centroids"};
-static std::filesystem::path fmnistsmall_index_uri{
+static std::string fmnistsmall_index_uri{
     fmnistsmall_root / "partition_indexes"};
-static std::filesystem::path fmnistsmall_ids_uri{
+static std::string fmnistsmall_ids_uri{
     fmnistsmall_root / "shuffled_vector_ids"};
-static std::filesystem::path fmnistsmall_parts_uri{
+static std::string fmnistsmall_parts_uri{
     fmnistsmall_root / "shuffled_vectors"};
-static std::filesystem::path fmnistsmall_query_uri{
+static std::string fmnistsmall_query_uri{
     fmnistsmall_root / "queries"};
-static std::filesystem::path fmnistsmall_groundtruth_uri{
+static std::string fmnistsmall_groundtruth_uri{
     fmnistsmall_root / "groundtruth"};
 
 using fmnist_feature_type = float;
@@ -240,71 +248,71 @@ using fmnist_indices_type = uint64_t;
 
 #ifdef USE_1M_UNIT_TEST_ARRAYS
 constexpr size_t num_fmnist_vectors = 60'000;
-static std::filesystem::path fmnist_root{test_array_root / "fmnist"};
+static std::string fmnist_root{test_array_root / "fmnist"};
 #else
 constexpr size_t num_fmnist_vectors = num_fmnistsmall_vectors;
-static std::filesystem::path fmnist_root{test_array_root / "fmnistsmall"};
+static std::string fmnist_root{test_array_root / "fmnistsmall"};
 #endif
 constexpr size_t fmnist_dimension = 784;
 
-static std::filesystem::path fmnist_group_uri{fmnist_root / "group"};
-static std::filesystem::path fmnist_inputs_uri{fmnist_root / "input_vectors"};
-static std::filesystem::path fmnist_centroids_uri{
+static std::string fmnist_group_uri{fmnist_root / "group"};
+static std::string fmnist_inputs_uri{fmnist_root / "input_vectors"};
+static std::string fmnist_centroids_uri{
     fmnist_root / "partition_centroids"};
-static std::filesystem::path fmnist_index_uri{
+static std::string fmnist_index_uri{
     fmnist_root / "partition_indexes"};
-static std::filesystem::path fmnist_ids_uri{
+static std::string fmnist_ids_uri{
     fmnist_root / "shuffled_vector_ids"};
-static std::filesystem::path fmnist_parts_uri{fmnist_root / "shuffled_vectors"};
-static std::filesystem::path fmnist_query_uri{fmnist_root / "queries"};
-static std::filesystem::path fmnist_groundtruth_uri{
+static std::string fmnist_parts_uri{fmnist_root / "shuffled_vectors"};
+static std::string fmnist_query_uri{fmnist_root / "queries"};
+static std::string fmnist_groundtruth_uri{
     fmnist_root / "groundtruth"};
 
 /**
  * @brief Some additional arrays that are not part of the IVF index, but
  * are part of the full fmnist dataset.
  */
-static std::filesystem::path fmnist_train_uri{fmnist_root / "train"};
-static std::filesystem::path fmnist_distances_uri{fmnist_root / "distances"};
+static std::string fmnist_train_uri{fmnist_root / "train"};
+static std::string fmnist_distances_uri{fmnist_root / "distances"};
 
 /**
  * @brief Raw data files.  (Note:  These are files not arrays!)
  */
-static std::filesystem::path siftsmall_files_root{test_file_root / "siftsmall"};
-static std::filesystem::path siftsmall_inputs_file{
+static std::string siftsmall_files_root{test_file_root / "siftsmall"};
+static std::string siftsmall_inputs_file{
     siftsmall_files_root / "input_vectors.fvecs"};
-static std::filesystem::path siftsmall_query_file{
+static std::string siftsmall_query_file{
     siftsmall_files_root / "queries.fvecs"};
-static std::filesystem::path siftsmall_groundtruth_file{
+static std::string siftsmall_groundtruth_file{
     siftsmall_files_root / "groundtruth.ivecs"};
 
 /**
  * @brief Data files used in unit tests in the DiskANN git repo.
  * (Note:  These are files not arrays!)
  */
-static std::filesystem::path diskann_root{test_file_root / "diskann"};
-static std::filesystem::path diskann_test_256bin{
+static std::string diskann_root{test_file_root / "diskann"};
+static std::string diskann_test_256bin{
     diskann_root / "siftsmall_learn_256pts.fbin"};
-static std::filesystem::path diskann_test_data_file{
+static std::string diskann_test_data_file{
     diskann_root / "siftsmall_learn_256pts.fbin"};
-static std::filesystem::path diskann_truth_disk_layout{
+static std::string diskann_truth_disk_layout{
     diskann_root /
     "truth_disk_index_siftsmall_learn_256pts_R4_L50_A1.2_disk.index"};
 
 static std::string diskann_disk_index_root_prefix{
     "disk_index_siftsmall_learn_256pts_R4_L50_A1.2"};
 
-static std::filesystem::path diskann_disk_index{
+static std::string diskann_disk_index{
     diskann_root / (diskann_disk_index_root_prefix + "_disk.index")};
-static std::filesystem::path diskann_mem_index{
+static std::string diskann_mem_index{
     diskann_root / (diskann_disk_index_root_prefix + "_mem.index")};
 
-static std::filesystem::path diskann_truth_index_data =
+static std::string diskann_truth_index_data =
     diskann_root / "truth_index_siftsmall_learn_256pts_R4_L50_A1.2.data";
 
-static std::filesystem::path pytest_170_group_root{
+static std::string pytest_170_group_root{
     test_array_root / "pytest-170"};
-static std::filesystem::path pytest_170_group_uri{
+static std::string pytest_170_group_uri{
     pytest_170_group_root / "test_ivf_flat_ingestion_f320/array"};
 
 #define TEMP_LEGACY_URIS
@@ -315,14 +323,14 @@ using centroids_type = siftsmall_centroids_type;
 using ids_type = siftsmall_ids_type;
 using indices_type = siftsmall_indices_type;
 
-static std::filesystem::path db_uri{siftsmall_root / "input_vectors"};
-static std::filesystem::path centroids_uri{
+static std::string db_uri{siftsmall_root / "input_vectors"};
+static std::string centroids_uri{
     siftsmall_root / "partition_centroids"};
-static std::filesystem::path index_uri{siftsmall_root / "partition_indexes"};
-static std::filesystem::path ids_uri{siftsmall_root / "shuffled_vector_ids"};
-static std::filesystem::path parts_uri{siftsmall_root / "shuffled_vectors"};
-static std::filesystem::path query_uri{siftsmall_root / "queries"};
-static std::filesystem::path groundtruth_uri{siftsmall_root / "groundtruth"};
+static std::string index_uri{siftsmall_root / "partition_indexes"};
+static std::string ids_uri{siftsmall_root / "shuffled_vector_ids"};
+static std::string parts_uri{siftsmall_root / "shuffled_vectors"};
+static std::string query_uri{siftsmall_root / "queries"};
+static std::string groundtruth_uri{siftsmall_root / "groundtruth"};
 #endif
 
 #endif  // TILEDB_ARRAY_DEFS_H

--- a/src/include/test/unit_api_feature_vector.cc
+++ b/src/include/test/unit_api_feature_vector.cc
@@ -110,7 +110,7 @@ TEST_CASE("api: FeatureVector dimension", "[api]") {
   CHECK(dimension(FeatureVector(Vector<int>{1, 2, 3})) == 3);
 }
 
-using TestTypes = std::tuple<float, uint8_t, int32_t, uint32_t, uint64_t>;
+using TestTypes = std::tuple<float, int32_t, uint32_t, uint64_t>;
 
 int api_counter = 0;
 TEMPLATE_LIST_TEST_CASE("api: FeatureVector read", "[api]", TestTypes) {

--- a/src/include/test/unit_array_defs.cc
+++ b/src/include/test/unit_array_defs.cc
@@ -43,7 +43,7 @@ TEST_CASE("array_defs: test test", "[array_defs]") {
   REQUIRE(true);
 }
 
-std::vector<std::filesystem::path> test_array_roots{
+std::vector<std::string> test_array_roots{
     sift_root,
     siftsmall_root,
     bigann1M_root,
@@ -52,7 +52,7 @@ std::vector<std::filesystem::path> test_array_roots{
     diskann_root,
 };
 
-std::vector<std::filesystem::path> test_file_roots{
+std::vector<std::string> test_file_roots{
     siftsmall_files_root,
 };
 
@@ -65,7 +65,7 @@ TEST_CASE("array_defs: test array root uris", "[array_defs]") {
   }
 }
 
-std::vector<std::filesystem::path> sift_array_uris{
+std::vector<std::string> sift_array_uris{
     sift_inputs_uri,
     sift_centroids_uri,
     sift_index_uri,
@@ -75,7 +75,7 @@ std::vector<std::filesystem::path> sift_array_uris{
     sift_groundtruth_uri,
 };
 
-std::vector<std::filesystem::path> siftsmall_array_uris{
+std::vector<std::string> siftsmall_array_uris{
     siftsmall_inputs_uri,
     siftsmall_centroids_uri,
     siftsmall_index_uri,
@@ -87,7 +87,7 @@ std::vector<std::filesystem::path> siftsmall_array_uris{
 
 // Note that we don't have a canonical IVF index for siftsmall_uint8 yet, so
 // some of these URIs are placeholders
-std::vector<std::filesystem::path> siftsmall_uint8_array_uris{
+std::vector<std::string> siftsmall_uint8_array_uris{
     siftsmall_uint8_inputs_uri,
     siftsmall_uint8_centroids_uri,
     siftsmall_uint8_index_uri,
@@ -99,7 +99,7 @@ std::vector<std::filesystem::path> siftsmall_uint8_array_uris{
 
 // Note that we don't have a canonical IVF index for bigann10k yet, so some
 // of these URIs are placeholders
-std::vector<std::filesystem::path> bigann10k_array_uris{
+std::vector<std::string> bigann10k_array_uris{
     bigann10k_inputs_uri,
     bigann10k_centroids_uri,
     bigann10k_index_uri,
@@ -109,7 +109,7 @@ std::vector<std::filesystem::path> bigann10k_array_uris{
     bigann10k_groundtruth_uri,
 };
 
-std::vector<std::filesystem::path> bigann1M_array_uris{
+std::vector<std::string> bigann1M_array_uris{
     bigann1M_inputs_uri,
     bigann1M_centroids_uri,
     bigann1M_index_uri,
@@ -121,7 +121,7 @@ std::vector<std::filesystem::path> bigann1M_array_uris{
 
 // Note that we don't have a canonical IVF index for fmnist yet, so some
 // of these URIs are placeholders
-std::vector<std::filesystem::path> fmnist_array_uris{
+std::vector<std::string> fmnist_array_uris{
     fmnist_inputs_uri,
     fmnist_centroids_uri,
     fmnist_index_uri,
@@ -131,7 +131,7 @@ std::vector<std::filesystem::path> fmnist_array_uris{
     fmnist_groundtruth_uri,
 };
 
-std::vector<std::filesystem::path> siftsmall_files{
+std::vector<std::string> siftsmall_files{
     siftsmall_inputs_file,
     siftsmall_query_file,
     siftsmall_groundtruth_file,

--- a/src/include/test/unit_utils.cc
+++ b/src/include/test/unit_utils.cc
@@ -33,6 +33,14 @@
 #include "config.h"
 #include "utils/utils.h"
 
+namespace {
+
+std::string operator/(const std::string& lhs, const std::string& rhs) {
+  return (std::filesystem::path{lhs} / rhs).string();
+}
+
+}  // namespace
+
 TEST_CASE("utils: test", "[utils]") {
   CHECK(is_http_address("http://www.tiledb.com"));
   CHECK(is_http_address("http://www.tiledb.com/index.html"));
@@ -48,7 +56,7 @@ TEST_CASE("utils: test", "[utils]") {
   CHECK(!is_s3_container("file://www.tiledb.com"));
   CHECK(!is_s3_container("www.tiledb.com"));
 
-  static std::filesystem::path cmake_source_dir{CMAKE_SOURCE_DIR};
+  static std::string cmake_source_dir{CMAKE_SOURCE_DIR};
   CHECK(is_local_directory(cmake_source_dir));
   CHECK(is_local_file(cmake_source_dir / "README.md"));
   CHECK(is_local_file(cmake_source_dir / "src" / "README.md"));

--- a/src/include/test/unit_vamana.cc
+++ b/src/include/test/unit_vamana.cc
@@ -164,7 +164,7 @@ TEST_CASE("vamana: small greedy search", "[vamana]") {
   std::ifstream binary_file(diskann_test_256bin, std::ios::binary);
   if (!binary_file.is_open()) {
     throw std::runtime_error(
-        "Could not open file " + diskann_test_256bin.string());
+        "Could not open file " + diskann_test_256bin);
   }
 
   binary_file.read((char*)&npoints, 4);
@@ -458,7 +458,7 @@ TEST_CASE("vamana: diskann fbin", "[vamana]") {
   std::ifstream binary_file(diskann_test_256bin, std::ios::binary);
   if (!binary_file.is_open()) {
     throw std::runtime_error(
-        "Could not open file " + diskann_test_256bin.string());
+        "Could not open file " + diskann_test_256bin);
   }
 
   binary_file.read((char*)&npoints, 4);
@@ -828,7 +828,7 @@ TEST_CASE("vamana: vamana_index vector diskann_test_256bin", "[vamana]") {
   std::ifstream binary_file(diskann_test_256bin, std::ios::binary);
   if (!binary_file.is_open()) {
     throw std::runtime_error(
-        "Could not open file " + diskann_test_256bin.string());
+        "Could not open file " + diskann_test_256bin);
   }
 
   binary_file.read((char*)&npoints, 4);

--- a/src/include/utils/filesystem.h
+++ b/src/include/utils/filesystem.h
@@ -1,0 +1,48 @@
+/**
+ * @file   filesystem.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Filesystem utilities used for cross-compatibility.
+ *
+ */
+
+#include <filesystem>
+#include <string>
+
+namespace stdx::filesystem {
+
+class path : public std::string {
+ public:
+  using std::string::path;
+
+  operator std::string() const {
+    return this->string();
+  }
+};
+
+}  // namespace stdx::filesystem

--- a/src/include/utils/utils.h
+++ b/src/include/utils/utils.h
@@ -64,7 +64,7 @@ std::string get_filename(const std::string& filename) {
 }
 
 bool local_directory_exists(const std::string& path) {
-  std::filesystem::path directoryPath(path);
+  std::string directoryPath(path);
   auto a = std::filesystem::status(directoryPath);
   auto b = std::filesystem::is_directory(directoryPath);
 
@@ -77,8 +77,9 @@ bool is_local_directory(const std::string& path) {
 
 bool subdirectory_exists(
     const std::string& path, const std::string& subdirectoryName) {
-  std::filesystem::path directoryPath(path);
-  std::filesystem::path subdirectoryPath = directoryPath / subdirectoryName;
+  std::string directoryPath(path);
+  std::string subdirectoryPath =
+      (std::filesystem::path{directoryPath} / subdirectoryName).string();
   auto b = std::filesystem::is_directory(subdirectoryPath);
   return std::filesystem::is_directory(subdirectoryPath);
 }
@@ -89,7 +90,7 @@ bool local_file_exists(const std::string& filename) {
     return false;
   }
   auto fname = get_filename(filename);
-  std::filesystem::path filePath(fname);
+  std::string filePath(fname);
   return std::filesystem::is_regular_file(filePath);
 }
 


### PR DESCRIPTION
This PR fixes all MSVC compilation issues with the exception of `mmap` issues that are addressed here:
https://github.com/TileDB-Inc/TileDB-Vector-Search/pull/224