### PR TITLE
In `tdb_matrix_with_ids` fix data loading, the default type of ids, and the attribute check when loading data

### DIFF
--- a/src/include/detail/linalg/tdb_matrix_with_ids.h
+++ b/src/include/detail/linalg/tdb_matrix_with_ids.h
@@ -50,7 +50,7 @@
  */
 template <
     class T,
-    class IdsType = size_t,
+    class IdsType = uint64_t,
     class LayoutPolicy = stdx::layout_right,
     class I = size_t>
 class tdbBlockedMatrixWithIds
@@ -188,11 +188,12 @@ class tdbBlockedMatrixWithIds
 
     std::string attr_name = attr.name();
     tiledb_datatype_t attr_type = attr.type();
-    if (attr_type != tiledb::impl::type_to_tiledb<T>::tiledb_type) {
+    if (attr_type != tiledb::impl::type_to_tiledb<IdsType>::tiledb_type) {
       throw std::runtime_error(
           "Attribute type mismatch with IDs: " + datatype_to_string(attr_type) +
           " != " +
-          datatype_to_string(tiledb::impl::type_to_tiledb<T>::tiledb_type));
+          datatype_to_string(
+              tiledb::impl::type_to_tiledb<IdsType>::tiledb_type));
     }
 
     static const size_t dimension = 1;
@@ -208,9 +209,8 @@ class tdbBlockedMatrixWithIds
 
     // Create a subarray for the next block of columns
     tiledb::Subarray subarray(this->ctx_, *ids_array_);
-    subarray.add_range(0, 0, (int)dimension - 1);
     subarray.add_range(
-        1, (int)this->first_resident_col_, (int)this->last_resident_col_ - 1);
+        0, (int)this->first_resident_col_, (int)this->last_resident_col_ - 1);
 
     auto layout_order = ids_schema_.cell_order();
     this->ids().resize(elements_to_load * dimension);
@@ -234,28 +234,28 @@ class tdbBlockedMatrixWithIds
 /**
  * Convenience class for row-major blocked matrices.
  */
-template <class T, class IdsType = size_t, class I = size_t>
+template <class T, class IdsType = uint64_t, class I = size_t>
 using tdbRowMajorBlockedMatrixWithIds =
     tdbBlockedMatrixWithIds<T, IdsType, stdx::layout_right, I>;
 
 /**
  * Convenience class for column-major blocked matrices.
  */
-template <class T, class IdsType = size_t, class I = size_t>
+template <class T, class IdsType = uint64_t, class I = size_t>
 using tdbColMajorBlockedMatrixWithIds =
     tdbBlockedMatrixWithIds<T, IdsType, stdx::layout_left, I>;
 
 /**
  * Convenience class for row-major matrices.
  */
-template <class T, class IdsType = size_t, class I = size_t>
+template <class T, class IdsType = uint64_t, class I = size_t>
 using tdbRowMajorMatrixWithIds =
     tdbBlockedMatrixWithIds<T, IdsType, stdx::layout_right, I>;
 
 /**
  * Convenience class for column-major matrices.
  */
-template <class T, class IdsType = size_t, class I = size_t>
+template <class T, class IdsType = uint64_t, class I = size_t>
 using tdbColMajorMatrixWithIds =
     tdbBlockedMatrixWithIds<T, IdsType, stdx::layout_left, I>;
 
@@ -264,7 +264,7 @@ using tdbColMajorMatrixWithIds =
  */
 template <
     class T,
-    class IdsType = size_t,
+    class IdsType = uint64_t,
     class LayoutPolicy = stdx::layout_right,
     class I = size_t>
 using tdbMatrixWithIds = tdbBlockedMatrixWithIds<T, IdsType, LayoutPolicy, I>;

--- a/src/include/detail/linalg/tdb_matrix_with_ids.h
+++ b/src/include/detail/linalg/tdb_matrix_with_ids.h
@@ -68,6 +68,7 @@ class tdbBlockedMatrixWithIds
 
  public:
   using index_type = typename Base::index_type;
+  using ids_type = typename Base::ids_type;
 
  private:
   log_timer constructor_timer{"tdbBlockedMatrixWithIds constructor"};
@@ -188,12 +189,12 @@ class tdbBlockedMatrixWithIds
 
     std::string attr_name = attr.name();
     tiledb_datatype_t attr_type = attr.type();
-    if (attr_type != tiledb::impl::type_to_tiledb<IdsType>::tiledb_type) {
+    if (attr_type != tiledb::impl::type_to_tiledb<ids_type>::tiledb_type) {
       throw std::runtime_error(
           "Attribute type mismatch with IDs: " + datatype_to_string(attr_type) +
           " != " +
           datatype_to_string(
-              tiledb::impl::type_to_tiledb<IdsType>::tiledb_type));
+              tiledb::impl::type_to_tiledb<ids_type>::tiledb_type));
     }
 
     static const size_t dimension = 1;

--- a/src/include/test/test_utils.h
+++ b/src/include/test/test_utils.h
@@ -106,27 +106,12 @@ void fill_and_write_matrix(
   }
   std::iota(X.data(), X.data() + dimension(X) * num_vectors(X), offset);
   std::iota(X.ids().begin(), X.ids().end(), offset);
-  // Write the vectors to the URI.
+
+  // Write the vectors to their URI.
   write_matrix(ctx, X, uri);
 
-  // Write the IDs to their URI. We could do this by modifying write_matrix() to
-  // separately write out to ids_uri from ids(), but that would require some
-  // changes. So instead we just create an additional temporary IDs matrix,
-  // write the ids into data(), and then write it separately.
-  size_t id_rows =
-      std::is_same<typename MatrixWithIds::layout_policy, stdx::layout_right>::
-              value ?
-          num_vectors(X) :
-          1;
-  size_t id_cols =
-      std::is_same<typename MatrixWithIds::layout_policy, stdx::layout_right>::
-              value ?
-          1 :
-          num_vectors(X);
-  MatrixWithIds tempIdsMatrix(id_rows, id_cols);
-  std::iota(
-      tempIdsMatrix.data(), tempIdsMatrix.data() + num_vectors(X), offset);
-  write_matrix(ctx, tempIdsMatrix, ids_uri);
+  // Write the IDs to their URI.
+  write_vector(ctx, X.ids(), ids_uri);
 }
 
 #endif  // TILEDB_TEST_UTILS_H

--- a/src/include/test/unit_tdb_matrix_with_ids.cc
+++ b/src/include/test/unit_tdb_matrix_with_ids.cc
@@ -104,7 +104,10 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "tdb_matrix_with_ids: assign to matrix", "[tdb_matrix_with_ids]", float) {
+    "tdb_matrix_with_ids: assign to matrix",
+    "[tdb_matrix_with_ids]",
+    float,
+    uint8_t) {
   tiledb::Context ctx;
   std::string tmp_matrix_uri = "/tmp/tmp_tdb_matrix";
   std::string tmp_ids_uri = "/tmp/tmp_tdb_ids_matrix";

--- a/src/include/test/unit_tdb_matrix_with_ids.cc
+++ b/src/include/test/unit_tdb_matrix_with_ids.cc
@@ -33,6 +33,7 @@
 #include "detail/linalg/matrix_with_ids.h"
 #include "detail/linalg/tdb_io.h"
 #include "detail/linalg/tdb_matrix_with_ids.h"
+#include "test/array_defs.h"
 #include "test/test_utils.h"
 
 TEST_CASE("tdb_matrix_with_ids: test test", "[tdb_matrix_with_ids]") {
@@ -103,7 +104,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "tdb_matrix: assign to matrix", "[tdb_matrix_with_ids]", float, uint8_t) {
+    "tdb_matrix_with_ids: assign to matrix", "[tdb_matrix_with_ids]", float) {
   tiledb::Context ctx;
   std::string tmp_matrix_uri = "/tmp/tmp_tdb_matrix";
   std::string tmp_ids_uri = "/tmp/tmp_tdb_ids_matrix";
@@ -117,7 +118,6 @@ TEMPLATE_TEST_CASE(
   CHECK(X.ids()[0] == offset + 0);
   CHECK(X.ids()[1] == offset + 1);
   CHECK(X.ids()[10] == offset + 10);
-  CHECK(size(X.ids()) == Ncols);
   CHECK(size(X.ids()) == Ncols);
 
   auto B = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
@@ -179,4 +179,18 @@ TEMPLATE_TEST_CASE(
       CHECK(X(i, j) == B(i, j));
     }
   }
+}
+
+TEST_CASE("tdb_matrix_with_ids: load from uri", "[tdb_matrix_with_ids]") {
+  tiledb::Context ctx;
+
+  auto ck = tdbColMajorMatrixWithIds<float>(ctx, sift_inputs_uri, sift_ids_uri);
+  ck.load();
+  CHECK(ck.num_ids() == num_sift_vectors);
+
+  auto num_queries = 10;
+  auto qk = tdbColMajorMatrixWithIds<float>(
+      ctx, sift_query_uri, sift_ids_uri, num_queries);
+  load(qk);
+  CHECK(qk.num_ids() == num_queries);
 }


### PR DESCRIPTION
### What
When adding IDs to `feature_vector_array.h` I found three bugs in `tdb_matrix_with_ids`:
1. We were loading data from a column major matrix (two dimensions) instead of a row major vector of IDs (one dimension). Here we fix that and also fix `fill_and_write_matrix()` to correctly create both a matrix at `uri` and a vector of IDs at `ids_uri`.
2. Update the default type of IDs to `uint64_t`
3. Fix the check for whether the data in `ids_uri` is the same type as the template parameter in the class.

### Testing
* Added unit tests in this PR
* My `feature_vector_array.h` changes now also pass unit tests