### PR TITLE
Fix packaging version

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -40,3 +40,6 @@ jobs:
         env:
           TILEDB_REST_TOKEN: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
         shell: bash -el {0}
+      - name: Check tiledb-vector-search version
+        run: |
+          python -c "from tiledb.vector_search.version import version; print(version)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,12 +43,12 @@ cmake.source-dir = "src"
 cmake.targets = ["skbuild-export"]
 # TODO: This should be removed, but currently can't bacause: 'src/src/CMakeLists.txt'
 sdist.include = [
-    ".git"
+    ".git",
+    "apis/python/src/tiledb/vector_search/version.py"
 ]
 wheel.packages = ["apis/python/src/tiledb"]
 
 [tool.scikit-build.cmake.define]
-#GIT_REPO_NAME = "placeholder"
 TILEDB_VS_PYTHON = "ON"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,17 @@ wheel.expand-macos-universal-tags = true
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 cmake.source-dir = "src"
 cmake.targets = ["skbuild-export"]
-# TODO: This should be removed, but currently can't bacause: 'src/src/CMakeLists.txt'
 sdist.include = [
-    ".git",
-    "apis/python/src/tiledb/vector_search/version.py"
+    "apis/python/src/tiledb/vector_search/version.py",
+    "src/config.h"
+]
+sdist.exclude = [
+    ".github"
 ]
 wheel.packages = ["apis/python/src/tiledb"]
+# We need to run cmake during packaging step in order to generate src/config.h and
+# thus not including .git to generate it later
+sdist.cmake = true
 
 [tool.scikit-build.cmake.define]
 TILEDB_VS_PYTHON = "ON"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,7 +175,7 @@ include(nlohmann_json)
 include (logging)
 
 # Write config file
-if(NOT EXISTS ${CMAKE_SOURCE_DIR}/config.h)
+if(LOGGING_INFO_QUERIED)
     configure_file(${CMAKE_SOURCE_DIR}/include/config.h.in ${CMAKE_SOURCE_DIR}/config.h)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,7 +175,9 @@ include(nlohmann_json)
 include (logging)
 
 # Write config file
-configure_file(${CMAKE_SOURCE_DIR}/include/config.h.in config.h)
+if(NOT EXISTS ${CMAKE_SOURCE_DIR}/config.h)
+    configure_file(${CMAKE_SOURCE_DIR}/include/config.h.in ${CMAKE_SOURCE_DIR}/config.h)
+endif()
 
 # -----------------------------------------------------------------------------
 # Interface libraries

--- a/src/cmake/logging.cmake
+++ b/src/cmake/logging.cmake
@@ -1,5 +1,4 @@
-
-if(NOT EXISTS ${CMAKE_SOURCE_DIR}/config.h)
+if(EXISTS ${CMAKE_SOURCE_DIR}/../.git)
 
 # Get the current date and time
 string(TIMESTAMP CURRENT_DATETIME "%Y-%m-%d %H:%M:%S")
@@ -60,4 +59,8 @@ execute_process(
 
 get_filename_component(IVF_HACK_CXX_COMPILER ${CMAKE_CXX_COMPILER} NAME)
 
+set(LOGGING_INFO_QUERIED)
+
+elseif(NOT EXISTS ${CMAKE_SOURCE_DIR}/config.h)
+    message(FATAL_ERROR ".git or pre generated config.h is required")
 endif()

--- a/src/cmake/logging.cmake
+++ b/src/cmake/logging.cmake
@@ -1,4 +1,5 @@
 
+if(NOT EXISTS ${CMAKE_SOURCE_DIR}/config.h)
 
 # Get the current date and time
 string(TIMESTAMP CURRENT_DATETIME "%Y-%m-%d %H:%M:%S")
@@ -58,3 +59,5 @@ execute_process(
 )
 
 get_filename_component(IVF_HACK_CXX_COMPILER ${CMAKE_CXX_COMPILER} NAME)
+
+endif()

--- a/src/cmake/logging.cmake
+++ b/src/cmake/logging.cmake
@@ -59,7 +59,7 @@ execute_process(
 
 get_filename_component(IVF_HACK_CXX_COMPILER ${CMAKE_CXX_COMPILER} NAME)
 
-set(LOGGING_INFO_QUERIED)
+set(LOGGING_INFO_QUERIED True)
 
 elseif(NOT EXISTS ${CMAKE_SOURCE_DIR}/config.h)
     message(FATAL_ERROR ".git or pre generated config.h is required")


### PR DESCRIPTION
This PR fixes version not correctly exporting in wheels. This is the current output if build locally:
```
Successfully installed tiledb-vector-search-0.1.1.dev25+gb0c5208e.d20240312
(zoo) taco:TileDB-Vector-Search dudoslav$ python
Python 3.11.7 | packaged by conda-forge | (main, Dec 23 2023, 14:43:09) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from tiledb.vector_search.version import version
>>> version
'0.1.1.dev25+gb0c5208e.d20240312'
```