### PR TITLE
Add support for empty and matrices and vectors

### DIFF
--- a/apis/python/src/tiledb/vector_search/module.cc
+++ b/apis/python/src/tiledb/vector_search/module.cc
@@ -640,7 +640,8 @@ PYBIND11_MODULE(_tiledbvspy, m) {
          size_t start_pos,
          size_t end_pos,
          uint64_t timestamp) -> std::vector<uint32_t> {
-        auto r = read_vector<uint32_t>(ctx, uri, start_pos, end_pos, timestamp);
+        auto r = read_vector<uint32_t>(
+            ctx, uri, start_pos, end_pos, timestamp, true);
         return r;
       });
   m.def(
@@ -650,7 +651,8 @@ PYBIND11_MODULE(_tiledbvspy, m) {
          size_t start_pos,
          size_t end_pos,
          uint64_t timestamp) -> std::vector<uint64_t> {
-        auto r = read_vector<uint64_t>(ctx, uri, start_pos, end_pos, timestamp);
+        auto r = read_vector<uint64_t>(
+            ctx, uri, start_pos, end_pos, timestamp, true);
         return r;
       });
 

--- a/src/include/detail/ivf/index.h
+++ b/src/include/detail/ivf/index.h
@@ -227,7 +227,7 @@ int ivf_index(
     std::iota(begin(external_ids), end(external_ids), start_pos);
   } else {
     external_ids = read_vector<ids_type>(
-        ctx, external_ids_uri, start_pos, end_pos, timestamp);
+        ctx, external_ids_uri, start_pos, end_pos, timestamp, true);
   }
   return ivf_index<T, ids_type, centroids_type>(
       ctx,
@@ -303,7 +303,7 @@ int ivf_index(
     std::iota(begin(external_ids), end(external_ids), start_pos);
   } else {
     external_ids = read_vector<ids_type>(
-        ctx, external_ids_uri, start_pos, end_pos, timestamp);
+        ctx, external_ids_uri, start_pos, end_pos, timestamp, true);
   }
   return ivf_index<T, ids_type, centroids_type>(
       ctx,

--- a/src/include/detail/linalg/tdb_io.h
+++ b/src/include/detail/linalg/tdb_io.h
@@ -65,9 +65,9 @@ void create_empty_for_matrix(
   tiledb::Domain domain(ctx);
   domain
       .add_dimension(tiledb::Dimension::create<int>(
-          ctx, "rows", {{0, std::max(0, (int)rows - 1)}}, row_extent))
+          ctx, "rows", {{0, (int)rows - 1}}, row_extent))
       .add_dimension(tiledb::Dimension::create<int>(
-          ctx, "cols", {{0, std::max(0, (int)cols - 1)}}, col_extent));
+          ctx, "cols", {{0, (int)cols - 1}}, col_extent));
 
   tiledb::ArraySchema schema(ctx, TILEDB_DENSE);
 

--- a/src/include/detail/linalg/tdb_io.h
+++ b/src/include/detail/linalg/tdb_io.h
@@ -57,8 +57,8 @@ template <class T, class LayoutPolicy = stdx::layout_right, class I = size_t>
 void create_empty_for_matrix(
     const tiledb::Context& ctx,
     const std::string& uri,
-    size_t rows,  // number of dimensions
-    size_t cols,  // number of vectors
+    size_t rows,
+    size_t cols,
     size_t row_extent,
     size_t col_extent,
     std::optional<tiledb_filter_type_t> filter = std::nullopt) {
@@ -143,9 +143,9 @@ void write_matrix(
 
   std::vector<int32_t> subarray_vals{
       0,
-      std::max((int)A.num_rows() - 1, 0),
+      (int)A.num_rows() - 1,
       (int)start_pos,
-      std::max((int)start_pos + (int)A.num_cols() - 1, 0)};
+      (int)start_pos + (int)A.num_cols() - 1};
 
   // Open array for writing
   auto array = tiledb_helpers::open_array(
@@ -190,7 +190,7 @@ void create_empty_for_vector(
     std::optional<tiledb_filter_type_t> filter = std::nullopt) {
   tiledb::Domain domain(ctx);
   domain.add_dimension(tiledb::Dimension::create<int>(
-      ctx, "rows", {{0, std::max(0, (int)rows - 1)}}, row_extent));
+      ctx, "rows", {{0, (int)rows - 1}}, row_extent));
 
   // The array will be dense.
   tiledb::ArraySchema schema(ctx, TILEDB_DENSE);

--- a/src/include/detail/linalg/tdb_io.h
+++ b/src/include/detail/linalg/tdb_io.h
@@ -57,17 +57,17 @@ template <class T, class LayoutPolicy = stdx::layout_right, class I = size_t>
 void create_empty_for_matrix(
     const tiledb::Context& ctx,
     const std::string& uri,
-    size_t rows,
-    size_t cols,
+    size_t rows,  // number of dimensions
+    size_t cols,  // number of vectors
     size_t row_extent,
     size_t col_extent,
     std::optional<tiledb_filter_type_t> filter = std::nullopt) {
   tiledb::Domain domain(ctx);
   domain
       .add_dimension(tiledb::Dimension::create<int>(
-          ctx, "rows", {{0, (int)rows - 1}}, row_extent))
+          ctx, "rows", {{0, std::max(0, (int)rows - 1)}}, row_extent))
       .add_dimension(tiledb::Dimension::create<int>(
-          ctx, "cols", {{0, (int)cols - 1}}, col_extent));
+          ctx, "cols", {{0, std::max(0, (int)cols - 1)}}, col_extent));
 
   tiledb::ArraySchema schema(ctx, TILEDB_DENSE);
 
@@ -143,9 +143,9 @@ void write_matrix(
 
   std::vector<int32_t> subarray_vals{
       0,
-      (int)A.num_rows() - 1,
+      std::max((int)A.num_rows() - 1, 0),
       (int)start_pos,
-      (int)start_pos + (int)A.num_cols() - 1};
+      std::max((int)start_pos + (int)A.num_cols() - 1, 0)};
 
   // Open array for writing
   auto array = tiledb_helpers::open_array(
@@ -190,7 +190,7 @@ void create_empty_for_vector(
     std::optional<tiledb_filter_type_t> filter = std::nullopt) {
   tiledb::Domain domain(ctx);
   domain.add_dimension(tiledb::Dimension::create<int>(
-      ctx, "rows", {{0, (int)rows - 1}}, row_extent));
+      ctx, "rows", {{0, std::max(0, (int)rows - 1)}}, row_extent));
 
   // The array will be dense.
   tiledb::ArraySchema schema(ctx, TILEDB_DENSE);
@@ -289,7 +289,8 @@ std::vector<T> read_vector(
     const std::string& uri,
     size_t start_pos,
     size_t end_pos,
-    size_t timestamp = 0) {
+    size_t timestamp = 0,
+    bool read_full_vector = false) {
   scoped_timer _{tdb_func__ + " " + std::string{uri}};
 
   tiledb::TemporalPolicy temporal_policy =
@@ -308,14 +309,20 @@ std::vector<T> read_vector(
   auto dim_num_{domain_.ndim()};
   auto array_rows_{domain_.dimension(0)};
 
-  if (start_pos == 0) {
-    start_pos = array_rows_.template domain<domain_type>().first;
-  }
-  if (end_pos == 0) {
-    end_pos = array_rows_.template domain<domain_type>().second + 1;
+  if (read_full_vector) {
+    if (start_pos == 0) {
+      start_pos = array_rows_.template domain<domain_type>().first;
+    }
+    if (end_pos == 0) {
+      end_pos = array_rows_.template domain<domain_type>().second + 1;
+    }
   }
 
   auto vec_rows_{end_pos - start_pos};
+
+  if (vec_rows_ == 0) {
+    return {};
+  }
 
   auto attr_num{schema_.attribute_num()};
   auto attr = schema_.attribute(idx);
@@ -350,7 +357,7 @@ std::vector<T> read_vector(
 template <class T>
 std::vector<T> read_vector(
     const tiledb::Context& ctx, const std::string& uri, size_t timestamp = 0) {
-  return read_vector<T>(ctx, uri, 0, 0, timestamp);
+  return read_vector<T>(ctx, uri, 0, 0, timestamp, true);
 }
 
 template <class T>

--- a/src/include/detail/linalg/tdb_matrix_with_ids.h
+++ b/src/include/detail/linalg/tdb_matrix_with_ids.h
@@ -97,7 +97,7 @@ class tdbBlockedMatrixWithIds
       const std::string& uri,
       const std::string& ids_uri) noexcept
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
-      : tdbBlockedMatrixWithIds(ctx, uri, ids_uri, 0, 0, 0, 0, 0, 0) {
+      : tdbBlockedMatrixWithIds(ctx, uri, ids_uri, 0, 0, 0, 0, 0, 0, true) {
   }
 
   /**
@@ -120,7 +120,7 @@ class tdbBlockedMatrixWithIds
       size_t timestamp = 0)
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
       : tdbBlockedMatrixWithIds(
-            ctx, uri, ids_uri, 0, 0, 0, 0, upper_bound, timestamp) {
+            ctx, uri, ids_uri, 0, 0, 0, 0, upper_bound, timestamp, true) {
   }
 
   /** General constructor */
@@ -133,7 +133,8 @@ class tdbBlockedMatrixWithIds
       size_t first_col,
       size_t last_col,
       size_t upper_bound,
-      size_t timestamp)
+      size_t timestamp,
+      bool read_full_matrix)
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
       : tdbBlockedMatrixWithIds(
             ctx,
@@ -146,7 +147,8 @@ class tdbBlockedMatrixWithIds
             upper_bound,
             (timestamp == 0 ?
                  tiledb::TemporalPolicy() :
-                 tiledb::TemporalPolicy(tiledb::TimeTravel, timestamp))) {
+                 tiledb::TemporalPolicy(tiledb::TimeTravel, timestamp)),
+            read_full_matrix) {
   }
 
   /** General constructor */
@@ -159,7 +161,8 @@ class tdbBlockedMatrixWithIds
       size_t first_col,
       size_t last_col,
       size_t upper_bound,
-      tiledb::TemporalPolicy temporal_policy)  // noexcept
+      tiledb::TemporalPolicy temporal_policy,
+      bool read_full_matrix)  // noexcept
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
       : Base(
             ctx,
@@ -169,7 +172,8 @@ class tdbBlockedMatrixWithIds
             first_col,
             last_col,
             upper_bound,
-            temporal_policy)
+            temporal_policy,
+            read_full_matrix)
       , ids_uri_(ids_uri)
       , ids_array_(std::make_unique<tiledb::Array>(
             ctx, ids_uri, TILEDB_READ, temporal_policy))

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -258,7 +258,7 @@ class tdbPartitionedMatrix
             ctx,
             partitioned_vectors_uri,
             read_vector<indices_type>(
-                ctx, indices_uri, 0, num_indices, timestamp),
+                ctx, indices_uri, 0, num_indices, timestamp, true),
             ids_uri,
             relevant_parts,
             upper_bound,

--- a/src/include/detail/linalg/tdb_vector.h
+++ b/src/include/detail/linalg/tdb_vector.h
@@ -48,7 +48,7 @@ class tdbVector : public Vector<T> {
 
  public:
   tdbVector(const tiledb::Context& ctx, const std::string& uri)
-      : Base(read_vector<T>(ctx, uri, 0, 0, 0)) {
+      : Base(read_vector<T>(ctx, uri, 0, 0, 0, true)) {
   }
 };
 

--- a/src/include/index/ivf_flat_index.h
+++ b/src/include/index/ivf_flat_index.h
@@ -235,7 +235,8 @@ class ivf_flat_index {
             0,
             num_partitions_,
             0,
-            timestamp_));
+            timestamp_,
+            true));
   }
 
   /****************************************************************************

--- a/src/include/test/unit_tdb_matrix_with_ids.cc
+++ b/src/include/test/unit_tdb_matrix_with_ids.cc
@@ -35,165 +35,228 @@
 #include "detail/linalg/tdb_matrix_with_ids.h"
 #include "test/array_defs.h"
 #include "test/test_utils.h"
+//
+// TEST_CASE("tdb_matrix_with_ids: test test", "[tdb_matrix_with_ids]") {
+//  REQUIRE(true);
+//}
+//
+// TEMPLATE_TEST_CASE(
+//    "tdb_matrix_with_ids: constructors",
+//    "[tdb_matrix_with_ids]",
+//    float,
+//    double,
+//    int,
+//    char,
+//    size_t,
+//    uint32_t) {
+//  tiledb::Context ctx;
+//
+//  std::string tmp_matrix_uri = "/tmp/tmp_tdb_matrix";
+//  std::string tmp_ids_uri = "/tmp/tmp_tdb_ids_matrix";
+//  int offset = 13;
+//  size_t Mrows = 200;
+//  size_t Ncols = 500;
+//  auto X = ColMajorMatrixWithIds<TestType, TestType, size_t>(Mrows, Ncols);
+//  fill_and_write_matrix(
+//      ctx, X, tmp_matrix_uri, tmp_ids_uri, Mrows, Ncols, offset);
+//  CHECK(X.ids()[0] == offset + 0);
+//  CHECK(X.ids()[1] == offset + 1);
+//  CHECK(X.ids()[10] == offset + 10);
+//
+//  auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
+//      ctx, tmp_matrix_uri, tmp_ids_uri);
+//  Y.load();
+//  CHECK(num_vectors(Y) == num_vectors(X));
+//  CHECK(dimension(Y) == dimension(X));
+//  CHECK(
+//      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X),
+//      Y.data()));
+//  for (size_t i = 0; i < X.num_rows(); ++i) {
+//    for (size_t j = 0; j < X.num_cols(); ++j) {
+//      CHECK(X(i, j) == Y(i, j));
+//    }
+//  }
+//  CHECK(size(Y.ids()) == Y.num_ids());
+//  CHECK(size(X.ids()) == size(Y.ids()));
+//  CHECK(X.num_ids() == Y.num_ids());
+//  CHECK(std::equal(X.ids().begin(), X.ids().end(), Y.ids().begin()));
+//  for (size_t i = 0; i < X.num_ids(); ++i) {
+//    CHECK(X.ids()[i] == Y.ids()[i]);
+//  }
+//
+//  auto Z = tdbColMajorMatrixWithIds<TestType, TestType>(std::move(Y));
+//  CHECK(num_vectors(Z) == num_vectors(X));
+//  CHECK(dimension(Z) == dimension(X));
+//  CHECK(
+//      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X),
+//      Z.data()));
+//  for (size_t i = 0; i < 5; ++i) {
+//    for (size_t j = 0; j < 5; ++j) {
+//      CHECK(X(i, j) == Z(i, j));
+//    }
+//  }
+//
+//  CHECK(size(Z.ids()) == Z.num_ids());
+//  CHECK(size(X.ids()) == size(Z.ids()));
+//  CHECK(X.num_ids() == Z.num_ids());
+//  CHECK(std::equal(X.ids().begin(), X.ids().end(), Z.ids().begin()));
+//  for (size_t i = 0; i < X.num_ids(); ++i) {
+//    CHECK(X.ids()[i] == Z.ids()[i]);
+//  }
+//}
+//
+// TEMPLATE_TEST_CASE(
+//    "tdb_matrix_with_ids: assign to matrix",
+//    "[tdb_matrix_with_ids]",
+//    float,
+//    uint8_t) {
+//  tiledb::Context ctx;
+//  std::string tmp_matrix_uri = "/tmp/tmp_tdb_matrix";
+//  std::string tmp_ids_uri = "/tmp/tmp_tdb_ids_matrix";
+//  int offset = 123;
+//  size_t Mrows = 200;
+//  size_t Ncols = 500;
+//
+//  auto X = ColMajorMatrixWithIds<TestType, TestType, size_t>(Mrows, Ncols);
+//  fill_and_write_matrix(
+//      ctx, X, tmp_matrix_uri, tmp_ids_uri, Mrows, Ncols, offset);
+//  CHECK(X.ids()[0] == offset + 0);
+//  CHECK(X.ids()[1] == offset + 1);
+//  CHECK(X.ids()[10] == offset + 10);
+//  CHECK(size(X.ids()) == Ncols);
+//
+//  auto B = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
+//  {
+//    auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
+//        ctx, tmp_matrix_uri, tmp_ids_uri);
+//    Y.load();
+//    B = std::move(Y);
+//  }
+//
+//  auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
+//      ctx, tmp_matrix_uri, tmp_ids_uri);
+//  Y.load();
+//  CHECK(size(Y.ids()) == size(X.ids()));
+//  CHECK(num_vectors(Y) == num_vectors(X));
+//  CHECK(dimension(Y) == dimension(X));
+//  CHECK(
+//      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X),
+//      Y.data()));
+//  for (size_t i = 0; i < 5; ++i) {
+//    for (size_t j = 0; j < 5; ++j) {
+//      CHECK(X(i, j) == Y(i, j));
+//    }
+//  }
+//
+//  // Check that we can assign to a matrix
+//  auto Z = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
+//  Z = std::move(Y);
+//
+//  CHECK(num_vectors(Z) == num_vectors(X));
+//  CHECK(dimension(Z) == dimension(X));
+//  CHECK(
+//      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X),
+//      Z.data()));
+//  for (size_t i = 0; i < 5; ++i) {
+//    for (size_t j = 0; j < 5; ++j) {
+//      CHECK(X(i, j) == Z(i, j));
+//    }
+//  }
+//
+//  auto A = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
+//  A = std::move(Z);
+//  CHECK(size(A.ids()) == size(X.ids()));
+//  CHECK(num_vectors(A) == num_vectors(X));
+//  CHECK(dimension(A) == dimension(X));
+//  CHECK(
+//      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X),
+//      A.data()));
+//  for (size_t i = 0; i < 5; ++i) {
+//    for (size_t j = 0; j < 5; ++j) {
+//      CHECK(X(i, j) == A(i, j));
+//    }
+//  }
+//
+//  CHECK(size(B.ids()) == size(X.ids()));
+//  CHECK(num_vectors(B) == num_vectors(X));
+//  CHECK(dimension(B) == dimension(X));
+//  CHECK(
+//      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X),
+//      B.data()));
+//  for (size_t i = 0; i < 5; ++i) {
+//    for (size_t j = 0; j < 5; ++j) {
+//      CHECK(X(i, j) == B(i, j));
+//    }
+//  }
+//}
+//
+// TEST_CASE("tdb_matrix_with_ids: load from uri", "[tdb_matrix_with_ids]") {
+//  tiledb::Context ctx;
+//
+//  auto ck = tdbColMajorMatrixWithIds<float>(ctx, sift_inputs_uri,
+//  sift_ids_uri); ck.load(); CHECK(ck.num_ids() == num_sift_vectors);
+//
+//  auto num_queries = 10;
+//  auto qk = tdbColMajorMatrixWithIds<float>(
+//      ctx, sift_query_uri, sift_ids_uri, num_queries);
+//  load(qk);
+//  CHECK(qk.num_ids() == num_queries);
+//}
 
-TEST_CASE("tdb_matrix_with_ids: test test", "[tdb_matrix_with_ids]") {
-  REQUIRE(true);
-}
-
-TEMPLATE_TEST_CASE(
-    "tdb_matrix_with_ids: constructors",
-    "[tdb_matrix_with_ids]",
-    float,
-    double,
-    int,
-    char,
-    size_t,
-    uint32_t) {
+TEST_CASE("tdb_matrix_with_ids: empty matrix", "[tdb_matrix_with_ids]") {
   tiledb::Context ctx;
-
   std::string tmp_matrix_uri = "/tmp/tmp_tdb_matrix";
   std::string tmp_ids_uri = "/tmp/tmp_tdb_ids_matrix";
-  int offset = 13;
-  size_t Mrows = 200;
-  size_t Ncols = 500;
-  auto X = ColMajorMatrixWithIds<TestType, TestType, size_t>(Mrows, Ncols);
-  fill_and_write_matrix(
-      ctx, X, tmp_matrix_uri, tmp_ids_uri, Mrows, Ncols, offset);
-  CHECK(X.ids()[0] == offset + 0);
-  CHECK(X.ids()[1] == offset + 1);
-  CHECK(X.ids()[10] == offset + 10);
+  size_t matrix_dimension{128};
+  int32_t matrix_domain{1000};
+  int32_t tile_extent{100};
 
-  auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
-      ctx, tmp_matrix_uri, tmp_ids_uri);
-  Y.load();
-  CHECK(num_vectors(Y) == num_vectors(X));
-  CHECK(dimension(Y) == dimension(X));
-  CHECK(
-      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X), Y.data()));
-  for (size_t i = 0; i < X.num_rows(); ++i) {
-    for (size_t j = 0; j < X.num_cols(); ++j) {
-      CHECK(X(i, j) == Y(i, j));
-    }
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(tmp_matrix_uri)) {
+    vfs.remove_dir(tmp_matrix_uri);
   }
-  CHECK(size(Y.ids()) == Y.num_ids());
-  CHECK(size(X.ids()) == size(Y.ids()));
-  CHECK(X.num_ids() == Y.num_ids());
-  CHECK(std::equal(X.ids().begin(), X.ids().end(), Y.ids().begin()));
-  for (size_t i = 0; i < X.num_ids(); ++i) {
-    CHECK(X.ids()[i] == Y.ids()[i]);
+  if (vfs.is_dir(tmp_ids_uri)) {
+    vfs.remove_dir(tmp_ids_uri);
   }
 
-  auto Z = tdbColMajorMatrixWithIds<TestType, TestType>(std::move(Y));
-  CHECK(num_vectors(Z) == num_vectors(X));
-  CHECK(dimension(Z) == dimension(X));
-  CHECK(
-      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X), Z.data()));
-  for (size_t i = 0; i < 5; ++i) {
-    for (size_t j = 0; j < 5; ++j) {
-      CHECK(X(i, j) == Z(i, j));
-    }
+  create_empty_for_matrix<float, stdx::layout_left>(
+      ctx,
+      tmp_matrix_uri,
+      matrix_dimension,
+      matrix_domain,
+      matrix_dimension,
+      tile_extent);
+  create_empty_for_vector<uint64_t>(
+      ctx, tmp_ids_uri, matrix_domain, tile_extent);
+
+  SECTION("empty") {
+    auto X = tdbColMajorMatrixWithIds<float>(
+        ctx, tmp_matrix_uri, tmp_ids_uri, 0, 0, 0, 0, 10000, 0, false);
+    X.load();
+    CHECK(X.num_cols() == 0);
+    CHECK(num_vectors(X) == 0);
+    CHECK(X.num_rows() == 0);
+    CHECK(dimension(X) == 0);
+
+    CHECK(X.num_ids() == 0);
+    CHECK(X.ids().size() == 0);
   }
+  SECTION("filled") {
+    auto X = tdbColMajorMatrixWithIds<float>(ctx, tmp_matrix_uri, tmp_ids_uri);
+    X.load();
+    CHECK(X.num_cols() == matrix_domain);
+    CHECK(num_vectors(X) == matrix_domain);
+    CHECK(X.num_rows() == matrix_dimension);
+    CHECK(dimension(X) == matrix_dimension);
+    CHECK(X.num_ids() == matrix_domain);
+    CHECK(X.ids().size() == matrix_domain);
 
-  CHECK(size(Z.ids()) == Z.num_ids());
-  CHECK(size(X.ids()) == size(Z.ids()));
-  CHECK(X.num_ids() == Z.num_ids());
-  CHECK(std::equal(X.ids().begin(), X.ids().end(), Z.ids().begin()));
-  for (size_t i = 0; i < X.num_ids(); ++i) {
-    CHECK(X.ids()[i] == Z.ids()[i]);
+    auto Y = tdbColMajorMatrixWithIds<float>(std::move(X));
+    CHECK(Y.num_cols() == X.num_cols());
+    CHECK(num_vectors(Y) == num_vectors(X));
+    CHECK(Y.num_rows() == X.num_rows());
+    CHECK(dimension(Y) == dimension(X));
+    CHECK(Y.num_ids() == 1000);
+    CHECK(Y.ids().size() == 1000);
   }
-}
-
-TEMPLATE_TEST_CASE(
-    "tdb_matrix_with_ids: assign to matrix",
-    "[tdb_matrix_with_ids]",
-    float,
-    uint8_t) {
-  tiledb::Context ctx;
-  std::string tmp_matrix_uri = "/tmp/tmp_tdb_matrix";
-  std::string tmp_ids_uri = "/tmp/tmp_tdb_ids_matrix";
-  int offset = 123;
-  size_t Mrows = 200;
-  size_t Ncols = 500;
-
-  auto X = ColMajorMatrixWithIds<TestType, TestType, size_t>(Mrows, Ncols);
-  fill_and_write_matrix(
-      ctx, X, tmp_matrix_uri, tmp_ids_uri, Mrows, Ncols, offset);
-  CHECK(X.ids()[0] == offset + 0);
-  CHECK(X.ids()[1] == offset + 1);
-  CHECK(X.ids()[10] == offset + 10);
-  CHECK(size(X.ids()) == Ncols);
-
-  auto B = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
-  {
-    auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
-        ctx, tmp_matrix_uri, tmp_ids_uri);
-    Y.load();
-    B = std::move(Y);
-  }
-
-  auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
-      ctx, tmp_matrix_uri, tmp_ids_uri);
-  Y.load();
-  CHECK(size(Y.ids()) == size(X.ids()));
-  CHECK(num_vectors(Y) == num_vectors(X));
-  CHECK(dimension(Y) == dimension(X));
-  CHECK(
-      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X), Y.data()));
-  for (size_t i = 0; i < 5; ++i) {
-    for (size_t j = 0; j < 5; ++j) {
-      CHECK(X(i, j) == Y(i, j));
-    }
-  }
-
-  // Check that we can assign to a matrix
-  auto Z = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
-  Z = std::move(Y);
-
-  CHECK(num_vectors(Z) == num_vectors(X));
-  CHECK(dimension(Z) == dimension(X));
-  CHECK(
-      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X), Z.data()));
-  for (size_t i = 0; i < 5; ++i) {
-    for (size_t j = 0; j < 5; ++j) {
-      CHECK(X(i, j) == Z(i, j));
-    }
-  }
-
-  auto A = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
-  A = std::move(Z);
-  CHECK(size(A.ids()) == size(X.ids()));
-  CHECK(num_vectors(A) == num_vectors(X));
-  CHECK(dimension(A) == dimension(X));
-  CHECK(
-      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X), A.data()));
-  for (size_t i = 0; i < 5; ++i) {
-    for (size_t j = 0; j < 5; ++j) {
-      CHECK(X(i, j) == A(i, j));
-    }
-  }
-
-  CHECK(size(B.ids()) == size(X.ids()));
-  CHECK(num_vectors(B) == num_vectors(X));
-  CHECK(dimension(B) == dimension(X));
-  CHECK(
-      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X), B.data()));
-  for (size_t i = 0; i < 5; ++i) {
-    for (size_t j = 0; j < 5; ++j) {
-      CHECK(X(i, j) == B(i, j));
-    }
-  }
-}
-
-TEST_CASE("tdb_matrix_with_ids: load from uri", "[tdb_matrix_with_ids]") {
-  tiledb::Context ctx;
-
-  auto ck = tdbColMajorMatrixWithIds<float>(ctx, sift_inputs_uri, sift_ids_uri);
-  ck.load();
-  CHECK(ck.num_ids() == num_sift_vectors);
-
-  auto num_queries = 10;
-  auto qk = tdbColMajorMatrixWithIds<float>(
-      ctx, sift_query_uri, sift_ids_uri, num_queries);
-  load(qk);
-  CHECK(qk.num_ids() == num_queries);
 }

--- a/src/include/test/unit_tdb_matrix_with_ids.cc
+++ b/src/include/test/unit_tdb_matrix_with_ids.cc
@@ -35,173 +35,168 @@
 #include "detail/linalg/tdb_matrix_with_ids.h"
 #include "test/array_defs.h"
 #include "test/test_utils.h"
-//
-// TEST_CASE("tdb_matrix_with_ids: test test", "[tdb_matrix_with_ids]") {
-//  REQUIRE(true);
-//}
-//
-// TEMPLATE_TEST_CASE(
-//    "tdb_matrix_with_ids: constructors",
-//    "[tdb_matrix_with_ids]",
-//    float,
-//    double,
-//    int,
-//    char,
-//    size_t,
-//    uint32_t) {
-//  tiledb::Context ctx;
-//
-//  std::string tmp_matrix_uri = "/tmp/tmp_tdb_matrix";
-//  std::string tmp_ids_uri = "/tmp/tmp_tdb_ids_matrix";
-//  int offset = 13;
-//  size_t Mrows = 200;
-//  size_t Ncols = 500;
-//  auto X = ColMajorMatrixWithIds<TestType, TestType, size_t>(Mrows, Ncols);
-//  fill_and_write_matrix(
-//      ctx, X, tmp_matrix_uri, tmp_ids_uri, Mrows, Ncols, offset);
-//  CHECK(X.ids()[0] == offset + 0);
-//  CHECK(X.ids()[1] == offset + 1);
-//  CHECK(X.ids()[10] == offset + 10);
-//
-//  auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
-//      ctx, tmp_matrix_uri, tmp_ids_uri);
-//  Y.load();
-//  CHECK(num_vectors(Y) == num_vectors(X));
-//  CHECK(dimension(Y) == dimension(X));
-//  CHECK(
-//      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X),
-//      Y.data()));
-//  for (size_t i = 0; i < X.num_rows(); ++i) {
-//    for (size_t j = 0; j < X.num_cols(); ++j) {
-//      CHECK(X(i, j) == Y(i, j));
-//    }
-//  }
-//  CHECK(size(Y.ids()) == Y.num_ids());
-//  CHECK(size(X.ids()) == size(Y.ids()));
-//  CHECK(X.num_ids() == Y.num_ids());
-//  CHECK(std::equal(X.ids().begin(), X.ids().end(), Y.ids().begin()));
-//  for (size_t i = 0; i < X.num_ids(); ++i) {
-//    CHECK(X.ids()[i] == Y.ids()[i]);
-//  }
-//
-//  auto Z = tdbColMajorMatrixWithIds<TestType, TestType>(std::move(Y));
-//  CHECK(num_vectors(Z) == num_vectors(X));
-//  CHECK(dimension(Z) == dimension(X));
-//  CHECK(
-//      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X),
-//      Z.data()));
-//  for (size_t i = 0; i < 5; ++i) {
-//    for (size_t j = 0; j < 5; ++j) {
-//      CHECK(X(i, j) == Z(i, j));
-//    }
-//  }
-//
-//  CHECK(size(Z.ids()) == Z.num_ids());
-//  CHECK(size(X.ids()) == size(Z.ids()));
-//  CHECK(X.num_ids() == Z.num_ids());
-//  CHECK(std::equal(X.ids().begin(), X.ids().end(), Z.ids().begin()));
-//  for (size_t i = 0; i < X.num_ids(); ++i) {
-//    CHECK(X.ids()[i] == Z.ids()[i]);
-//  }
-//}
-//
-// TEMPLATE_TEST_CASE(
-//    "tdb_matrix_with_ids: assign to matrix",
-//    "[tdb_matrix_with_ids]",
-//    float,
-//    uint8_t) {
-//  tiledb::Context ctx;
-//  std::string tmp_matrix_uri = "/tmp/tmp_tdb_matrix";
-//  std::string tmp_ids_uri = "/tmp/tmp_tdb_ids_matrix";
-//  int offset = 123;
-//  size_t Mrows = 200;
-//  size_t Ncols = 500;
-//
-//  auto X = ColMajorMatrixWithIds<TestType, TestType, size_t>(Mrows, Ncols);
-//  fill_and_write_matrix(
-//      ctx, X, tmp_matrix_uri, tmp_ids_uri, Mrows, Ncols, offset);
-//  CHECK(X.ids()[0] == offset + 0);
-//  CHECK(X.ids()[1] == offset + 1);
-//  CHECK(X.ids()[10] == offset + 10);
-//  CHECK(size(X.ids()) == Ncols);
-//
-//  auto B = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
-//  {
-//    auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
-//        ctx, tmp_matrix_uri, tmp_ids_uri);
-//    Y.load();
-//    B = std::move(Y);
-//  }
-//
-//  auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
-//      ctx, tmp_matrix_uri, tmp_ids_uri);
-//  Y.load();
-//  CHECK(size(Y.ids()) == size(X.ids()));
-//  CHECK(num_vectors(Y) == num_vectors(X));
-//  CHECK(dimension(Y) == dimension(X));
-//  CHECK(
-//      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X),
-//      Y.data()));
-//  for (size_t i = 0; i < 5; ++i) {
-//    for (size_t j = 0; j < 5; ++j) {
-//      CHECK(X(i, j) == Y(i, j));
-//    }
-//  }
-//
-//  // Check that we can assign to a matrix
-//  auto Z = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
-//  Z = std::move(Y);
-//
-//  CHECK(num_vectors(Z) == num_vectors(X));
-//  CHECK(dimension(Z) == dimension(X));
-//  CHECK(
-//      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X),
-//      Z.data()));
-//  for (size_t i = 0; i < 5; ++i) {
-//    for (size_t j = 0; j < 5; ++j) {
-//      CHECK(X(i, j) == Z(i, j));
-//    }
-//  }
-//
-//  auto A = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
-//  A = std::move(Z);
-//  CHECK(size(A.ids()) == size(X.ids()));
-//  CHECK(num_vectors(A) == num_vectors(X));
-//  CHECK(dimension(A) == dimension(X));
-//  CHECK(
-//      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X),
-//      A.data()));
-//  for (size_t i = 0; i < 5; ++i) {
-//    for (size_t j = 0; j < 5; ++j) {
-//      CHECK(X(i, j) == A(i, j));
-//    }
-//  }
-//
-//  CHECK(size(B.ids()) == size(X.ids()));
-//  CHECK(num_vectors(B) == num_vectors(X));
-//  CHECK(dimension(B) == dimension(X));
-//  CHECK(
-//      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X),
-//      B.data()));
-//  for (size_t i = 0; i < 5; ++i) {
-//    for (size_t j = 0; j < 5; ++j) {
-//      CHECK(X(i, j) == B(i, j));
-//    }
-//  }
-//}
-//
-// TEST_CASE("tdb_matrix_with_ids: load from uri", "[tdb_matrix_with_ids]") {
-//  tiledb::Context ctx;
-//
-//  auto ck = tdbColMajorMatrixWithIds<float>(ctx, sift_inputs_uri,
-//  sift_ids_uri); ck.load(); CHECK(ck.num_ids() == num_sift_vectors);
-//
-//  auto num_queries = 10;
-//  auto qk = tdbColMajorMatrixWithIds<float>(
-//      ctx, sift_query_uri, sift_ids_uri, num_queries);
-//  load(qk);
-//  CHECK(qk.num_ids() == num_queries);
-//}
+
+TEST_CASE("tdb_matrix_with_ids: test test", "[tdb_matrix_with_ids]") {
+  REQUIRE(true);
+}
+
+TEMPLATE_TEST_CASE(
+    "tdb_matrix_with_ids: constructors",
+    "[tdb_matrix_with_ids]",
+    float,
+    double,
+    int,
+    char,
+    size_t,
+    uint32_t) {
+  tiledb::Context ctx;
+
+  std::string tmp_matrix_uri = "/tmp/tmp_tdb_matrix";
+  std::string tmp_ids_uri = "/tmp/tmp_tdb_ids_matrix";
+  int offset = 13;
+  size_t Mrows = 200;
+  size_t Ncols = 500;
+  auto X = ColMajorMatrixWithIds<TestType, TestType, size_t>(Mrows, Ncols);
+  fill_and_write_matrix(
+      ctx, X, tmp_matrix_uri, tmp_ids_uri, Mrows, Ncols, offset);
+  CHECK(X.ids()[0] == offset + 0);
+  CHECK(X.ids()[1] == offset + 1);
+  CHECK(X.ids()[10] == offset + 10);
+
+  auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
+      ctx, tmp_matrix_uri, tmp_ids_uri);
+  Y.load();
+  CHECK(num_vectors(Y) == num_vectors(X));
+  CHECK(dimension(Y) == dimension(X));
+  CHECK(
+      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X), Y.data()));
+  for (size_t i = 0; i < X.num_rows(); ++i) {
+    for (size_t j = 0; j < X.num_cols(); ++j) {
+      CHECK(X(i, j) == Y(i, j));
+    }
+  }
+  CHECK(size(Y.ids()) == Y.num_ids());
+  CHECK(size(X.ids()) == size(Y.ids()));
+  CHECK(X.num_ids() == Y.num_ids());
+  CHECK(std::equal(X.ids().begin(), X.ids().end(), Y.ids().begin()));
+  for (size_t i = 0; i < X.num_ids(); ++i) {
+    CHECK(X.ids()[i] == Y.ids()[i]);
+  }
+
+  auto Z = tdbColMajorMatrixWithIds<TestType, TestType>(std::move(Y));
+  CHECK(num_vectors(Z) == num_vectors(X));
+  CHECK(dimension(Z) == dimension(X));
+  CHECK(
+      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X), Z.data()));
+  for (size_t i = 0; i < 5; ++i) {
+    for (size_t j = 0; j < 5; ++j) {
+      CHECK(X(i, j) == Z(i, j));
+    }
+  }
+
+  CHECK(size(Z.ids()) == Z.num_ids());
+  CHECK(size(X.ids()) == size(Z.ids()));
+  CHECK(X.num_ids() == Z.num_ids());
+  CHECK(std::equal(X.ids().begin(), X.ids().end(), Z.ids().begin()));
+  for (size_t i = 0; i < X.num_ids(); ++i) {
+    CHECK(X.ids()[i] == Z.ids()[i]);
+  }
+}
+
+TEMPLATE_TEST_CASE(
+    "tdb_matrix_with_ids: assign to matrix",
+    "[tdb_matrix_with_ids]",
+    float,
+    uint8_t) {
+  tiledb::Context ctx;
+  std::string tmp_matrix_uri = "/tmp/tmp_tdb_matrix";
+  std::string tmp_ids_uri = "/tmp/tmp_tdb_ids_matrix";
+  int offset = 123;
+  size_t Mrows = 200;
+  size_t Ncols = 500;
+
+  auto X = ColMajorMatrixWithIds<TestType, TestType, size_t>(Mrows, Ncols);
+  fill_and_write_matrix(
+      ctx, X, tmp_matrix_uri, tmp_ids_uri, Mrows, Ncols, offset);
+  CHECK(X.ids()[0] == offset + 0);
+  CHECK(X.ids()[1] == offset + 1);
+  CHECK(X.ids()[10] == offset + 10);
+  CHECK(size(X.ids()) == Ncols);
+
+  auto B = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
+  {
+    auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
+        ctx, tmp_matrix_uri, tmp_ids_uri);
+    Y.load();
+    B = std::move(Y);
+  }
+
+  auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
+      ctx, tmp_matrix_uri, tmp_ids_uri);
+  Y.load();
+  CHECK(size(Y.ids()) == size(X.ids()));
+  CHECK(num_vectors(Y) == num_vectors(X));
+  CHECK(dimension(Y) == dimension(X));
+  CHECK(
+      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X), Y.data()));
+  for (size_t i = 0; i < 5; ++i) {
+    for (size_t j = 0; j < 5; ++j) {
+      CHECK(X(i, j) == Y(i, j));
+    }
+  }
+
+  // Check that we can assign to a matrix
+  auto Z = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
+  Z = std::move(Y);
+
+  CHECK(num_vectors(Z) == num_vectors(X));
+  CHECK(dimension(Z) == dimension(X));
+  CHECK(
+      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X), Z.data()));
+  for (size_t i = 0; i < 5; ++i) {
+    for (size_t j = 0; j < 5; ++j) {
+      CHECK(X(i, j) == Z(i, j));
+    }
+  }
+
+  auto A = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
+  A = std::move(Z);
+  CHECK(size(A.ids()) == size(X.ids()));
+  CHECK(num_vectors(A) == num_vectors(X));
+  CHECK(dimension(A) == dimension(X));
+  CHECK(
+      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X), A.data()));
+  for (size_t i = 0; i < 5; ++i) {
+    for (size_t j = 0; j < 5; ++j) {
+      CHECK(X(i, j) == A(i, j));
+    }
+  }
+
+  CHECK(size(B.ids()) == size(X.ids()));
+  CHECK(num_vectors(B) == num_vectors(X));
+  CHECK(dimension(B) == dimension(X));
+  CHECK(
+      std::equal(X.data(), X.data() + dimension(X) * num_vectors(X), B.data()));
+  for (size_t i = 0; i < 5; ++i) {
+    for (size_t j = 0; j < 5; ++j) {
+      CHECK(X(i, j) == B(i, j));
+    }
+  }
+}
+
+TEST_CASE("tdb_matrix_with_ids: load from uri", "[tdb_matrix_with_ids]") {
+  tiledb::Context ctx;
+
+  auto ck = tdbColMajorMatrixWithIds<float>(ctx, sift_inputs_uri, sift_ids_uri);
+  ck.load();
+  CHECK(ck.num_ids() == num_sift_vectors);
+
+  auto num_queries = 10;
+  auto qk = tdbColMajorMatrixWithIds<float>(
+      ctx, sift_query_uri, sift_ids_uri, num_queries);
+  load(qk);
+  CHECK(qk.num_ids() == num_queries);
+}
 
 TEST_CASE("tdb_matrix_with_ids: empty matrix", "[tdb_matrix_with_ids]") {
   tiledb::Context ctx;


### PR DESCRIPTION
### What
When we add type-erased APIs we will have a flow where we need to create an empty index:
```
def create(
    uri: str,
    dimensions: int,
    vector_type: np.dtype,
    id_type: np.dtype = np.uint32,
    adjacency_row_index_type: np.dtype = np.uint32,
    group_exists: bool = False,
    config: Optional[Mapping[str, Any]] = None,
    storage_version: str = STORAGE_VERSION,
    **kwargs,
) -> VamanaIndex:
      ctx = vspy.Ctx(config)
      index = vspy.IndexVamana(
          feature_type=np.dtype(vector_type).name, 
          id_type=np.dtype(id_type).name, 
          adjacency_row_index_type=np.dtype(adjacency_row_index_type).name, 
          dimension=dimensions,
        )
      index.write_index(ctx, uri)
      return VamanaIndex(uri=uri, config=config, memory_budget=1000000) # this is a Python VamanaIndex object.
```
When we do that we need to be able to write empty arrays and vectors. This writing of empty arrays and vectors works, but when we try to read them back we use code like this for both vectors and matrices to fill in the returned data:
```
if (start_pos == 0) {
    start_pos = array_rows_.template domain<domain_type>().first;
  }
  if (end_pos == 0) {
    end_pos = array_rows_.template domain<domain_type>().second + 1;
  }
```
Because of this we then try to run the query:
```
tiledb::Query query(ctx, *array_);
  query.set_subarray(subarray).set_data_buffer(
      attr_name, data_.data(), vec_rows_);
  tiledb_helpers::submit_query(tdb_func__, uri, query);
```
But we crash because `data_.data()` is actually empty and so there is no where to write the data to.

The fix that this PR makes is change the default behavior to not update the start and end positions and to return early if there is nothing to read. Ideally we would get to a point where we never need the default behavior and the caller is responsible for correctly asking for how much data to read. This is based off of what Python does where it has the caller manage how much to read, versus the reader automatically reading all it can. Though please do let me know if you have a different suggestion on how to fix this.

### Testing
* Added new unit tests.
* Existing unit tests pass.