### PR TITLE
Add support for an empty `tdb_matrix`

### DIFF
--- a/apis/python/src/tiledb/vector_search/module.cc
+++ b/apis/python/src/tiledb/vector_search/module.cc
@@ -395,14 +395,14 @@ static void declareColMajorMatrixSubclass(
 
   cls.def(
       py::init<
-          const Ctx&,
-          std::string,
-          size_t,
-          size_t,
-          size_t,
-          size_t,
-          size_t,
-          uint64_t>(),
+          const Ctx&,             // ctx
+          std::string,            // uri
+          size_t,                 // first_row
+          std::optional<size_t>,  // last_row
+          size_t,                 // first_col
+          std::optional<size_t>,  // last_col
+          size_t,                 // upper_bound
+          uint64_t>(),            // timestamp
       py::keep_alive<1, 2>());
 
   if constexpr (std::is_same<P, tdbColMajorMatrix<T>>::value) {

--- a/apis/python/src/tiledb/vector_search/module.py
+++ b/apis/python/src/tiledb/vector_search/module.py
@@ -11,11 +11,11 @@ def load_as_matrix(
     path: str,
     ctx: "Ctx" = None,
     config: Optional[Mapping[str, Any]] = None,
-    size: int = 0,
+    size: Optional[int] = None,
     timestamp: int = 0,
 ):
     """
-    Load array as Matrix class
+    Load array as Matrix class. We read in all rows (i.e. from 0 to the row domain length).
 
     Parameters
     ----------
@@ -24,7 +24,7 @@ def load_as_matrix(
     ctx: Ctx
         TileDB context
     size: int
-        Size of vectors to load
+        Size of vectors to load. If not set we will read from 0 to the column domain length.
     """
     # If the user passes a tiledb python Config object convert to a dictionary
     if isinstance(config, tiledb.Config):
@@ -35,20 +35,38 @@ def load_as_matrix(
 
     a = tiledb.ArraySchema.load(path, ctx=tiledb.Ctx(config))
     dtype = a.attr(0).dtype
-    if dtype == np.float32:
-        m = tdbColMajorMatrix_f32(ctx, path, 0, 0, 0, size, 0, timestamp)
-    elif dtype == np.float64:
-        m = tdbColMajorMatrix_f64(ctx, path, 0, 0, 0, size, 0, timestamp)
-    elif dtype == np.int32:
-        m = tdbColMajorMatrix_i32(ctx, path, 0, 0, 0, size, 0, timestamp)
-    elif dtype == np.int32:
-        m = tdbColMajorMatrix_i64(ctx, path, 0, 0, 0, size, 0, timestamp)
-    elif dtype == np.uint8:
-        m = tdbColMajorMatrix_u8(ctx, path, 0, 0, 0, size, 0, timestamp)
-    # elif dtype == np.uint64:
-    #     return tdbColMajorMatrix_u64(ctx, path, size, timestamp)
+    if size == None:
+        # Read all rows and all cols. Set no upper_bound.
+        if dtype == np.float32:
+            m = tdbColMajorMatrix_f32(ctx, path, 0, None, 0, None, 0, timestamp)
+        elif dtype == np.float64:
+            m = tdbColMajorMatrix_f64(ctx, path, 0, None, 0, None, 0, timestamp)
+        elif dtype == np.int32:
+            m = tdbColMajorMatrix_i32(ctx, path, 0, None, 0, None, 0, timestamp)
+        elif dtype == np.int32:
+            m = tdbColMajorMatrix_i64(ctx, path, 0, None, 0, None, 0, timestamp)
+        elif dtype == np.uint8:
+            m = tdbColMajorMatrix_u8(ctx, path, 0, None, 0, None, 0, timestamp)
+        # elif dtype == np.uint64:
+        #     return tdbColMajorMatrix_u64(ctx, path, size, timestamp)
+        else:
+            raise ValueError("Unsupported Matrix dtype: {}".format(a.attr(0).dtype))
     else:
-        raise ValueError("Unsupported Matrix dtype: {}".format(a.attr(0).dtype))
+        # Read all rows from column 0 -> `size`. Set no upper_bound.
+        if dtype == np.float32:
+            m = tdbColMajorMatrix_f32(ctx, path, 0, None, 0, size, 0, timestamp)
+        elif dtype == np.float64:
+            m = tdbColMajorMatrix_f64(ctx, path, 0, None, 0, size, 0, timestamp)
+        elif dtype == np.int32:
+            m = tdbColMajorMatrix_i32(ctx, path, 0, None, 0, size, 0, timestamp)
+        elif dtype == np.int32:
+            m = tdbColMajorMatrix_i64(ctx, path, 0, None, 0, size, 0, timestamp)
+        elif dtype == np.uint8:
+            m = tdbColMajorMatrix_u8(ctx, path, 0, None, 0, size, 0, timestamp)
+        # elif dtype == np.uint64:
+        #     return tdbColMajorMatrix_u64(ctx, path, size, timestamp)
+        else:
+            raise ValueError("Unsupported Matrix dtype: {}".format(a.attr(0).dtype))
     m.load()
     return m
 
@@ -58,6 +76,7 @@ def load_as_array(
     return_matrix: bool = False,
     ctx: "Ctx" = None,
     config: Optional[Mapping[str, Any]] = None,
+    size: Optional[int] = None,
 ):
     """
     Load array as array class
@@ -71,7 +90,7 @@ def load_as_array(
     config: Dict
         TileDB configuration parameters
     """
-    m = load_as_matrix(path, ctx=ctx, config=config)
+    m = load_as_matrix(path, size=size, ctx=ctx, config=config)
     r = np.array(m, copy=False)
 
     # hang on to a copy for testing purposes, for now

--- a/apis/python/src/tiledb/vector_search/module.py
+++ b/apis/python/src/tiledb/vector_search/module.py
@@ -35,38 +35,22 @@ def load_as_matrix(
 
     a = tiledb.ArraySchema.load(path, ctx=tiledb.Ctx(config))
     dtype = a.attr(0).dtype
-    if size == None:
-        # Read all rows and all cols. Set no upper_bound.
-        if dtype == np.float32:
-            m = tdbColMajorMatrix_f32(ctx, path, 0, None, 0, None, 0, timestamp)
-        elif dtype == np.float64:
-            m = tdbColMajorMatrix_f64(ctx, path, 0, None, 0, None, 0, timestamp)
-        elif dtype == np.int32:
-            m = tdbColMajorMatrix_i32(ctx, path, 0, None, 0, None, 0, timestamp)
-        elif dtype == np.int32:
-            m = tdbColMajorMatrix_i64(ctx, path, 0, None, 0, None, 0, timestamp)
-        elif dtype == np.uint8:
-            m = tdbColMajorMatrix_u8(ctx, path, 0, None, 0, None, 0, timestamp)
-        # elif dtype == np.uint64:
-        #     return tdbColMajorMatrix_u64(ctx, path, size, timestamp)
-        else:
-            raise ValueError("Unsupported Matrix dtype: {}".format(a.attr(0).dtype))
+    # Read all rows from column 0 -> `size`. Set no upper_bound. Note that if `size` is None then 
+    # we'll read to the column domain length.
+    if dtype == np.float32:
+        m = tdbColMajorMatrix_f32(ctx, path, 0, None, 0, size, 0, timestamp)
+    elif dtype == np.float64:
+        m = tdbColMajorMatrix_f64(ctx, path, 0, None, 0, size, 0, timestamp)
+    elif dtype == np.int32:
+        m = tdbColMajorMatrix_i32(ctx, path, 0, None, 0, size, 0, timestamp)
+    elif dtype == np.int32:
+        m = tdbColMajorMatrix_i64(ctx, path, 0, None, 0, size, 0, timestamp)
+    elif dtype == np.uint8:
+        m = tdbColMajorMatrix_u8(ctx, path, 0, None, 0, size, 0, timestamp)
+    # elif dtype == np.uint64:
+    #     return tdbColMajorMatrix_u64(ctx, path, size, timestamp)
     else:
-        # Read all rows from column 0 -> `size`. Set no upper_bound.
-        if dtype == np.float32:
-            m = tdbColMajorMatrix_f32(ctx, path, 0, None, 0, size, 0, timestamp)
-        elif dtype == np.float64:
-            m = tdbColMajorMatrix_f64(ctx, path, 0, None, 0, size, 0, timestamp)
-        elif dtype == np.int32:
-            m = tdbColMajorMatrix_i32(ctx, path, 0, None, 0, size, 0, timestamp)
-        elif dtype == np.int32:
-            m = tdbColMajorMatrix_i64(ctx, path, 0, None, 0, size, 0, timestamp)
-        elif dtype == np.uint8:
-            m = tdbColMajorMatrix_u8(ctx, path, 0, None, 0, size, 0, timestamp)
-        # elif dtype == np.uint64:
-        #     return tdbColMajorMatrix_u64(ctx, path, size, timestamp)
-        else:
-            raise ValueError("Unsupported Matrix dtype: {}".format(a.attr(0).dtype))
+        raise ValueError("Unsupported Matrix dtype: {}".format(a.attr(0).dtype))
     m.load()
     return m
 

--- a/apis/python/test/test_api.py
+++ b/apis/python/test/test_api.py
@@ -22,6 +22,24 @@ def test_load_matrix(tmpdir):
     assert np.array_equal(m, data)
     assert np.array_equal(orig_matrix[0, 0], data[0, 0])
 
+def test_load_matrix_specify_size(tmpdir):
+    p = str(tmpdir.mkdir("test").join("test.tdb"))
+    data = np.random.rand(12).astype(np.float32).reshape(3, 4)
+
+    # write some test data with tiledb-py
+    create_array(p, data)
+
+    # test specifying a size
+    m = vs.load_as_array(p, size=data.shape[1])
+    assert np.array_equal(m, data)
+
+    # test specifying a smaller size
+    m = vs.load_as_array(p, size=2)
+    assert np.array_equal(m, data[:, :2])
+
+    # test specifying a size of 0
+    m = vs.load_as_array(p, size=0)
+    assert m.shape == (3, 0)
 
 def test_vector(tmpdir):
     v = vspy._create_vector_u64()

--- a/apis/python/test/test_module.py
+++ b/apis/python/test/test_module.py
@@ -13,11 +13,31 @@ def test_tdbMatrix(tmpdir):
     create_array(p, data)
 
     ctx = vspy.Ctx({})
-    m = vspy.tdbColMajorMatrix_f32(ctx, p, 0, 0, 0, 0, 0, 0)
+    # Read all rows and cols automatically.
+    m = vspy.tdbColMajorMatrix_f32(ctx, p, 0, None, 0, None, 0, 0)
     m.load()
     m_array = np.array(m)
     assert m_array.shape == data.shape
     assert np.array_equal(m_array, data)
+
+    # Read all rows and cols by specifying how many rows and cols there are.
+    m = vspy.tdbColMajorMatrix_f32(ctx, p, 0, data.shape[0], 0, data.shape[1], 0, 0)
+    m.load()
+    m_array = np.array(m)
+    assert m_array.shape == data.shape
+    assert np.array_equal(m_array, data)
+
+    # Read all rows and no cols.
+    m_no_fill = vspy.tdbColMajorMatrix_f32(ctx, p, 0, None, 0, 0, 0, 0)
+    m_no_fill.load()
+    m_array = np.array(m_no_fill)
+    assert m_array.shape == (3, 0)
+
+    # Read no rows and no cols.
+    m_no_fill = vspy.tdbColMajorMatrix_f32(ctx, p, 0, 0, 0, 0, 0, 0)
+    m_no_fill.load()
+    m_array = np.array(m_no_fill)
+    assert m_array.shape == (0, 0)
 
     m_array2 = np.array(m, copy=False)  # mutable view
     v = np.random.rand(1).astype(np.float32)

--- a/src/include/detail/ivf/index.h
+++ b/src/include/detail/ivf/index.h
@@ -80,11 +80,12 @@ int ivf_index(
   auto non_empty = array.non_empty_domain<int32_t>();
   auto partitions = non_empty[1].second.second + 1;
 
+  // Read all rows from column 0 -> `partitions`. Set no upper_bound.
   auto centroids = tdbColMajorMatrix<centroids_type>(
       ctx,
       centroids_uri,
       0,
-      0,
+      std::nullopt,
       0,
       partitions,
       0,
@@ -218,8 +219,9 @@ int ivf_index(
     size_t end_pos = 0,
     size_t nthreads = 0,
     uint64_t timestamp = 0) {
-  auto db =
-      tdbColMajorMatrix<T>(ctx, db_uri, 0, 0, start_pos, end_pos, 0, timestamp);
+  // Read all rows from column `start_pos` -> `end_pos`. Set no upper_bound.
+  auto db = tdbColMajorMatrix<T>(
+      ctx, db_uri, 0, std::nullopt, start_pos, end_pos, 0, timestamp);
   db.load();
   std::vector<ids_type> external_ids;
   if (external_ids_uri.empty()) {
@@ -261,8 +263,9 @@ int ivf_index(
     size_t end_pos = 0,
     size_t nthreads = 0,
     uint64_t timestamp = 0) {
-  auto db =
-      tdbColMajorMatrix<T>(ctx, db_uri, 0, 0, start_pos, end_pos, 0, timestamp);
+  // Read all rows from column `start_pos` -> `end_pos`. Set no upper_bound.
+  auto db = tdbColMajorMatrix<T>(
+      ctx, db_uri, 0, std::nullopt, start_pos, end_pos, 0, timestamp);
   db.load();
   return ivf_index<T, ids_type, centroids_type>(
       ctx,

--- a/src/include/detail/linalg/tdb_matrix.h
+++ b/src/include/detail/linalg/tdb_matrix.h
@@ -323,7 +323,7 @@ class tdbBlockedMatrix : public MatrixBase {
         std::min(load_blocksize_, last_col_ - last_resident_col_);
 
     // Return if we're at the end
-    if (elements_to_load == 0) {
+    if (elements_to_load == 0 || dimension == 0) {
       return false;
     }
 

--- a/src/include/detail/linalg/tdb_matrix.h
+++ b/src/include/detail/linalg/tdb_matrix.h
@@ -225,11 +225,9 @@ class tdbBlockedMatrix : public MatrixBase {
     constructor_timer.stop();
     scoped_timer _{tdb_func__ + " " + uri};
 
-    // Check if first_row and last_row have values before comparison
     if (last_row && *last_row < first_row_) {
       throw std::runtime_error("last_row < first_row");
     }
-    // Check if first_col and last_col have values before comparison
     if (last_col && *last_col < first_col_) {
       throw std::runtime_error("last_col < first_col");
     }

--- a/src/include/detail/linalg/tdb_matrix.h
+++ b/src/include/detail/linalg/tdb_matrix.h
@@ -392,7 +392,8 @@ class tdbPreLoadMatrix : public tdbBlockedMatrix<T, LayoutPolicy, I> {
       const std::string& uri,
       size_t upper_bound = 0,
       uint64_t timestamp = 0)
-      : tdbPreLoadMatrix(ctx, uri, {}, {}, upper_bound, timestamp) {
+      : tdbPreLoadMatrix(
+            ctx, uri, std::nullopt, std::nullopt, upper_bound, timestamp) {
   }
 
   tdbPreLoadMatrix(
@@ -413,31 +414,6 @@ class tdbPreLoadMatrix : public tdbBlockedMatrix<T, LayoutPolicy, I> {
             timestamp) {
     Base::load();
   }
-
-  // tdbPreLoadMatrix(
-  //     const tiledb::Context& ctx,
-  //     const std::string& uri,
-  //     size_t upper_bound,
-  //     const tiledb::TemporalPolicy& temporal_policy)
-  //     : tdbPreLoadMatrix(ctx, uri, 0, 0, upper_bound, temporal_policy) {
-  // }
-
-  // tdbPreLoadMatrix(
-  //     const tiledb::Context& ctx,
-  //     const std::string& uri,
-  //     size_t num_array_rows,
-  //     size_t num_array_cols,
-  //     size_t upper_bound,
-  //     const tiledb::TemporalPolicy& temporal_policy)
-  //     : Base(
-  //           ctx,
-  //           uri,
-  //           num_array_rows,
-  //           num_array_cols,
-  //           upper_bound,
-  //           temporal_policy) {
-  //   Base::load();
-  // }
 };
 
 /**

--- a/src/include/detail/linalg/tdb_matrix.h
+++ b/src/include/detail/linalg/tdb_matrix.h
@@ -122,26 +122,29 @@ class tdbBlockedMatrix : public MatrixBase {
 
   /**
    * @brief Construct a new tdbBlockedMatrix object, limited to `upper_bound`
-   * vectors. In this case, the `Matrix` is row-major, so the number of vectors
-   * is the number of rows.
+   * vectors. We read rows from 0 -> row domain length and cols from 0 -> col
+   * domain length. In this case, the `Matrix` is column-major, so the number of
+   * vectors is the number of columns.
    *
    * @param ctx The TileDB context to use.
    * @param uri URI of the TileDB array to read.
    */
   tdbBlockedMatrix(const tiledb::Context& ctx, const std::string& uri) noexcept
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
-      : tdbBlockedMatrix(ctx, uri, 0, 0, 0, 0, 0, 0) {
+      : tdbBlockedMatrix(ctx, uri, 0, std::nullopt, 0, std::nullopt, 0, 0) {
   }
 
   /**
    * @brief Construct a new tdbBlockedMatrix object, limited to `upper_bound`
-   * vectors. In this case, the `Matrix` is column-major, so the number of
+   * vectors. We read rows from 0 -> row domain length and cols from 0 -> col
+   * domain length. In this case, the `Matrix` is column-major, so the number of
    * vectors is the number of columns.
    *
    * @param ctx The TileDB context to use.
    * @param uri URI of the TileDB array to read.
-   * @param upper_bound The maximum number of vectors to read.
-   * @param temporal_policy The TemporalPolicy to use for reading the array
+   * @param upper_bound The maximum number of vectors to read. Set to 0 for no
+   * upper bound.
+   * @param timestamp The TemporalPolicy to use for reading the array
    * data.
    */
   tdbBlockedMatrix(
@@ -150,17 +153,33 @@ class tdbBlockedMatrix : public MatrixBase {
       size_t upper_bound,
       size_t timestamp = 0)
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
-      : tdbBlockedMatrix(ctx, uri, 0, 0, 0, 0, upper_bound, timestamp) {
+      : tdbBlockedMatrix(
+            ctx,
+            uri,
+            0,
+            std::nullopt,
+            0,
+            std::nullopt,
+            upper_bound,
+            timestamp) {
   }
 
-  /** General constructor */
+  /** General constructor
+   *
+   * @param first_row The first row to read from.
+   * @param last_row The last row to read to. Read rows from 0 -> row domain
+   * length if nullopt is passed.
+   * @param first_col The first col to read from.
+   * @param last_col The last col to read to. Read rows from 0 -> col domain
+   * length if nullopt is passed.
+   */
   tdbBlockedMatrix(
       const tiledb::Context& ctx,
       const std::string& uri,
       size_t first_row,
-      size_t last_row,
+      std::optional<size_t> last_row,
       size_t first_col,
-      size_t last_col,
+      std::optional<size_t> last_col,
       size_t upper_bound,
       size_t timestamp)
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
@@ -177,14 +196,22 @@ class tdbBlockedMatrix : public MatrixBase {
                  tiledb::TemporalPolicy(tiledb::TimeTravel, timestamp))) {
   }
 
-  /** General constructor */
+  /** General constructor
+   *
+   * @param first_row The first row to read from.
+   * @param last_row The last row to read to. Read rows from 0 -> row domain
+   * length if nullopt is passed.
+   * @param first_col The first col to read from.
+   * @param last_col The last col to read to. Read rows from 0 -> col domain
+   * length if nullopt is passed.
+   */
   tdbBlockedMatrix(
       const tiledb::Context& ctx,
       const std::string& uri,
       size_t first_row,
-      size_t last_row,
+      std::optional<size_t> last_row,
       size_t first_col,
-      size_t last_col,
+      std::optional<size_t> last_col,
       size_t upper_bound,
       tiledb::TemporalPolicy temporal_policy)  // noexcept
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
@@ -194,16 +221,16 @@ class tdbBlockedMatrix : public MatrixBase {
             ctx, uri, TILEDB_READ, temporal_policy))
       , schema_{array_->schema()}
       , first_row_{first_row}
-      , last_row_{last_row}
-      , first_col_{first_col}
-      , last_col_{last_col} {
+      , first_col_{first_col} {
     constructor_timer.stop();
     scoped_timer _{tdb_func__ + " " + uri};
 
-    if (last_row_ < first_row_) {
+    // Check if first_row and last_row have values before comparison
+    if (last_row && *last_row < first_row_) {
       throw std::runtime_error("last_row < first_row");
     }
-    if (last_col_ < first_col_) {
+    // Check if first_col and last_col have values before comparison
+    if (last_col && *last_col < first_col_) {
       throw std::runtime_error("last_col < first_col");
     }
 
@@ -228,15 +255,17 @@ class tdbBlockedMatrix : public MatrixBase {
 
     /* The size of the array may not be the size of domain.  Use non-zero value
      * if set in constructor */
-    if (last_row_ == 0) {
-      last_row_ =
-          (row_domain.template domain<row_domain_type>().second -
-           row_domain.template domain<row_domain_type>().first + 1);
+    if (!last_row.has_value()) {
+      last_row_ = row_domain.template domain<row_domain_type>().second -
+                  row_domain.template domain<row_domain_type>().first + 1;
+    } else {
+      last_row_ = *last_row;
     }
-    if (last_col_ == 0) {
-      last_col_ =
-          (col_domain.template domain<col_domain_type>().second -
-           col_domain.template domain<col_domain_type>().first + 1);
+    if (!last_col.has_value()) {
+      last_col_ = col_domain.template domain<col_domain_type>().second -
+                  col_domain.template domain<col_domain_type>().first + 1;
+    } else {
+      last_col_ = *last_col;
     }
 
     size_t dimension = last_row_ - first_row_;
@@ -363,14 +392,14 @@ class tdbPreLoadMatrix : public tdbBlockedMatrix<T, LayoutPolicy, I> {
       const std::string& uri,
       size_t upper_bound = 0,
       uint64_t timestamp = 0)
-      : tdbPreLoadMatrix(ctx, uri, 0, 0, upper_bound, timestamp) {
+      : tdbPreLoadMatrix(ctx, uri, {}, {}, upper_bound, timestamp) {
   }
 
   tdbPreLoadMatrix(
       const tiledb::Context& ctx,
       const std::string& uri,
-      size_t num_array_rows,
-      size_t num_array_cols,
+      std::optional<size_t> num_array_rows,
+      std::optional<size_t> num_array_cols,
       size_t upper_bound = 0,
       uint64_t timestamp = 0)
       : Base(
@@ -385,30 +414,30 @@ class tdbPreLoadMatrix : public tdbBlockedMatrix<T, LayoutPolicy, I> {
     Base::load();
   }
 
-  tdbPreLoadMatrix(
-      const tiledb::Context& ctx,
-      const std::string& uri,
-      size_t upper_bound,
-      const tiledb::TemporalPolicy& temporal_policy)
-      : tdbPreLoadMatrix(ctx, uri, 0, 0, upper_bound, temporal_policy) {
-  }
+  // tdbPreLoadMatrix(
+  //     const tiledb::Context& ctx,
+  //     const std::string& uri,
+  //     size_t upper_bound,
+  //     const tiledb::TemporalPolicy& temporal_policy)
+  //     : tdbPreLoadMatrix(ctx, uri, 0, 0, upper_bound, temporal_policy) {
+  // }
 
-  tdbPreLoadMatrix(
-      const tiledb::Context& ctx,
-      const std::string& uri,
-      size_t num_array_rows,
-      size_t num_array_cols,
-      size_t upper_bound,
-      const tiledb::TemporalPolicy& temporal_policy)
-      : Base(
-            ctx,
-            uri,
-            num_array_rows,
-            num_array_cols,
-            upper_bound,
-            temporal_policy) {
-    Base::load();
-  }
+  // tdbPreLoadMatrix(
+  //     const tiledb::Context& ctx,
+  //     const std::string& uri,
+  //     size_t num_array_rows,
+  //     size_t num_array_cols,
+  //     size_t upper_bound,
+  //     const tiledb::TemporalPolicy& temporal_policy)
+  //     : Base(
+  //           ctx,
+  //           uri,
+  //           num_array_rows,
+  //           num_array_cols,
+  //           upper_bound,
+  //           temporal_policy) {
+  //   Base::load();
+  // }
 };
 
 /**

--- a/src/include/detail/linalg/tdb_matrix_with_ids.h
+++ b/src/include/detail/linalg/tdb_matrix_with_ids.h
@@ -97,7 +97,8 @@ class tdbBlockedMatrixWithIds
       const std::string& uri,
       const std::string& ids_uri) noexcept
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
-      : tdbBlockedMatrixWithIds(ctx, uri, ids_uri, 0, 0, 0, 0, 0, 0) {
+      : tdbBlockedMatrixWithIds(
+            ctx, uri, ids_uri, 0, std::nullopt, 0, std::nullopt, 0, 0) {
   }
 
   /**
@@ -120,7 +121,15 @@ class tdbBlockedMatrixWithIds
       size_t timestamp = 0)
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
       : tdbBlockedMatrixWithIds(
-            ctx, uri, ids_uri, 0, 0, 0, 0, upper_bound, timestamp) {
+            ctx,
+            uri,
+            ids_uri,
+            0,
+            std::nullopt,
+            0,
+            std::nullopt,
+            upper_bound,
+            timestamp) {
   }
 
   /** General constructor */
@@ -129,9 +138,9 @@ class tdbBlockedMatrixWithIds
       const std::string& uri,
       const std::string& ids_uri,
       size_t first_row,
-      size_t last_row,
+      std::optional<size_t> last_row,
       size_t first_col,
-      size_t last_col,
+      std::optional<size_t> last_col,
       size_t upper_bound,
       size_t timestamp)
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
@@ -155,9 +164,9 @@ class tdbBlockedMatrixWithIds
       const std::string& uri,
       const std::string& ids_uri,
       size_t first_row,
-      size_t last_row,
+      std::optional<size_t> last_row,
       size_t first_col,
-      size_t last_col,
+      std::optional<size_t> last_col,
       size_t upper_bound,
       tiledb::TemporalPolicy temporal_policy)  // noexcept
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)

--- a/src/include/index/ivf_flat_index.h
+++ b/src/include/index/ivf_flat_index.h
@@ -228,11 +228,12 @@ class ivf_flat_index {
      */
     dimension_ = group_->get_dimension();
     num_partitions_ = group_->get_num_partitions();
+    // Read all rows from column 0 -> `num_partitions_`. Set no upper_bound.
     centroids_ =
         std::move(tdbPreLoadMatrix<centroid_feature_type, stdx::layout_left>(
             group_->cached_ctx(),
             group_->centroids_uri(),
-            0,
+            std::nullopt,
             num_partitions_,
             0,
             timestamp_));

--- a/src/include/test/unit_tdb_io.cc
+++ b/src/include/test/unit_tdb_io.cc
@@ -151,6 +151,39 @@ TEMPLATE_TEST_CASE("tdb_io: write matrix", "[tdb_io]", float, uint8_t) {
   }
 }
 
+TEST_CASE("tdb_io: write empty matrix", "[tdb_io]") {
+  tiledb::Context ctx;
+  std::string tmp_matrix_uri = "/tmp/tmp_matrix";
+  int offset = 13;
+
+  size_t dimension = 128;
+  int32_t domain = std::numeric_limits<int32_t>::max() - 1;
+  int32_t extent = 100'000;
+  int32_t tile_size_bytes = 64 * 1024 * 1024;
+  tiledb_filter_type_t compression{string_to_filter("zstd")};
+  size_t timestamp = 0;
+
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(tmp_matrix_uri)) {
+    vfs.remove_dir(tmp_matrix_uri);
+  }
+
+  create_empty_for_matrix<float, stdx::layout_left>(
+      ctx, tmp_matrix_uri, dimension, domain, dimension, extent, compression);
+  auto empty_matrix = tdbColMajorBlockedMatrix<float>(
+      ctx, tmp_matrix_uri, 0, dimension, 0, 0, 0, timestamp);
+  empty_matrix.load();
+  CHECK(num_vectors(empty_matrix) == 0);
+  CHECK(empty_matrix.num_cols() == 0);
+  CHECK(empty_matrix.num_rows() == dimension);
+
+  auto empty_preload_matrix = tdbColMajorPreLoadMatrix<float>(
+      ctx, tmp_matrix_uri, dimension, 0, 0, timestamp);
+  CHECK(num_vectors(empty_preload_matrix) == 0);
+  CHECK(empty_preload_matrix.num_cols() == 0);
+  CHECK(empty_preload_matrix.num_rows() == dimension);
+}
+
 TEST_CASE("tdb_io: create group", "[tdb_io]") {
   size_t N = 10'000;
 

--- a/src/include/test/unit_tdb_io.cc
+++ b/src/include/test/unit_tdb_io.cc
@@ -153,7 +153,8 @@ TEMPLATE_TEST_CASE("tdb_io: write matrix", "[tdb_io]", float, uint8_t) {
 
 TEST_CASE("tdb_io: write empty matrix", "[tdb_io]") {
   tiledb::Context ctx;
-  std::string tmp_matrix_uri = "/tmp/tmp_matrix";
+  std::string tmp_matrix_uri =
+      (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
   int offset = 13;
 
   size_t dimension = 128;

--- a/src/include/test/unit_tdb_matrix.cc
+++ b/src/include/test/unit_tdb_matrix.cc
@@ -293,7 +293,7 @@ TEST_CASE("tdb_matrix: empty matrix", "[tdb_matrix]") {
       matrix_dimension,
       tile_extent);
 
-  SECTION("empty") {
+  SECTION("empty: no rows and no cols") {
     auto X =
         tdbColMajorMatrix<float>(ctx, tmp_matrix_uri, 0, 0, 0, 0, 10000, 0);
     X.load();
@@ -302,6 +302,27 @@ TEST_CASE("tdb_matrix: empty matrix", "[tdb_matrix]") {
     CHECK(X.num_rows() == 0);
     CHECK(dimension(X) == 0);
   }
+
+  SECTION("empty: all rows and no cols") {
+    auto X = tdbColMajorMatrix<float>(
+        ctx, tmp_matrix_uri, 0, std::nullopt, 0, 0, 10000, 0);
+    X.load();
+    CHECK(X.num_cols() == 0);
+    CHECK(num_vectors(X) == 0);
+    CHECK(X.num_rows() == matrix_dimension);
+    CHECK(dimension(X) == matrix_dimension);
+  }
+
+  SECTION("empty: no rows and all cols") {
+    auto X = tdbColMajorMatrix<float>(
+        ctx, tmp_matrix_uri, 0, 0, 0, std::nullopt, 10000, 0);
+    X.load();
+    CHECK(X.num_cols() == matrix_domain);
+    CHECK(num_vectors(X) == matrix_domain);
+    CHECK(X.num_rows() == 0);
+    CHECK(dimension(X) == 0);
+  }
+
   SECTION("filled") {
     auto X = tdbColMajorMatrix<float>(ctx, tmp_matrix_uri);
     X.load();
@@ -311,6 +332,11 @@ TEST_CASE("tdb_matrix: empty matrix", "[tdb_matrix]") {
     CHECK(dimension(X) == matrix_dimension);
 
     auto Y = tdbColMajorMatrix<float>(std::move(X));
+    CHECK(Y.num_cols() == X.num_cols());
+    CHECK(num_vectors(Y) == num_vectors(X));
+    CHECK(Y.num_rows() == X.num_rows());
+    CHECK(dimension(Y) == dimension(X));
+    Y.load();
     CHECK(Y.num_cols() == X.num_cols());
     CHECK(num_vectors(Y) == num_vectors(X));
     CHECK(Y.num_rows() == X.num_rows());

--- a/src/include/test/unit_tdb_matrix.cc
+++ b/src/include/test/unit_tdb_matrix.cc
@@ -271,3 +271,49 @@ TEST_CASE("tdb_matrix: MatrixBase template parameter", "[tdb_matrix]") {
     }
   }
 }
+
+TEST_CASE("tdb_matrix: empty matrix", "[tdb_matrix]") {
+  tiledb::Context ctx;
+  std::string tmp_matrix_uri =
+      (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
+  size_t matrix_dimension{128};
+  int32_t matrix_domain{1000};
+  int32_t tile_extent{100};
+
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(tmp_matrix_uri)) {
+    vfs.remove_dir(tmp_matrix_uri);
+  }
+
+  create_empty_for_matrix<float, stdx::layout_left>(
+      ctx,
+      tmp_matrix_uri,
+      matrix_dimension,
+      matrix_domain,
+      matrix_dimension,
+      tile_extent);
+
+  SECTION("empty") {
+    auto X =
+        tdbColMajorMatrix<float>(ctx, tmp_matrix_uri, 0, 0, 0, 0, 10000, 0);
+    X.load();
+    CHECK(X.num_cols() == 0);
+    CHECK(num_vectors(X) == 0);
+    CHECK(X.num_rows() == 0);
+    CHECK(dimension(X) == 0);
+  }
+  SECTION("filled") {
+    auto X = tdbColMajorMatrix<float>(ctx, tmp_matrix_uri);
+    X.load();
+    CHECK(X.num_cols() == matrix_domain);
+    CHECK(num_vectors(X) == matrix_domain);
+    CHECK(X.num_rows() == matrix_dimension);
+    CHECK(dimension(X) == matrix_dimension);
+
+    auto Y = tdbColMajorMatrix<float>(std::move(X));
+    CHECK(Y.num_cols() == X.num_cols());
+    CHECK(num_vectors(Y) == num_vectors(X));
+    CHECK(Y.num_rows() == X.num_rows());
+    CHECK(dimension(Y) == dimension(X));
+  }
+}

--- a/src/include/test/unit_tdb_matrix_with_ids.cc
+++ b/src/include/test/unit_tdb_matrix_with_ids.cc
@@ -272,7 +272,7 @@ TEST_CASE("tdb_matrix_with_ids: empty matrix", "[tdb_matrix_with_ids]") {
 
   SECTION("empty") {
     auto X = tdbColMajorMatrixWithIds<float>(
-        ctx, tmp_matrix_uri, tmp_ids_uri, 0, 0, 0, 0, 0, 10000);
+        ctx, tmp_matrix_uri, tmp_ids_uri, 0, 0, 0, 0, 10000, 0);
     X.load();
     CHECK(X.num_cols() == 0);
     CHECK(num_vectors(X) == 0);

--- a/src/include/test/unit_tdb_matrix_with_ids.cc
+++ b/src/include/test/unit_tdb_matrix_with_ids.cc
@@ -299,5 +299,12 @@ TEST_CASE("tdb_matrix_with_ids: empty matrix", "[tdb_matrix_with_ids]") {
     CHECK(dimension(Y) == dimension(X));
     CHECK(Y.num_ids() == 1000);
     CHECK(Y.ids().size() == 1000);
+    Y.load();
+    CHECK(Y.num_cols() == X.num_cols());
+    CHECK(num_vectors(Y) == num_vectors(X));
+    CHECK(Y.num_rows() == X.num_rows());
+    CHECK(dimension(Y) == dimension(X));
+    CHECK(Y.num_ids() == 1000);
+    CHECK(Y.ids().size() == 1000);
   }
 }


### PR DESCRIPTION
### What
When we add type-erased APIs we will have a flow where we need to create an empty index:
```
def create(
    uri: str,
    dimensions: int,
    vector_type: np.dtype,
    id_type: np.dtype = np.uint32,
    adjacency_row_index_type: np.dtype = np.uint32,
    group_exists: bool = False,
    config: Optional[Mapping[str, Any]] = None,
    storage_version: str = STORAGE_VERSION,
    **kwargs,
) -> VamanaIndex:
      ctx = vspy.Ctx(config)
      index = vspy.IndexVamana(
          feature_type=np.dtype(vector_type).name, 
          id_type=np.dtype(id_type).name, 
          adjacency_row_index_type=np.dtype(adjacency_row_index_type).name, 
          dimension=dimensions,
        )
      index.write_index(ctx, uri)
      return VamanaIndex(uri=uri, config=config, memory_budget=1000000) # this is a Python VamanaIndex object.
```
When we do that we need to be able to write empty arrays and vectors. This writing of empty arrays and vectors works, but when we try to read them back we use code like this for both vectors and matrices to fill in the returned data:
```
  if (start_pos == 0) {
    start_pos = array_rows_.template domain<domain_type>().first;
  }
  if (end_pos == 0) {
    end_pos = array_rows_.template domain<domain_type>().second + 1;
  }
```
Because of this we then try to run the query:
```
tiledb::Query query(ctx, *array_);
  query.set_subarray(subarray).set_data_buffer(
      attr_name, data_.data(), vec_rows_);
  tiledb_helpers::submit_query(tdb_func__, uri, query);
```
But we crash because `data_.data()` is actually empty and so there is no where to write the data to.

The fix we make here is to disambiguate between a matrix that we should read all the rows / cols from and a matrix to read nothing from - i.e. we not support an empty `tdbMatrix`.

Note that the original version of this PR was #254, but we move over to here to split up code for supporting an empty matrix vs an empty vector.

### Testing
* Added new unit tests.
* Existing unit tests pass.


### TODO
In future PRs we will:
* Update `tdb_matrix` to use the correct types for first_row/last_row/first_col/last_col: https://app.shortcut.com/tiledb-inc/story/42696