### PR TITLE
Remove `[ci-skip]` on unit tests

### DIFF
--- a/src/include/test/unit_api_ivf_flat_index.cc
+++ b/src/include/test/unit_api_ivf_flat_index.cc
@@ -130,8 +130,7 @@ TEST_CASE("api_ivf_flat_index: init constructor", "[api_ivf_flat_index]") {
   }
 }
 
-TEST_CASE(
-    "api_ivf_flat_index: infer feature type", "[api_ivf_flat_index][ci-skip]") {
+TEST_CASE("api_ivf_flat_index: infer feature type", "[api_ivf_flat_index]") {
   auto a = IndexIVFFlat(std::make_optional<IndexOptions>(
       {{"id_type", "uint32"}, {"px_type", "uint32"}}));
   auto ctx = tiledb::Context{};
@@ -142,8 +141,7 @@ TEST_CASE(
   CHECK(a.px_type() == TILEDB_UINT32);
 }
 
-TEST_CASE(
-    "api_ivf_flat_index: infer dimension", "[api_ivf_flat_index][ci-skip]") {
+TEST_CASE("api_ivf_flat_index: infer dimension", "[api_ivf_flat_index]") {
   auto a = IndexIVFFlat(std::make_optional<IndexOptions>(
       {{"id_type", "uint32"}, {"px_type", "uint32"}}));
   auto ctx = tiledb::Context{};
@@ -158,7 +156,7 @@ TEST_CASE(
 
 TEST_CASE(
     "api_ivf_flat_index: api_ivf_flat_index write and read",
-    "[api_ivf_flat_index][ci-skip]") {
+    "[api_ivf_flat_index]") {
   auto ctx = tiledb::Context{};
   std::string api_ivf_flat_index_uri =
       (std::filesystem::temp_directory_path() / "api_ivf_flat_index").string();
@@ -182,7 +180,7 @@ TEST_CASE(
 
 TEST_CASE(
     "api_ivf_flat_index: build index and query in place infinite",
-    "[api_ivf_flat_index][ci-skip]") {
+    "[api_ivf_flat_index]") {
   auto ctx = tiledb::Context{};
   size_t k_nn = 10;
   size_t nprobe = GENERATE(8, 32);
@@ -220,7 +218,7 @@ TEST_CASE(
 
 TEST_CASE(
     "api_ivf_flat_index: read index and query infinite and finite",
-    "[api_ivf_flat_index][ci-skip]") {
+    "[api_ivf_flat_index]") {
   auto ctx = tiledb::Context{};
   size_t k_nn = 10;
   size_t nprobe = GENERATE(8, 32);

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -158,8 +158,7 @@ TEST_CASE("api_vamana_index: infer dimension", "[api_vamana_index]") {
 }
 
 TEST_CASE(
-    "api_vamana_index: api_vamana_index write and read",
-    "[api_vamana_index][ci-skip]") {
+    "api_vamana_index: api_vamana_index write and read", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   std::string api_vamana_index_uri =
       (std::filesystem::temp_directory_path() / "api_vamana_index").string();
@@ -181,9 +180,7 @@ TEST_CASE(
   CHECK(a.adjacency_row_index_type() == b.adjacency_row_index_type());
 }
 
-TEST_CASE(
-    "api_vamana_index: build index and query in place infinite",
-    "[api_vamana_index][ci-skip]") {
+TEST_CASE("api_vamana_index: build index and query", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   size_t k_nn = 10;
   size_t nprobe = GENERATE(8, 32);
@@ -204,9 +201,7 @@ TEST_CASE(
   CHECK(recall == 1.0);
 }
 
-TEST_CASE(
-    "api_vamana_index: read index and query infinite and finite",
-    "[api_vamana_index][ci-skip]") {
+TEST_CASE("api_vamana_index: read index and query", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   size_t k_nn = 10;
   size_t nprobe = GENERATE(8, 32);

--- a/src/include/test/unit_ivf_qv.cc
+++ b/src/include/test/unit_ivf_qv.cc
@@ -42,7 +42,7 @@ TEST_CASE("qv: test test", "[qv]") {
   REQUIRE(true);
 }
 
-TEST_CASE("ivf qv: infinite all or none", "[ivf qv][ci-skip]") {
+TEST_CASE("ivf qv: infinite all or none", "[ivf qv]") {
   // vq_query_infinite_ram
   // vq_query_infinite_ram_2
 
@@ -141,7 +141,7 @@ TEST_CASE("ivf qv: infinite all or none", "[ivf qv][ci-skip]") {
   }
 }
 
-TEST_CASE("ivf qv: finite all or none", "[ivf qv][ci-skip]") {
+TEST_CASE("ivf qv: finite all or none", "[ivf qv]") {
   // vq_query_infinite_ram
   // vq_query_infinite_ram_2
 

--- a/src/include/test/unit_ivf_vq.cc
+++ b/src/include/test/unit_ivf_vq.cc
@@ -44,13 +44,13 @@ TEST_CASE("vq: test test", "[ivf vq]") {
 }
 
 // vq_apply_query
-TEST_CASE("ivf vq: vq apply query", "[ivf vq][ci-skip]") {
+TEST_CASE("ivf vq: vq apply query", "[ivf vq]") {
   //  vq_apply_query(query, shuffled_db, new_indices, active_queries, ids,
   //  active_partitions, k_nn, first_part, last_part);
   REQUIRE(true);
 }
 
-TEST_CASE("ivf vq: infinite all or none", "[ivf vq][ci-skip]") {
+TEST_CASE("ivf vq: infinite all or none", "[ivf vq]") {
   // vq_query_infinite_ram
   // vq_query_infinite_ram_2
 
@@ -123,7 +123,7 @@ TEST_CASE("ivf vq: infinite all or none", "[ivf vq][ci-skip]") {
   }
 }
 
-TEST_CASE("ivf vq: finite all or none", "[ivf vq][ci-skip]") {
+TEST_CASE("ivf vq: finite all or none", "[ivf vq]") {
   // vq_query_infinite_ram
   // vq_query_infinite_ram_2
 

--- a/src/include/test/unit_slicing.cc
+++ b/src/include/test/unit_slicing.cc
@@ -37,7 +37,7 @@
 
 std::string global_region = "us-east-1";
 
-TEST_CASE("slice", "[linalg][ci-skip]") {
+TEST_CASE("slice", "[linalg]") {
   const bool debug = false;
 
   tiledb::Context ctx_;


### PR DESCRIPTION
### What
Not sure why we need these, but things pass without it, so remove it.

### Testing
Tests pass.