### PR TITLE
Add support for reading an empty vector with `read_vector()`

### DIFF
--- a/src/include/detail/linalg/tdb_io.h
+++ b/src/include/detail/linalg/tdb_io.h
@@ -43,6 +43,77 @@
 #include "utils/print_types.h"
 #include "utils/timer.h"
 
+namespace {
+
+template <class T>
+std::vector<T> read_vector_helper(
+    const tiledb::Context& ctx,
+    const std::string& uri,
+    size_t start_pos,
+    size_t end_pos,
+    size_t timestamp,
+    bool read_full_vector) {
+  scoped_timer _{tdb_func__ + " " + std::string{uri}};
+
+  tiledb::TemporalPolicy temporal_policy =
+      (timestamp == 0) ? tiledb::TemporalPolicy() :
+                         tiledb::TemporalPolicy(tiledb::TimeTravel, timestamp);
+
+  auto array_ = tiledb_helpers::open_array(
+      tdb_func__, ctx, uri, TILEDB_READ, temporal_policy);
+  auto schema_ = array_->schema();
+
+  using domain_type = int32_t;
+  const size_t idx = 0;
+
+  auto domain_{schema_.domain()};
+
+  auto dim_num_{domain_.ndim()};
+  auto array_rows_{domain_.dimension(0)};
+
+  if (read_full_vector) {
+    if (start_pos == 0) {
+      start_pos = array_rows_.template domain<domain_type>().first;
+    }
+    if (end_pos == 0) {
+      end_pos = array_rows_.template domain<domain_type>().second + 1;
+    }
+  }
+
+  auto vec_rows_{end_pos - start_pos};
+
+  if (vec_rows_ == 0) {
+    return {};
+  }
+
+  auto attr_num{schema_.attribute_num()};
+  auto attr = schema_.attribute(idx);
+
+  std::string attr_name = attr.name();
+  tiledb_datatype_t attr_type = attr.type();
+
+  // Create a subarray that reads the array up to the specified subset.
+  std::vector<int32_t> subarray_vals = {
+      (int32_t)start_pos, (int32_t)end_pos - 1};
+  tiledb::Subarray subarray(ctx, *array_);
+  subarray.set_subarray(subarray_vals);
+
+  // @todo: use something non-initializing
+  std::vector<T> data_(vec_rows_);
+
+  tiledb::Query query(ctx, *array_);
+  query.set_subarray(subarray).set_data_buffer(
+      attr_name, data_.data(), vec_rows_);
+  tiledb_helpers::submit_query(tdb_func__, uri, query);
+  _memory_data.insert_entry(tdb_func__, vec_rows_ * sizeof(T));
+
+  array_->close();
+  assert(tiledb::Query::Status::COMPLETE == query.query_status());
+
+  return data_;
+}
+}  // namespace
+
 /******************************************************************************
  * Matrix creation and writing.  Because we support out-of-core operations with
  * matrices, reading a matrix is more subtle and is contained in the tdb_matrix
@@ -290,67 +361,16 @@ std::vector<T> read_vector(
     size_t start_pos,
     size_t end_pos,
     size_t timestamp = 0) {
-  scoped_timer _{tdb_func__ + " " + std::string{uri}};
-
-  tiledb::TemporalPolicy temporal_policy =
-      (timestamp == 0) ? tiledb::TemporalPolicy() :
-                         tiledb::TemporalPolicy(tiledb::TimeTravel, timestamp);
-
-  auto array_ = tiledb_helpers::open_array(
-      tdb_func__, ctx, uri, TILEDB_READ, temporal_policy);
-  auto schema_ = array_->schema();
-
-  using domain_type = int32_t;
-  const size_t idx = 0;
-
-  auto domain_{schema_.domain()};
-
-  auto dim_num_{domain_.ndim()};
-  auto array_rows_{domain_.dimension(0)};
-
-  if (start_pos == 0) {
-    start_pos = array_rows_.template domain<domain_type>().first;
-  }
-  if (end_pos == 0) {
-    end_pos = array_rows_.template domain<domain_type>().second + 1;
-  }
-
-  auto vec_rows_{end_pos - start_pos};
-
-  auto attr_num{schema_.attribute_num()};
-  auto attr = schema_.attribute(idx);
-
-  std::string attr_name = attr.name();
-  tiledb_datatype_t attr_type = attr.type();
-
-  // Create a subarray that reads the array up to the specified subset.
-  std::vector<int32_t> subarray_vals = {
-      (int32_t)start_pos, (int32_t)end_pos - 1};
-  tiledb::Subarray subarray(ctx, *array_);
-  subarray.set_subarray(subarray_vals);
-
-  // @todo: use something non-initializing
-  std::vector<T> data_(vec_rows_);
-
-  tiledb::Query query(ctx, *array_);
-  query.set_subarray(subarray).set_data_buffer(
-      attr_name, data_.data(), vec_rows_);
-  tiledb_helpers::submit_query(tdb_func__, uri, query);
-  _memory_data.insert_entry(tdb_func__, vec_rows_ * sizeof(T));
-
-  array_->close();
-  assert(tiledb::Query::Status::COMPLETE == query.query_status());
-
-  return data_;
+  return read_vector_helper<T>(ctx, uri, start_pos, end_pos, timestamp, false);
 }
 
 /**
- * @brief Overload with 0 for start_pos and end_pos (read entire vector)
+ * @brief Overload to read the entire vector.
  */
 template <class T>
 std::vector<T> read_vector(
     const tiledb::Context& ctx, const std::string& uri, size_t timestamp = 0) {
-  return read_vector<T>(ctx, uri, 0, 0, timestamp);
+  return read_vector_helper<T>(ctx, uri, 0, 0, timestamp, true);
 }
 
 template <class T>

--- a/src/include/detail/linalg/tdb_vector.h
+++ b/src/include/detail/linalg/tdb_vector.h
@@ -48,7 +48,7 @@ class tdbVector : public Vector<T> {
 
  public:
   tdbVector(const tiledb::Context& ctx, const std::string& uri)
-      : Base(read_vector<T>(ctx, uri, 0, 0, 0)) {
+      : Base(read_vector<T>(ctx, uri)) {
   }
 };
 

--- a/src/include/test/unit_tdb_io.cc
+++ b/src/include/test/unit_tdb_io.cc
@@ -151,6 +151,35 @@ TEMPLATE_TEST_CASE("tdb_io: write matrix", "[tdb_io]", float, uint8_t) {
   }
 }
 
+TEST_CASE("tdb_io: write empty vector", "[tdb_io]") {
+  tiledb::Context ctx;
+  std::string tmp_vector_uri =
+      (std::filesystem::temp_directory_path() / "tmp_vector").string();
+  int offset = 13;
+
+  size_t dimension = 128;
+  static const int32_t domain{10000};
+  static const int32_t tile_size_bytes{1024};
+  static const tiledb_filter_type_t compression{string_to_filter("zstd")};
+  static const int32_t tile_size{
+      (int32_t)(tile_size_bytes / sizeof(float) / dimension)};
+  size_t timestamp = 0;
+
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(tmp_vector_uri)) {
+    vfs.remove_dir(tmp_vector_uri);
+  }
+
+  create_empty_for_vector<float>(
+      ctx, tmp_vector_uri, domain, tile_size, compression);
+
+  auto empty_vector = read_vector<float>(ctx, tmp_vector_uri, 0, 0, timestamp);
+  CHECK(empty_vector.size() == 0);
+
+  auto filled_vector = read_vector<float>(ctx, tmp_vector_uri);
+  CHECK(filled_vector.size() == domain);
+}
+
 TEST_CASE("tdb_io: create group", "[tdb_io]") {
   size_t N = 10'000;
 


### PR DESCRIPTION
### What
Right now in `read_vector()` you cannot read an empty vector because we'll automatically read to the domain end if you pass 0. Here we update so we have a different constructor for automatically reading to the end versus reading a range.

### Testing
* Existing tests pass.
* New unit test checking that we can read an empty vector with this function.
