### PR TITLE
Update to use `pytest` <8 to fix issue with `nbmake`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["nbmake", "pytest"]
+test = ["nbmake", "pytest<8.0.0"]
 formatting = ["pre-commit"]
 
 [project.urls]


### PR DESCRIPTION
### What
CI is failing with:
```
Run pip install .[test]
Processing /home/runner/work/TileDB-Vector-Search/TileDB-Vector-Search
  Installing build dependencies: started
...
Successfully installed Pygments-2.17.2 asttokens-2.4.1 attrs-23.2.0 certifi-2024.2.2 cloudpickle-2.2.1 comm-0.2.1 debugpy-1.8.1 decorator-5.1.1 exceptiongroup-1.2.0 executing-2.0.1 fastjsonschema-2.19.1 importlib-metadata-7.0.1 iniconfig-2.0.0 ipykernel-6.29.3 ipython-8.18.1 jedi-0.19.1 joblib-1.3.2 jsonschema-4.21.1 jsonschema-specifications-2023.12.1 jupyter-client-8.6.0 jupyter-core-5.7.1 matplotlib-inline-0.1.6 nbclient-0.6.8 nbformat-5.9.2 nbmake-1.5.0 nest-asyncio-1.6.0 numpy-1.26.4 packaging-23.2 pandas-2.2.1 parso-0.8.3 pexpect-4.9.0 platformdirs-4.2.0 pluggy-1.4.0 prompt-toolkit-3.0.43 psutil-5.9.8 ptyprocess-0.7.0 pure-eval-0.2.2 pyarrow-15.0.0 pytest-8.1.0 python-dateutil-2.9.0.post0 pytz-2024.1 pyzmq-25.1.2 referencing-0.33.0 rpds-py-0.18.0 scikit-learn-1.4.1.post1 scipy-1.12.0 six-1.16.0 stack-data-0.6.3 tblib-1.7.0 threadpoolctl-3.3.0 tiledb-0.26.1 tiledb-cloud-0.11.11 tiledb-vector-search-0.1.dev1+gdfa190c tomli-2.0.1 tornado-6.4 traitlets-5.14.1 typing-extensions-4.10.0 tzdata-2024.1 urllib3-2.2.1 wcwidth-0.2.13 zipp-3.17.0

Notice:  A new release of pip is available: 23.0.1 -> 24.0
Notice:  To update, run: pip install --upgrade pip

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.18/x64/bin/pytest", line 8, in <module>
    sys.exit(console_main())
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/_pytest/config/__init__.py", line 195, in console_main
    code = main()
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/_pytest/config/__init__.py", line 153, in main
    config = _prepareconfig(args, plugins)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/_pytest/config/__init__.py", line 335, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pluggy/_hooks.py", line 501, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pluggy/_callers.py", line 138, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/_pytest/helpconfig.py", line 105, in pytest_cmdline_parse
    config = yield
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/_pytest/config/__init__.py", line 1141, in pytest_cmdline_parse
    self.parse(args)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/_pytest/config/__init__.py", line 1490, in parse
    self._preparse(args, addopts=addopts)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/_pytest/config/__init__.py", line 1377, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pluggy/_manager.py", line 415, in load_setuptools_entrypoints
    self.register(plugin, name=ep.name)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/_pytest/config/__init__.py", line 497, in register
    plugin_name = super().register(plugin, name)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pluggy/_manager.py", line 167, in register
    self._verify_hook(hook, hookimpl)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pluggy/_manager.py", line 342, in _verify_hook
    raise PluginValidationError(
pluggy._manager.PluginValidationError: Plugin 'nbmake' for hook 'pytest_collect_file'
hookimpl definition: pytest_collect_file(path: str, parent: Any) -> Optional[Any]
Argument(s) {'path'} are declared in the hookimpl but can not be found in the hookspec
Error: Process completed with exit code 1.
```
This is because `pytest` deprecated something in 8.1.0 (https://github.com/pytest-dev/pytest/issues/11779) which broke `nbmake`. The fix here is locking pytest to < 8.0.0. This lock can likely be removed as soon as nbmake releases a fix.

### Testing
* Can run tests locally.
* CI passes.