### PR TITLE
Fix some ingestion bugs

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -2016,7 +2016,7 @@ def ingest(
                                 config=config,
                                 verbose=verbose,
                                 name="read-random-sample-" + str(idx),
-                                resources={"cpu": str(threads), "memory": "1Gi"},
+                                resources={"cpu": "2", "memory": "6Gi"},
                                 image_name=DEFAULT_IMG_NAME,
                             )
                         )

--- a/apis/python/src/tiledb/vector_search/object_api/embeddings_ingestion.py
+++ b/apis/python/src/tiledb/vector_search/object_api/embeddings_ingestion.py
@@ -443,7 +443,7 @@ def ingest_embeddings_with_driver(
     ):
         submit = d.submit
     driver_access_credentials_name_kwargs = {}
-    if embeddings_generation_mode == Mode.BATCH:
+    if embeddings_generation_driver_mode == Mode.BATCH:
         driver_access_credentials_name_kwargs[
             "access_credentials_name"
         ] = worker_access_credentials_name


### PR DESCRIPTION
- Random sample workers were using `16CPU` and `1Gi` which is problematic for most datasets. We need at least a couple of GB of memory to run this. For CPU we don't need 16 cores.
- `access_credentials_name` was not passed correctly when `embeddings_generation_driver_mode == Mode.BATCH`