### PR TITLE
Add debug helper to `matrix_with_ids`

### DIFF
--- a/src/include/detail/linalg/matrix_with_ids.h
+++ b/src/include/detail/linalg/matrix_with_ids.h
@@ -167,4 +167,48 @@ using RowMajorMatrixWithIds = MatrixWithIds<T, IdsType, stdx::layout_right, I>;
 template <class T, class IdsType = uint64_t, class I = size_t>
 using ColMajorMatrixWithIds = MatrixWithIds<T, IdsType, stdx::layout_left, I>;
 
+template <class MatrixWithIds>
+void debug_slice_with_ids(
+    const MatrixWithIds& A,
+    const std::string& msg = "",
+    size_t rows = 6,
+    size_t cols = 18) {
+  auto max_size = 10;
+  auto rowsEnd = std::min(dimension(A), static_cast<size_t>(max_size));
+  auto colsEnd = std::min(num_vectors(A), static_cast<size_t>(max_size));
+
+  std::cout << "# " << msg << std::endl;
+  for (size_t i = 0; i < rowsEnd; ++i) {
+    std::cout << "# ";
+    for (size_t j = 0; j < colsEnd; ++j) {
+      std::cout << (float)A(i, j) << " ";
+    }
+    if (A.num_cols() > max_size) {
+      std::cout << "...";
+    }
+    std::cout << std::endl;
+  }
+  if (A.num_rows() > max_size) {
+    std::cout << "# ..." << std::endl;
+  }
+
+  std::cout << "# ids: [";
+  auto end = std::min(A.num_ids(), static_cast<size_t>(max_size));
+  for (size_t i = 0; i < end; ++i) {
+    std::cout << (float)A.ids()[i];
+    if (i != A.num_ids() - 1) {
+      std::cout << ", ";
+    }
+  }
+  if (A.num_ids() > max_size) {
+    std::cout << "...";
+  }
+  std::cout << "]" << std::endl;
+}
+
+template <class MatrixWithIds>
+void debug_with_ids(const MatrixWithIds& A, const std::string& msg = "") {
+  debug_slice_with_ids(A, msg, A.num_rows(), A.num_cols());
+}
+
 #endif  // TILEDB_MATRIX_WITH_IDS_H


### PR DESCRIPTION
### What
Adds a debug helper to `matrix_with_ids`.

### Testing
This code:
```
TEMPLATE_TEST_CASE(
    "matrix_with_ids: initializer list",
    "[matrix_with_ids]",
    stdx::layout_right,
    stdx::layout_left) {
  auto A = MatrixWithIds<float, size_t, TestType>{
      {{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}}, {1, 2, 3, 4}};

  auto a = std::vector<float>{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8};
  auto idsData = std::vector<size_t>{1, 2, 3, 4};
  auto raveled = A.raveled();
  auto ids = A.ids();
  debug_with_ids(A, "A");
```
gives:
```
# A
# 3 1 2 3 
# 1 5 6 5 
# 4 9 5 8 
# ids: [1, 2, 3, 4]
# A
# 3 1 4 1 
# 1 5 9 2 
# 2 6 5 3 
# ids: [1, 2, 3, 4]
Process finished with exi
```