### PR TITLE
Make clear which `ctx` we are using in Python

### DIFF
--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -6,6 +6,7 @@ from typing import Any, Mapping, Optional
 
 from tiledb.vector_search.module import *
 from tiledb.vector_search.storage_formats import storage_formats
+from tiledb.vector_search import _tiledbvspy as vspy
 
 MAX_UINT64 = np.iinfo(np.dtype("uint64")).max
 MAX_INT32 = np.iinfo(np.dtype("int32")).max
@@ -41,7 +42,8 @@ class Index:
 
         self.uri = uri
         self.config = config
-        self.ctx = Ctx(config)
+        self.ctx_vspy = vspy.Ctx(config)
+        self.ctx_tiledb = tiledb.Ctx(config)
         self.group = tiledb.Group(self.uri, "r", ctx=tiledb.Ctx(config))
         self.storage_version = self.group.meta.get("storage_version", "0.1")
         if (

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -42,8 +42,7 @@ class Index:
 
         self.uri = uri
         self.config = config
-        self.ctx_vspy = vspy.Ctx(config)
-        self.ctx_tiledb = tiledb.Ctx(config)
+        self.ctx = vspy.Ctx(config)
         self.group = tiledb.Group(self.uri, "r", ctx=tiledb.Ctx(config))
         self.storage_version = self.group.meta.get("storage_version", "0.1")
         if (

--- a/apis/python/src/tiledb/vector_search/module.py
+++ b/apis/python/src/tiledb/vector_search/module.py
@@ -22,7 +22,7 @@ def load_as_matrix(
     path: str
         Array path
     ctx: vspy.Ctx
-        TileDB context
+        The vspy Context
     size: int
         Size of vectors to load. If not set we will read from 0 to the column domain length.
     """
@@ -280,7 +280,7 @@ def ivf_query_ram(
     nthreads: int
         Number of theads
     ctx: vspy.Ctx
-        Tiledb Context
+        The vspy Context
     """
     if ctx is None:
         ctx = vspy.Ctx({})

--- a/apis/python/src/tiledb/vector_search/module.py
+++ b/apis/python/src/tiledb/vector_search/module.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import tiledb
 from tiledb.vector_search._tiledbvspy import *
-
+from tiledb.vector_search import _tiledbvspy as vspy
 
 def load_as_matrix(
     path: str,
@@ -21,7 +21,7 @@ def load_as_matrix(
     ----------
     path: str
         Array path
-    ctx: Ctx
+    ctx: vspy.Ctx
         TileDB context
     size: int
         Size of vectors to load. If not set we will read from 0 to the column domain length.
@@ -31,7 +31,7 @@ def load_as_matrix(
         config = dict(config)
 
     if ctx is None:
-        ctx = Ctx(config)
+        ctx = vspy.Ctx(config)
 
     a = tiledb.ArraySchema.load(path, ctx=tiledb.Ctx(config))
     dtype = a.attr(0).dtype
@@ -169,9 +169,9 @@ def ivf_index_tdb(
     config: Dict = None,
 ):
     if config is None:
-        ctx = Ctx({})
+        ctx = vspy.Ctx({})
     else:
-        ctx = Ctx(config)
+        ctx = vspy.Ctx(config)
 
     args = tuple(
         [
@@ -214,9 +214,9 @@ def ivf_index(
     config: Dict = None,
 ):
     if config is None:
-        ctx = Ctx({})
+        ctx = vspy.Ctx({})
     else:
-        ctx = Ctx(config)
+        ctx = vspy.Ctx(config)
 
     args = tuple(
         [
@@ -279,11 +279,11 @@ def ivf_query_ram(
         Number of nn
     nthreads: int
         Number of theads
-    ctx: Ctx
+    ctx: vspy.Ctx
         Tiledb Context
     """
     if ctx is None:
-        ctx = Ctx({})
+        ctx = vspy.Ctx({})
 
     args = tuple(
         [
@@ -355,13 +355,13 @@ def ivf_query(
         Main memory budget
     nthreads: int
         Number of theads
-    ctx: Ctx
-        Tiledb Context
+    ctx: vspy.Ctx
+        The vspy Context
     timestamp: int
         Read timestamp
     """
     if ctx is None:
-        ctx = Ctx({})
+        ctx = vspy.Ctx({})
 
     args = tuple(
         [
@@ -419,7 +419,7 @@ def dist_qv(
     timestamp: int = 0,
 ):
     if ctx is None:
-        ctx = Ctx({})
+        ctx = vspy.Ctx({})
     args = tuple(
         [
             ctx,  # 0


### PR DESCRIPTION
### What
We have two different contexts: `tiledb.Ctx`, which you use with TileDB Py, and `vspy.Ctx`, which you use when calling into C++ code. Here we make it more clear which one we are using in Python code to help readability.

### Testing
Unit tests pass.