### PR TITLE
Check for a nullptr `index_` in all api/index methods

### DIFF
--- a/src/include/api/flat_l2_index.h
+++ b/src/include/api/flat_l2_index.h
@@ -91,6 +91,9 @@ class IndexFlatL2 {
   // @todo query() or search() -- or both?
   [[nodiscard]] auto query(
       const QueryVectorArray& vectors, size_t top_k) const {
+    if (!index_) {
+      throw std::runtime_error("Cannot query() because there is no index.");
+    }
     return index_->query(vectors, top_k);
   }
 
@@ -98,6 +101,9 @@ class IndexFlatL2 {
       const FeatureVectorArray& vectors,
       const std::optional<IdVector>& ids = std::nullopt,
       const std::optional<UpdateOptions>& options = std::nullopt) const {
+    if (!index_) {
+      throw std::runtime_error("Cannot update() because there is no index.");
+    }
     index_->update(vectors, ids, options);
   }
 
@@ -105,10 +111,16 @@ class IndexFlatL2 {
       const URI& vectors_uri,
       const std::optional<IdVector>& ids = std::nullopt,
       const std::optional<UpdateOptions>& options = std::nullopt) const {
+    if (!index_) {
+      throw std::runtime_error("Cannot update() because there is no index.");
+    }
     index_->update(vectors_uri, ids, options);
   }
 
   void remove(const IdVector& ids) const {
+    if (!index_) {
+      throw std::runtime_error("Cannot remove() because there is no index.");
+    }
     index_->remove(ids);
   }
 

--- a/src/include/api/ivf_flat_index.h
+++ b/src/include/api/ivf_flat_index.h
@@ -338,6 +338,9 @@ class IndexIVFFlat {
           datatype_to_string(feature_datatype_) +
           " != " + datatype_to_string(data_set.feature_type()));
     }
+    if (!index_) {
+      throw std::runtime_error("Cannot add() because there is no index.");
+    }
     index_->add(data_set);
   }
 
@@ -348,6 +351,10 @@ class IndexIVFFlat {
   // todo query() or search() -- or both?
   [[nodiscard]] auto query_infinite_ram(
       const QueryVectorArray& vectors, size_t top_k, size_t nprobe) const {
+    if (!index_) {
+      throw std::runtime_error(
+          "Cannot query_infinite_ram() because there is no index.");
+    }
     return index_->query_infinite_ram(vectors, top_k, nprobe);
   }
 
@@ -356,6 +363,10 @@ class IndexIVFFlat {
       size_t top_k,
       size_t nprobe,
       size_t upper_bound = 0) const {
+    if (!index_) {
+      throw std::runtime_error(
+          "Cannot query_finite_ram() because there is no index.");
+    }
     return index_->query_finite_ram(vectors, top_k, nprobe, upper_bound);
   }
 
@@ -363,6 +374,9 @@ class IndexIVFFlat {
       const FeatureVectorArray& vectors,
       const std::optional<IdVector>& ids = std::nullopt,
       const std::optional<UpdateOptions>& options = std::nullopt) const {
+    if (!index_) {
+      throw std::runtime_error("Cannot update() because there is no index.");
+    }
     index_->update(vectors, ids, options);
   }
 
@@ -370,10 +384,16 @@ class IndexIVFFlat {
       const URI& vectors_uri,
       const std::optional<IdVector>& ids = std::nullopt,
       const std::optional<UpdateOptions>& options = std::nullopt) const {
+    if (!index_) {
+      throw std::runtime_error("Cannot update() because there is no index.");
+    }
     index_->update(vectors_uri, ids, options);
   }
 
   void remove(const IdVector& ids) const {
+    if (!index_) {
+      throw std::runtime_error("Cannot remove() because there is no index.");
+    }
     index_->remove(ids);
   }
 
@@ -381,6 +401,10 @@ class IndexIVFFlat {
       const tiledb::Context& ctx,
       const std::string& group_uri,
       bool overwrite = false) const {
+    if (!index_) {
+      throw std::runtime_error(
+          "Cannot write_index() because there is no index.");
+    }
     index_->write_index(ctx, group_uri, overwrite);
   }
 

--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -215,6 +215,9 @@ class IndexVamana {
           datatype_to_string(feature_datatype_) +
           " != " + datatype_to_string(data_set.feature_type()));
     }
+    if (!index_) {
+      throw std::runtime_error("Cannot add() because there is no index.");
+    }
     index_->add(data_set);
   }
 
@@ -223,6 +226,9 @@ class IndexVamana {
       const QueryVectorArray& vectors,
       size_t top_k,
       std::optional<size_t> opt_L = std::nullopt) {
+    if (!index_) {
+      throw std::runtime_error("Cannot query() because there is no index.");
+    }
     return index_->query(vectors, top_k, opt_L);
   }
 
@@ -230,6 +236,10 @@ class IndexVamana {
       const tiledb::Context& ctx,
       const std::string& group_uri,
       bool overwrite = false) const {
+    if (!index_) {
+      throw std::runtime_error(
+          "Cannot write_index() because there is no index.");
+    }
     index_->write_index(ctx, group_uri, overwrite);
   }
 


### PR DESCRIPTION
### What
Right now we seg fault if you call APIs in the wrong order. Here we guard against that and instead throw with a more useful error.

### Testing 
* Builds and tests pass.