### PR TITLE
Update `create_empty_for_vector()` and `write_vector()` to write to col major vectors

### DIFF
--- a/src/include/detail/linalg/tdb_io.h
+++ b/src/include/detail/linalg/tdb_io.h
@@ -269,7 +269,7 @@ void create_empty_for_vector(
 
   // The array will be dense.
   tiledb::ArraySchema schema(ctx, TILEDB_DENSE);
-  schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+  schema.set_domain(domain).set_order({{TILEDB_COL_MAJOR, TILEDB_COL_MAJOR}});
 
   schema.add_attribute(tiledb::Attribute::create<feature_type>(ctx, "values"));
 
@@ -347,7 +347,7 @@ void write_vector(
   // print_types(v, v.data(), v.size());
 
   tiledb::Query query(ctx, *array);
-  query.set_layout(TILEDB_ROW_MAJOR)
+  query.set_layout(TILEDB_COL_MAJOR)
       .set_data_buffer("values", const_cast<value_type*>(v.data()), size(v))
       .set_subarray(subarray);
 


### PR DESCRIPTION
### What
When we create empty vector arrays in C++ we used to create row-major arrays:
```
src/include/detail/linalg/tdb_io.h

template <class feature_type>
void create_empty_for_vector(
    const tiledb::Context& ctx,
    const std::string& uri,
    size_t rows,
    size_t row_extent,
    std::optional<tiledb_filter_type_t> filter = std::nullopt) {
  tiledb::Domain domain(ctx);
  domain.add_dimension(tiledb::Dimension::create<int>(
      ctx, "rows", {{0, std::max(0, (int)rows - 1)}}, row_extent));

  // The array will be dense.
  tiledb::ArraySchema schema(ctx, TILEDB_DENSE);
  schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});

  schema.add_attribute(tiledb::Attribute::create<feature_type>(ctx, "values"));

  tiledb::Array::create(uri, schema);
}
```
Which means that our IDs arrays are row-major:
```
src/include/index/ivf_flat_group.h

create_empty_for_vector<typename index_type::id_type>(
        cached_ctx_, ids_uri(), default_domain, tile_size, default_compression);
```
But in Python we create our IDs arrays as column-major:
```
ingestion.py    
    if not tiledb.array_exists(partial_write_array_ids_uri):
                logger.debug("Creating temp ids array")
                ids_array_rows_dim = tiledb.Dim(
                    name="rows",
                    domain=(0, MAX_INT32),
                    tile=tile_size,
                    dtype=np.dtype(np.int32),
                )
                ids_array_dom = tiledb.Domain(ids_array_rows_dim)
                ids_attr = tiledb.Attr(
                    name="values",
                    dtype=np.dtype(np.uint64),
                    filters=DEFAULT_ATTR_FILTERS,
                )
                ids_schema = tiledb.ArraySchema(
                    domain=ids_array_dom,
                    sparse=False,
                    attrs=[ids_attr],
                    capacity=tile_size,
                    cell_order="col-major",
                    tile_order="col-major",
                )
                logger.debug(ids_schema)
                tiledb.Array.create(partial_write_array_ids_uri, ids_schema)
                add_to_group(
                    partial_write_array_group,
                    partial_write_array_ids_uri,
                    IDS_ARRAY_NAME,
                )
```
So here we update to use col-major vectors to match Python.

### Testing
* Unit tests pass
* I can use these successfully in my type-erased Vamana code