### PR TITLE
Optimize query latency for Index and ObjectIndex classes

### DIFF
--- a/apis/python/src/tiledb/vector_search/object_api/object_index.py
+++ b/apis/python/src/tiledb/vector_search/object_api/object_index.py
@@ -1,8 +1,7 @@
-import base64
+import json
 from collections import OrderedDict
 from typing import Any, Dict, List, Mapping, Optional
 
-import json
 import numpy as np
 
 import tiledb
@@ -29,12 +28,14 @@ class ObjectIndex:
         config: Optional[Mapping[str, Any]] = None,
         timestamp=None,
         load_embedding: bool = True,
+        load_metadata_in_memory: bool = True,
         **kwargs,
     ):
         with tiledb.scope_ctx(ctx_or_config=config):
             self.uri = uri
             self.config = config
             self.timestamp = timestamp
+            self.load_metadata_in_memory = load_metadata_in_memory
             group = tiledb.Group(uri, "r")
             self.index_type = group.meta["index_type"]
             group.close()
@@ -90,6 +91,16 @@ class ObjectIndex:
                 self.object_metadata_array_uri = None
                 self.object_metadata_external_id_dim = None
 
+            if self.object_metadata_array_uri is not None:
+                self.metadata_array = tiledb.open(
+                    self.object_metadata_array_uri,
+                    mode="r",
+                    timestamp=self.timestamp,
+                    config=self.config,
+                )
+                if self.load_metadata_in_memory:
+                    self.metadata_df = self.metadata_array.df[:]
+
     def query(
         self,
         query_objects: np.ndarray,
@@ -122,44 +133,49 @@ class ObjectIndex:
         )
         unique_ids, idx = np.unique(object_ids, return_inverse=True)
         idx = np.reshape(idx, object_ids.shape)
-
         if metadata_array_cond is not None or metadata_df_filter_fn is not None:
-            with tiledb.open(
-                self.object_metadata_array_uri,
-                mode="r",
-                timestamp=self.timestamp,
-                config=self.config,
-            ) as metadata_array:
-                q = metadata_array.query(
+            if self.load_metadata_in_memory:
+                if metadata_array_cond is not None:
+                    raise AttributeError(
+                        "metadata_array_cond is not supported with load_metadata_in_memory. Please use metadata_df_filter_fn."
+                    )
+                unique_ids_metadata_df = self.metadata_df[
+                    self.metadata_df[self.object_metadata_external_id_dim].isin(
+                        unique_ids
+                    )
+                ]
+            else:
+                q = self.metadata_array.query(
                     cond=metadata_array_cond, coords=True, use_arrow=False
                 )
                 unique_ids_metadata_df = q.df[unique_ids]
-                if metadata_df_filter_fn is not None:
-                    unique_ids_metadata_df = unique_ids_metadata_df[
-                        unique_ids_metadata_df.apply(metadata_df_filter_fn, axis=1)
-                    ]
-                filtered_unique_ids = unique_ids_metadata_df[
-                    self.object_metadata_external_id_dim
-                ].to_numpy()
-                filtered_distances = np.zeros((query_embeddings.shape[0], k)).astype(
-                    object_ids.dtype
-                )
-                filtered_object_ids = np.zeros((query_embeddings.shape[0], k)).astype(
-                    object_ids.dtype
-                )
-                for query_id in range(query_embeddings.shape[0]):
-                    write_id = 0
-                    for result_id in range(fetch_k):
-                        if object_ids[query_id, result_id] in filtered_unique_ids:
-                            filtered_distances[query_id, write_id] = distances[
-                                query_id, result_id
-                            ]
-                            filtered_object_ids[query_id, write_id] = object_ids[
-                                query_id, result_id
-                            ]
-                            write_id += 1
-                            if write_id >= k:
-                                break
+
+            if metadata_df_filter_fn is not None:
+                unique_ids_metadata_df = unique_ids_metadata_df[
+                    unique_ids_metadata_df.apply(metadata_df_filter_fn, axis=1)
+                ]
+            filtered_unique_ids = unique_ids_metadata_df[
+                self.object_metadata_external_id_dim
+            ].to_numpy()
+            filtered_distances = np.zeros((query_embeddings.shape[0], k)).astype(
+                object_ids.dtype
+            )
+            filtered_object_ids = np.zeros((query_embeddings.shape[0], k)).astype(
+                object_ids.dtype
+            )
+            for query_id in range(query_embeddings.shape[0]):
+                write_id = 0
+                for result_id in range(fetch_k):
+                    if object_ids[query_id, result_id] in filtered_unique_ids:
+                        filtered_distances[query_id, write_id] = distances[
+                            query_id, result_id
+                        ]
+                        filtered_object_ids[query_id, write_id] = object_ids[
+                            query_id, result_id
+                        ]
+                        write_id += 1
+                        if write_id >= k:
+                            break
 
             distances = filtered_distances
             object_ids = filtered_object_ids
@@ -169,15 +185,20 @@ class ObjectIndex:
         object_metadata = None
         if return_metadata:
             if self.object_metadata_array_uri is not None:
-                with tiledb.open(
-                    self.object_metadata_array_uri,
-                    mode="r",
-                    timestamp=self.timestamp,
-                    config=self.config,
-                ) as metadata_array:
-                    unique_metadata = metadata_array.multi_index[unique_ids]
+                if self.load_metadata_in_memory:
+                    unique_metadata = self.metadata_df[
+                        self.metadata_df[self.object_metadata_external_id_dim].isin(
+                            unique_ids
+                        )
+                    ]
                     object_metadata = {}
                     for attr in unique_metadata.keys():
+                        object_metadata[attr] = unique_metadata[attr].to_numpy()[idx]
+                else:
+                    unique_metadata = self.metadata_array.multi_index[unique_ids]
+                    object_metadata = {}
+                    for attr in unique_metadata.keys():
+                        unique_metadata[attr][idx]
                         object_metadata[attr] = unique_metadata[attr][idx]
 
         if return_objects:

--- a/apis/python/test/test_object_index.py
+++ b/apis/python/test/test_object_index.py
@@ -146,6 +146,7 @@ def test_object_index_ivf_flat(tmp_path):
 
     index.update_index()
 
+    index = object_index.ObjectIndex(uri=index_uri, load_metadata_in_memory=False)
     distances, objects, metadata = index.query(
         {"object": np.array([[12, 12, 12, 12]])},
         k=5,
@@ -158,6 +159,27 @@ def test_object_index_ivf_flat(tmp_path):
     distances, objects, metadata = index.query(
         {"object": np.array([[12, 12, 12, 12]])},
         metadata_array_cond="test_attr >= 12",
+        k=5,
+        nprobe=10,
+    )
+    assert np.array_equiv(objects["external_id"], np.array([12, 13, 14, 15, 16]))
+
+    index = object_index.ObjectIndex(uri=index_uri, load_metadata_in_memory=False)
+    distances, objects, metadata = index.query(
+        {"object": np.array([[12, 12, 12, 12]])},
+        k=5,
+        nprobe=10,
+    )
+    assert np.array_equiv(
+        np.unique(objects["external_id"]), np.array([10, 11, 12, 13, 14])
+    )
+
+    def df_filter(row):
+        return row["test_attr"] >= 12
+
+    distances, objects, metadata = index.query(
+        {"object": np.array([[12, 12, 12, 12]])},
+        metadata_df_filter_fn=df_filter,
         k=5,
         nprobe=10,
     )
@@ -179,6 +201,41 @@ def test_object_index_flat(tmp_path):
 
     index.update_index()
 
+    index = object_index.ObjectIndex(uri=index_uri)
+    distances, objects, metadata = index.query(
+        {"object": np.array([[12, 12, 12, 12]])}, k=5
+    )
+    assert np.array_equiv(
+        np.unique(objects["external_id"]), np.array([10, 11, 12, 13, 14])
+    )
+    distances, object_ids = index.query(
+        {"object": np.array([[12, 12, 12, 12]])},
+        k=5,
+        return_objects=False,
+        return_metadata=False,
+    )
+    assert np.array_equiv(np.unique(object_ids), np.array([10, 11, 12, 13, 14]))
+
+    def df_filter(row):
+        return row["test_attr"] >= 12
+
+    distances, objects, metadata = index.query(
+        {"object": np.array([[12, 12, 12, 12]])},
+        metadata_df_filter_fn=df_filter,
+        k=5,
+    )
+    assert np.array_equiv(objects["external_id"], np.array([12, 13, 14, 15, 16]))
+
+    distances, object_ids = index.query(
+        {"object": np.array([[12, 12, 12, 12]])},
+        metadata_df_filter_fn=df_filter,
+        k=5,
+        return_objects=False,
+        return_metadata=False,
+    )
+    assert np.array_equiv(object_ids, np.array([12, 13, 14, 15, 16]))
+
+    index = object_index.ObjectIndex(uri=index_uri, load_metadata_in_memory=False)
     distances, objects, metadata = index.query(
         {"object": np.array([[12, 12, 12, 12]])}, k=5
     )


### PR DESCRIPTION
This adds the following query latency optimizations:
- `ObjectIndex`: 
   - Open `object_metadata_array` in the constructor and reuse the opened array in all queries.
   - Add option to load the `object_metadata` in memory during the constructor. This allows metadata filtering and retrieval directly from main memory without reading from the TileDB array.
- `Index`: Avoid checking existence of updates array and `has_updates` metadata value in the critical path of queries. 