### PR TITLE
Update `set_has_updates()` to be able to set to `false`

### DIFF
--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -285,8 +285,8 @@ class Index:
         return array_exists and has_updates
 
     def set_has_updates(self, has_updates: bool = True):
-        self.has_updates = True
-        if not self.group.meta["has_updates"]:
+        self.has_updates = has_updates
+        if "has_updates" not in self.group.meta or self.group.meta["has_updates"] != has_updates:
             self.group.close()
             self.group = tiledb.Group(self.uri, "w", ctx=tiledb.Ctx(self.config))
             self.group.meta["has_updates"] = has_updates


### PR DESCRIPTION
### What
Update `set_has_updates()` to be able to set to `false`. We also update it so that if it's not present in metadata we don't crash and just set it instead.

Based on a message I sent to Nikos:
> Two questions from reading more code about has_updates:
> 
>  A) It seems that we never set the has_updates metadata value (i.e. self.group.meta["has_updates"]) to false - we only return false in check_has_updates if we see that array_exists = tiledb.array_exists(self.updates_array_uri)  is false. Should we be setting self.group.meta["has_updates"] to false when we call consolidate_updates()?  Right now even after calling consolidate_updates(), has_updates is true.
> 
>  B) I noticed this because I was looking at set_has_updates and see a small potential issue: we accept has_updates: bool = True, but we always set self.has_updates = True:
> ```
> def set_has_updates(self, has_updates: bool = True):
>         self.has_updates = True
>         if not self.group.meta["has_updates"]:
>             self.group.close()
>             self.group = tiledb.Group(self.uri, "w", ctx=tiledb.Ctx(self.config))
>             self.group.meta["has_updates"] = has_updates
>             self.group.close()
>             self.group = tiledb.Group(self.uri, "r", ctx=tiledb.Ctx(self.config))
> ```
> In practice this is not an issue because we never call set_has_updates with false. It seems like we should:
> 1. Remove has_updates: bool = True as an argument and have the function "set has updates to true"
> 2. Change to self.has_updates = has_updates
> But it seems that the option somewhat relies on the decision for A).

From Nikos:
> To make it consistent we can add support for has_updates=False
> We can also set it to false after consolidation, but we need to be careful because there might be more updates that happened in parallel
>  Concurrent updates is the reason I never set it to False

From me:
> Got it thanks, that makes sense. I'll update set_has_updates to support has_updates = true / false and leave it at that


### Testing
* Unit tests pass
* I can use it successfully in my type-erased Vamana code