### PR TITLE
Fix broken path on Windows in `unit_tdb_matrix_with_ids.cc`

### DIFF
--- a/src/include/test/unit_tdb_matrix_with_ids.cc
+++ b/src/include/test/unit_tdb_matrix_with_ids.cc
@@ -107,8 +107,8 @@ TEMPLATE_TEST_CASE(
 
 TEST_CASE("tdb_matrix_with_ids: different types", "[tdb_matrix_with_ids]") {
   tiledb::Context ctx;
-  std::string tmp_matrix_uri = "/tmp/tmp_tdb_matrix";
-  std::string tmp_ids_uri = "/tmp/tmp_tdb_ids_matrix";
+  std::string tmp_matrix_uri = (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
+  std::string tmp_ids_uri = (std::filesystem::temp_directory_path() / "tmp_tdb_ids_matrix").string();
   int offset = 13;
   size_t Mrows = 200;
   size_t Ncols = 500;


### PR DESCRIPTION
### What
Fixes a path that is broken on Windows in `unit_tdb_matrix_with_ids.cc`.

### Testing
Unit tests pass.