### PR TITLE
Update `tdb_matrix` to load in the non-empty domain instead of the full domain

### DIFF
--- a/src/include/detail/linalg/tdb_matrix.h
+++ b/src/include/detail/linalg/tdb_matrix.h
@@ -122,9 +122,9 @@ class tdbBlockedMatrix : public MatrixBase {
 
   /**
    * @brief Construct a new tdbBlockedMatrix object, limited to `upper_bound`
-   * vectors. We read rows from 0 -> row domain length and cols from 0 -> col
-   * domain length. In this case, the `Matrix` is column-major, so the number of
-   * vectors is the number of columns.
+   * vectors. We read rows from 0 -> row non-empty domain length and cols from 0
+   * -> col non-empty domain length. In this case, the `Matrix` is column-major,
+   * so the number of vectors is the number of columns.
    *
    * @param ctx The TileDB context to use.
    * @param uri URI of the TileDB array to read.
@@ -136,9 +136,9 @@ class tdbBlockedMatrix : public MatrixBase {
 
   /**
    * @brief Construct a new tdbBlockedMatrix object, limited to `upper_bound`
-   * vectors. We read rows from 0 -> row domain length and cols from 0 -> col
-   * domain length. In this case, the `Matrix` is column-major, so the number of
-   * vectors is the number of columns.
+   * vectors. We read rows from 0 -> row non-empty domain length and cols from 0
+   * -> col non-empty domain length. In this case, the `Matrix` is column-major,
+   * so the number of vectors is the number of columns.
    *
    * @param ctx The TileDB context to use.
    * @param uri URI of the TileDB array to read.
@@ -199,11 +199,11 @@ class tdbBlockedMatrix : public MatrixBase {
   /** General constructor
    *
    * @param first_row The first row to read from.
-   * @param last_row The last row to read to. Read rows from 0 -> row domain
-   * length if nullopt is passed.
+   * @param last_row The last row to read to. Read rows from 0 -> row non-empty
+   * domain length if nullopt is passed.
    * @param first_col The first col to read from.
-   * @param last_col The last col to read to. Read rows from 0 -> col domain
-   * length if nullopt is passed.
+   * @param last_col The last col to read to. Read rows from 0 -> col non-empty
+   * domain length if nullopt is passed.
    */
   tdbBlockedMatrix(
       const tiledb::Context& ctx,
@@ -251,17 +251,27 @@ class tdbBlockedMatrix : public MatrixBase {
     auto row_domain{domain_.dimension(0)};
     auto col_domain{domain_.dimension(1)};
 
-    /* The size of the array may not be the size of domain.  Use non-zero value
-     * if set in constructor */
+    // If the user specifies a value then we use it, otherwise we use the
+    // non-empty domain. If non_empty_domain() is an empty vector it means that
+    // the array is empty.
+    auto non_empty_domain = array_->non_empty_domain<int>();
     if (!last_row.has_value()) {
-      last_row_ = row_domain.template domain<row_domain_type>().second -
-                  row_domain.template domain<row_domain_type>().first + 1;
+      if (non_empty_domain.empty()) {
+        last_row_ = 0;
+      } else {
+        last_row_ = non_empty_domain[0].second.second -
+                    non_empty_domain[0].second.first + 1;
+      }
     } else {
       last_row_ = *last_row;
     }
     if (!last_col.has_value()) {
-      last_col_ = col_domain.template domain<col_domain_type>().second -
-                  col_domain.template domain<col_domain_type>().first + 1;
+      if (non_empty_domain.empty()) {
+        last_col_ = 0;
+      } else {
+        last_col_ = non_empty_domain[1].second.second -
+                    non_empty_domain[1].second.first + 1;
+      }
     } else {
       last_col_ = *last_col;
     }

--- a/src/include/detail/linalg/vector.h
+++ b/src/include/detail/linalg/vector.h
@@ -162,20 +162,20 @@ class Vector : public std::span<T> {
 
 template <feature_vector V>
 void debug_vector(const V& v, const std::string& msg = "") {
-  std::cout << msg;
+  std::cout << msg << ": [";
   for (size_t i = 0; i < dimension(v); ++i) {
     std::cout << v[i] << " ";
   }
-  std::cout << "\n";
+  std::cout << "]\n";
 }
 
 template <std::ranges::forward_range V>
 void debug_vector(const V& v, const std::string& msg = "") {
-  std::cout << msg;
+  std::cout << msg << ": [";
   for (auto&& i : v) {
     std::cout << i << " ";
   }
-  std::cout << "\n";
+  std::cout << "]\n";
 }
 
 template <feature_vector V>

--- a/src/include/test/unit_api_feature_vector_array.cc
+++ b/src/include/test/unit_api_feature_vector_array.cc
@@ -524,3 +524,22 @@ TEST_CASE("api: query checks with IDs", "[api][index]") {
     CHECK(ok);
   }
 }
+
+TEST_CASE("api: load empty matrix", "[api][index]") {
+  tiledb::Context ctx;
+  std::string tmp_matrix_uri =
+      (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
+  size_t dimension{10};
+  int32_t domain{std::numeric_limits<int32_t>::max() - 1};
+  int32_t tile_extent{100'000};
+
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(tmp_matrix_uri)) {
+    vfs.remove_dir(tmp_matrix_uri);
+  }
+
+  create_empty_for_matrix<float, stdx::layout_left>(
+      ctx, tmp_matrix_uri, dimension, domain, dimension, tile_extent);
+
+  auto X = FeatureVectorArray(ctx, tmp_matrix_uri);
+}

--- a/src/include/test/unit_tdb_matrix.cc
+++ b/src/include/test/unit_tdb_matrix.cc
@@ -293,7 +293,8 @@ TEST_CASE("tdb_matrix: empty matrix", "[tdb_matrix]") {
       matrix_dimension,
       tile_extent);
 
-  SECTION("empty: no rows and no cols") {
+  {
+    // No rows and no cols.
     auto X =
         tdbColMajorMatrix<float>(ctx, tmp_matrix_uri, 0, 0, 0, 0, 10000, 0);
     X.load();
@@ -303,43 +304,35 @@ TEST_CASE("tdb_matrix: empty matrix", "[tdb_matrix]") {
     CHECK(dimension(X) == 0);
   }
 
-  SECTION("empty: all rows and no cols") {
+  {
+    // All rows and no cols.
     auto X = tdbColMajorMatrix<float>(
         ctx, tmp_matrix_uri, 0, std::nullopt, 0, 0, 10000, 0);
     X.load();
     CHECK(X.num_cols() == 0);
     CHECK(num_vectors(X) == 0);
-    CHECK(X.num_rows() == matrix_dimension);
-    CHECK(dimension(X) == matrix_dimension);
-  }
-
-  SECTION("empty: no rows and all cols") {
-    auto X = tdbColMajorMatrix<float>(
-        ctx, tmp_matrix_uri, 0, 0, 0, std::nullopt, 10000, 0);
-    X.load();
-    CHECK(X.num_cols() == matrix_domain);
-    CHECK(num_vectors(X) == matrix_domain);
     CHECK(X.num_rows() == 0);
     CHECK(dimension(X) == 0);
   }
 
-  SECTION("filled") {
+  {
+    // No rows and all cols.
+    auto X = tdbColMajorMatrix<float>(
+        ctx, tmp_matrix_uri, 0, 0, 0, std::nullopt, 10000, 0);
+    X.load();
+    CHECK(X.num_cols() == 0);
+    CHECK(num_vectors(X) == 0);
+    CHECK(X.num_rows() == 0);
+    CHECK(dimension(X) == 0);
+  }
+
+  {
+    // No constraints.
     auto X = tdbColMajorMatrix<float>(ctx, tmp_matrix_uri);
     X.load();
-    CHECK(X.num_cols() == matrix_domain);
-    CHECK(num_vectors(X) == matrix_domain);
-    CHECK(X.num_rows() == matrix_dimension);
-    CHECK(dimension(X) == matrix_dimension);
-
-    auto Y = tdbColMajorMatrix<float>(std::move(X));
-    CHECK(Y.num_cols() == X.num_cols());
-    CHECK(num_vectors(Y) == num_vectors(X));
-    CHECK(Y.num_rows() == X.num_rows());
-    CHECK(dimension(Y) == dimension(X));
-    Y.load();
-    CHECK(Y.num_cols() == X.num_cols());
-    CHECK(num_vectors(Y) == num_vectors(X));
-    CHECK(Y.num_rows() == X.num_rows());
-    CHECK(dimension(Y) == dimension(X));
+    CHECK(X.num_cols() == 0);
+    CHECK(num_vectors(X) == 0);
+    CHECK(X.num_rows() == 0);
+    CHECK(dimension(X) == 0);
   }
 }

--- a/src/include/test/unit_tdb_matrix_with_ids.cc
+++ b/src/include/test/unit_tdb_matrix_with_ids.cc
@@ -270,7 +270,8 @@ TEST_CASE("tdb_matrix_with_ids: empty matrix", "[tdb_matrix_with_ids]") {
   create_empty_for_vector<uint64_t>(
       ctx, tmp_ids_uri, matrix_domain, tile_extent);
 
-  SECTION("empty") {
+  {
+    // Empty.
     auto X = tdbColMajorMatrixWithIds<float>(
         ctx, tmp_matrix_uri, tmp_ids_uri, 0, 0, 0, 0, 10000, 0);
     X.load();
@@ -282,30 +283,17 @@ TEST_CASE("tdb_matrix_with_ids: empty matrix", "[tdb_matrix_with_ids]") {
     CHECK(X.num_ids() == 0);
     CHECK(X.ids().size() == 0);
   }
-  SECTION("filled") {
+
+  {
+    // No constraints.
     auto X = tdbColMajorMatrixWithIds<float>(ctx, tmp_matrix_uri, tmp_ids_uri);
     X.load();
-    CHECK(X.num_cols() == matrix_domain);
-    CHECK(num_vectors(X) == matrix_domain);
-    CHECK(X.num_rows() == matrix_dimension);
-    CHECK(dimension(X) == matrix_dimension);
-    CHECK(X.num_ids() == matrix_domain);
-    CHECK(X.ids().size() == matrix_domain);
-
-    auto Y = tdbColMajorMatrixWithIds<float>(std::move(X));
-    CHECK(Y.num_cols() == X.num_cols());
-    CHECK(num_vectors(Y) == num_vectors(X));
-    CHECK(Y.num_rows() == X.num_rows());
-    CHECK(dimension(Y) == dimension(X));
-    CHECK(Y.num_ids() == 1000);
-    CHECK(Y.ids().size() == 1000);
-    Y.load();
-    CHECK(Y.num_cols() == X.num_cols());
-    CHECK(num_vectors(Y) == num_vectors(X));
-    CHECK(Y.num_rows() == X.num_rows());
-    CHECK(dimension(Y) == dimension(X));
-    CHECK(Y.num_ids() == 1000);
-    CHECK(Y.ids().size() == 1000);
+    CHECK(X.num_cols() == 0);
+    CHECK(num_vectors(X) == 0);
+    CHECK(X.num_rows() == 0);
+    CHECK(dimension(X) == 0);
+    CHECK(X.num_ids() == 0);
+    CHECK(X.ids().size() == 0);
   }
 }
 


### PR DESCRIPTION
### What
Update `tdb_matrix` to load in the non-empty domain instead of the full domain if no bound was specified.

### Context

> Hi @Nikos Papailiou / @Andrew Lumsdaine, could you help me understand the context behind @todo Handle incomplete queries in this code?
> ```
> src/include/detail/linalg/tdb_matrix.h
>   virtual bool load() {
>     ...
>     // @todo Handle incomplete queries.
>     if (tiledb::Query::Status::COMPLETE != query.query_status()) {
>       throw std::runtime_error("Query status is not complete");
>     }
> ```
> I'm currently having an issue where after writing to an updates array in Python:
> ```
> def ingest_vamana(...):
>     parts_array_uri = group[PARTS_ARRAY_NAME].uri
>     parts_array = tiledb.open(parts_array_uri, mode="w", timestamp=index_timestamp)
>     for part in range(0, size, batch):
>         in_vectors = read_input_vectors(...)
>         parts_array[0:dimensions, write_offset:end_offset] = np.transpose(in_vectors)
>     if additions_vectors is not None:
>         parts_array[0:dimensions, write_offset:end] = np.transpose(additions_vectors)
>     parts_array.close()
> ```
> I then try to read it in with a FeatureVectorArray, which then reads it in with a tdbBlockedMatrix, but in tdbMatrix@load() my query is INCOMPLETE:
> ```
>     tiledb::Query query(ctx_, *array_);
>     query.set_subarray(subarray)
>         .set_layout(layout_order)
>         .set_data_buffer(attr_name, this->data(), elements_to_load * dimension);
>     tiledb_helpers::submit_query(tdb_func__, uri_, query);
>     _memory_data.insert_entry(
>         tdb_func__, elements_to_load * dimension * sizeof(T));
>     std::cout << "query.has_results(): " << query.has_results() << std::endl;
>     std::cout << "query.query_status(): " << query.query_status() << std::endl;
> 
> query.has_results(): 1
> query.query_status(): INCOMPLETE
> ```
> I'm trying to understand if this is a bug in my code, or if there is a known issue that I should fix.

The discussion around this led me to this simple repro:
```
I have come up with a simple repro though which might help us understand the behavior:
TEST_CASE("api: load empty matrix", "[api][index]") {
  tiledb::Context ctx;
  std::string tmp_matrix_uri =
      (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
  size_t dimension{1};
  int32_t domain{std::numeric_limits<int32_t>::max() - 1};
  int32_t tile_extent{100'000};

  tiledb::VFS vfs(ctx);
  if (vfs.is_dir(tmp_matrix_uri)) {
    vfs.remove_dir(tmp_matrix_uri);
  }

  create_empty_for_matrix<float, stdx::layout_left>(
      ctx,
      tmp_matrix_uri,
      dimension,
      domain,
      dimension,
      tile_extent);
    
  auto X = FeatureVectorArray(ctx, tmp_matrix_uri);
}
```
Which results in:
```
/Users/parismorgan/repo/TileDB-Vector-Search-4/src/cmake-build-debug/libtiledbvectorsearch/include/test/unit_api_feature_vector_array -r xml -d yes --order lex
Testing started at 3:18 PM ...
Run with rng-seed=1143749797
- Array type: dense
- Cell order: col-major
- Tile order: col-major
- Capacity: 10000
- Allows duplicates: false
- Coordinates filters: 1
> ZSTD: COMPRESSION_LEVEL=-1
- Offsets filters: 1
> ZSTD: COMPRESSION_LEVEL=-1
- Validity filters: 1
> RLE: COMPRESSION_LEVEL=-1
### Dimension ###
- Name: rows
- Type: INT32
- Cell val num: 1
- Domain: [0, 0]
- Tile extent: 1
- Filters: 1
> ZSTD: COMPRESSION_LEVEL=-1
### Dimension ###
- Name: cols
- Type: INT32
- Cell val num: 1
- Domain: [0, 2147483645]
- Tile extent: 100000
- Filters: 1
> ZSTD: COMPRESSION_LEVEL=-1
### Attribute ###
- Name: values
- Type: FLOAT32
- Nullable: false
- Cell val num: 1
- Filters: 0
- Fill value: nan
[feature_vector_array@FeatureVectorArray]
[feature_vector_array@FeatureVectorArray] uri: /var/folders/jb/5gq49wh97wn0j7hj6zfn9pzh0000gn/T/tmp_tdb_matrix
[feature_vector_array@FeatureVectorArray] ids_uri: 
[feature_vector_array@FeatureVectorArray] feature_type_: float32
[tdbBlockedMatrix::tdbBlockedMatrix] schema_:
[tdbBlockedMatrix::tdbBlockedMatrix] last_row no value so read all
[tdbBlockedMatrix::tdbBlockedMatrix] last_col no value so read all
[tdbBlockedMatrix::tdbBlockedMatrix] dimension: 1
[tdbBlockedMatrix::tdbBlockedMatrix] num_vectors: 2147483646
[tdbBlockedMatrix::tdbBlockedMatrix] upper_bound: 0
[tdbBlockedMatrix::tdbBlockedMatrix] load_blocksize_: 2147483646
[tdbBlockedMatrix::load] will allocate data_ to have 2147483646
[tdbBlockedMatrix::load] attr_name: values
[tdbBlockedMatrix::load] dimension: 1
[tdbBlockedMatrix::load] elements_to_load: 2147483646
[tdbBlockedMatrix::load] first_resident_col_: 0
[tdbBlockedMatrix::load] last_resident_col_: 2147483646
[tdbBlockedMatrix::load] will read idx 0 from 0 -> 0
[tdbBlockedMatrix::load] will read idx 1 from 0 -> 2147483645
[tdbBlockedMatrix::load] attr_name: values
[tdbBlockedMatrix::load] layout_order: 1
[tdbBlockedMatrix::load] query.has_results(): 1
[tdbBlockedMatrix::load] query.query_status(): INCOMPLETE
Process finished with exit code 0
```
We then determined:
> Yeah, probably don’t want to do that for the arrays that have maxint domains.  When we switched to using those (to accommodate updates), the amount to be read has to be specified. That is probably why there is an incomplete read — even though the domain is intmax, the actual data in the array is less than that.

So instead of reading the maxint domain, we update here to just read the non-empty domain.

Note that this change does mean that when we return an empty matrix with 0 cols we don't have the dimension of it, and vice versa (i.e. now we just return a `(0, 0)` dimension matrix instead of `(N, 0)`). This seems fine because it was really a quirk of the last implementation that we returned the non-empty dimension if the number of columns is 0, and we don't rely on it.

### Testing
* Existing unit tests pass
* The new test to load an empty matrix into `FeatureVectorArray` passes
