### PR TITLE
Fix C++ indexes not saving metadata after the first `write_index()`

### DIFF
--- a/src/include/index/ivf_flat_index.h
+++ b/src/include/index/ivf_flat_index.h
@@ -752,12 +752,11 @@ class ivf_flat_index {
       if (overwrite == false) {
         return false;
       }
-      vfs.remove_dir(group_uri);
     }
 
     // Write the group
     auto write_group =
-        ivf_flat_index_group(*this, ctx, group_uri, TILEDB_WRITE);
+        ivf_flat_index_group(*this, ctx, group_uri, TILEDB_WRITE, timestamp_);
 
     write_group.set_dimension(dimension_);
 

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -825,10 +825,10 @@ class vamana_index {
       if (overwrite == false) {
         return false;
       }
-      vfs.remove_dir(group_uri);
     }
 
-    auto write_group = vamana_index_group(*this, ctx, group_uri, TILEDB_WRITE);
+    auto write_group =
+        vamana_index_group(*this, ctx, group_uri, TILEDB_WRITE, timestamp_);
 
     // @todo Make this table-driven
     write_group.set_dimension(dimension_);

--- a/src/include/test/query_common.h
+++ b/src/include/test/query_common.h
@@ -177,6 +177,10 @@ struct siftsmall_test_init : public siftsmall_test_init_defaults {
   auto get_write_read_idx() {
     std::string tmp_ivf_index_uri =
         (std::filesystem::temp_directory_path() / "tmp_ivf_index").string();
+    tiledb::VFS vfs(ctx_);
+    if (vfs.is_dir(tmp_ivf_index_uri)) {
+      vfs.remove_dir(tmp_ivf_index_uri);
+    }
     idx.write_index(ctx_, tmp_ivf_index_uri, true);
     auto idx0 =
         // ivf_flat_l2_index<feature_type, id_type, px_type>(ctx_,

--- a/src/include/test/randomize.h
+++ b/src/include/test/randomize.h
@@ -1,0 +1,75 @@
+/**
+ * * @file   test/randomize.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ */
+
+#ifndef TILEDB_RANDOMIZE_H
+#define TILEDB_RANDOMIZE_H
+
+#include <random>
+
+template <std::ranges::range R>
+void randomize(R& r, std::tuple<int, int> range = {0, 128}) {
+  using element_type = std::ranges::range_value_t<R>;
+
+  std::random_device rd;
+  // std::mt19937 gen(rd());
+  std::mt19937 gen(2514908090);
+
+  if constexpr (std::is_floating_point_v<element_type>) {
+    std::uniform_real_distribution<element_type> dist(
+        std::get<0>(range), std::get<1>(range));
+    for (auto& x : r) {
+      x = dist(gen);
+    }
+  } else {
+    if constexpr (sizeof(element_type) == 1u) {
+      // For MSVC the std::uniform_int_distribution does not compile for char
+      // types e.g. char, uint8_t, int8_t, signed char...
+      std::uniform_int_distribution<uint16_t> dist(
+          std::get<0>(range), std::get<1>(range));
+      for (auto& x : r) {
+        x = static_cast<element_type>(dist(gen));
+      }
+    } else {
+      std::uniform_int_distribution<element_type> dist(
+          std::get<0>(range), std::get<1>(range));
+      for (auto& x : r) {
+        x = dist(gen);
+      }
+    }
+  }
+}
+
+template <std::ranges::range R>
+void randomize(R&& r, std::tuple<int, int> range = {0, 128}) {
+  randomize(r, range);
+}
+
+#endif  // TILEDB_RANDOMIZE_H

--- a/src/include/test/test_utils.h
+++ b/src/include/test/test_utils.h
@@ -35,6 +35,7 @@
 #include <random>
 #include <ranges>
 
+#include <tiledb/group_experimental.h>
 #include <tiledb/tiledb>
 
 template <std::ranges::range R>
@@ -129,6 +130,75 @@ void fill_and_write_matrix(
 
   // Write the IDs to their URI.
   write_vector(ctx, X.ids(), ids_uri);
+}
+
+void validate_metadata(
+    tiledb::Group& read_group,
+    const std::vector<std::tuple<std::string, std::string>>& expected_str,
+    const std::vector<std::tuple<std::string, size_t>>& expected_arithmetic) {
+  for (auto& [name, value] : expected_str) {
+    tiledb_datatype_t v_type;
+    uint32_t v_num;
+    const void* v;
+    CHECK(read_group.has_metadata(name, &v_type));
+    if (!read_group.has_metadata(name, &v_type)) {
+      continue;
+    }
+
+    read_group.get_metadata(name, &v_type, &v_num, &v);
+    CHECK((v_type == TILEDB_STRING_ASCII || v_type == TILEDB_STRING_UTF8));
+    std::string tmp = std::string(static_cast<const char*>(v), v_num);
+    CHECK(!empty(value));
+    CHECK(tmp == value);
+  }
+  for (auto& [name, value] : expected_arithmetic) {
+    tiledb_datatype_t v_type;
+    uint32_t v_num;
+    const void* v;
+    CHECK(read_group.has_metadata(name, &v_type));
+    if (!read_group.has_metadata(name, &v_type)) {
+      continue;
+    }
+
+    read_group.get_metadata(name, &v_type, &v_num, &v);
+
+    if (name == "temp_size") {
+      CHECK((v_type == TILEDB_INT64 || v_type == TILEDB_FLOAT64));
+      if (v_type == TILEDB_INT64) {
+        CHECK(value == *static_cast<const int64_t*>(v));
+      } else if (v_type == TILEDB_FLOAT64) {
+        CHECK(value == (int64_t) * static_cast<const double*>(v));
+      }
+    }
+    CHECK(
+        (v_type == TILEDB_UINT32 || v_type == TILEDB_INT64 ||
+         v_type == TILEDB_UINT64 || v_type == TILEDB_FLOAT64 ||
+         v_type == TILEDB_FLOAT32));
+
+    switch (v_type) {
+      case TILEDB_FLOAT64:
+        CHECK(value == *static_cast<const double*>(v));
+        break;
+      case TILEDB_FLOAT32:
+        CHECK(value == *static_cast<const float*>(v));
+        break;
+      case TILEDB_INT64:
+        CHECK(value == *static_cast<const int64_t*>(v));
+        break;
+      case TILEDB_UINT64:
+        CHECK(value == *static_cast<const uint64_t*>(v));
+        break;
+      case TILEDB_UINT32:
+        CHECK(value == *static_cast<const uint32_t*>(v));
+        break;
+      case TILEDB_STRING_UTF8:
+        CHECK(false);
+        break;
+      default:
+        CHECK(false);
+        break;
+    }
+  }
 }
 
 #endif  // TILEDB_TEST_UTILS_H

--- a/src/include/test/test_utils.h
+++ b/src/include/test/test_utils.h
@@ -32,9 +32,9 @@
 #ifndef TILEDB_TEST_UTILS_H
 #define TILEDB_TEST_UTILS_H
 
+#include <catch2/catch_all.hpp>
 #include <random>
 #include <ranges>
-#include <catch2/catch_all.hpp>
 
 #include <tiledb/group_experimental.h>
 #include <tiledb/tiledb>

--- a/src/include/test/test_utils.h
+++ b/src/include/test/test_utils.h
@@ -33,49 +33,10 @@
 #define TILEDB_TEST_UTILS_H
 
 #include <catch2/catch_all.hpp>
-#include <random>
 #include <ranges>
 
 #include <tiledb/group_experimental.h>
 #include <tiledb/tiledb>
-
-template <std::ranges::range R>
-void randomize(R& r, std::tuple<int, int> range = {0, 128}) {
-  using element_type = std::ranges::range_value_t<R>;
-
-  std::random_device rd;
-  // std::mt19937 gen(rd());
-  std::mt19937 gen(2514908090);
-
-  if constexpr (std::is_floating_point_v<element_type>) {
-    std::uniform_real_distribution<element_type> dist(
-        std::get<0>(range), std::get<1>(range));
-    for (auto& x : r) {
-      x = dist(gen);
-    }
-  } else {
-    if constexpr (sizeof(element_type) == 1u) {
-      // For MSVC the std::uniform_int_distribution does not compile for char
-      // types e.g. char, uint8_t, int8_t, signed char...
-      std::uniform_int_distribution<uint16_t> dist(
-          std::get<0>(range), std::get<1>(range));
-      for (auto& x : r) {
-        x = static_cast<element_type>(dist(gen));
-      }
-    } else {
-      std::uniform_int_distribution<element_type> dist(
-          std::get<0>(range), std::get<1>(range));
-      for (auto& x : r) {
-        x = dist(gen);
-      }
-    }
-  }
-}
-
-template <std::ranges::range R>
-void randomize(R&& r, std::tuple<int, int> range = {0, 128}) {
-  randomize(r, range);
-}
 
 // Fill a matrix with sequentially increasing values. Will delete data from the
 // URI if it exists.

--- a/src/include/test/test_utils.h
+++ b/src/include/test/test_utils.h
@@ -34,6 +34,7 @@
 
 #include <random>
 #include <ranges>
+#include <catch2/catch_all.hpp>
 
 #include <tiledb/group_experimental.h>
 #include <tiledb/tiledb>

--- a/src/include/test/time_scoring.cc
+++ b/src/include/test/time_scoring.cc
@@ -32,7 +32,7 @@
 // #include "scoring.h"
 #include "detail/linalg/matrix.h"
 #include "detail/linalg/vector.h"
-#include "test_utils.h"
+#include "randomize.h"
 #include "utils/timer.h"
 
 #include "detail/scoring/inner_product.h"

--- a/src/include/test/unit_api_feature_vector.cc
+++ b/src/include/test/unit_api_feature_vector.cc
@@ -31,6 +31,7 @@
 
 #include "api/feature_vector.h"
 #include "catch2/catch_all.hpp"
+#include "test/randomize.h"
 #include "test/test_utils.h"
 #include "utils/utils.h"
 

--- a/src/include/test/unit_ivf_flat_index.cc
+++ b/src/include/test/unit_ivf_flat_index.cc
@@ -250,6 +250,10 @@ TEST_CASE("ivf_index: ivf_index write and read", "[ivf_index]") {
   tiledb::Context ctx;
   std::string ivf_index_uri =
       (std::filesystem::temp_directory_path() / "tmp_ivf_index").string();
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(ivf_index_uri)) {
+    vfs.remove_dir(ivf_index_uri);
+  }
   auto training_set = tdbColMajorMatrix<float>(ctx, siftsmall_inputs_uri, 0);
   load(training_set);
 
@@ -560,6 +564,10 @@ TEST_CASE("Read from externally written index", "[ivf_index]") {
           ctx, nlist);
   std::string tmp_ivf_index_uri =
       (std::filesystem::temp_directory_path() / "tmp_ivf_index").string();
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(tmp_ivf_index_uri)) {
+    vfs.remove_dir(tmp_ivf_index_uri);
+  }
   init.idx.write_index(ctx, tmp_ivf_index_uri, true);
 
 // Just some sanity checking and for interactive debugging

--- a/src/include/test/unit_ivf_flat_metadata.cc
+++ b/src/include/test/unit_ivf_flat_metadata.cc
@@ -77,6 +77,10 @@ TEST_CASE(
 
   std::string uri =
       (std::filesystem::temp_directory_path() / "tmp_ivf_index").string();
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(uri)) {
+    vfs.remove_dir(uri);
+  }
   auto training_vectors =
       tdbColMajorPreLoadMatrix<float>(ctx, siftsmall_inputs_uri);
   auto idx = ivf_flat_index<float, uint32_t, uint32_t>(100, 1);

--- a/src/include/test/unit_ivf_flat_metadata.cc
+++ b/src/include/test/unit_ivf_flat_metadata.cc
@@ -38,26 +38,7 @@
 #include "detail/linalg/tdb_matrix.h"
 #include "index/ivf_flat_index.h"
 #include "index/ivf_flat_metadata.h"
-
-std::vector<std::tuple<std::string, std::string>> expected_str{
-    {"dataset_type", "vector_search"},
-    {"storage_version", current_storage_version},
-    {"dtype", "float32"},
-    {"feature_type", "float32"},
-    {"id_type", "uint32"},
-    {"indices_type", "uint32"},
-    {"index_type", "IVF_FLAT"},
-    {"base_sizes", "[0,10000]"},
-    {"partition_history", "[0,100]"},
-};
-
-std::vector<std::tuple<std::string, size_t>> expected_arithmetic{
-    {"temp_size", 0},
-    {"dimension", 128},
-    {"feature_datatype", 2},
-    {"id_datatype", 9},
-    {"px_datatype", 9},
-};
+#include "test_utils.h"
 
 TEST_CASE("ivf_flat_metadata: test test", "[ivf_flat_metadata]") {
   REQUIRE(true);
@@ -84,85 +65,61 @@ TEST_CASE(
   auto training_vectors =
       tdbColMajorPreLoadMatrix<float>(ctx, siftsmall_inputs_uri);
   auto idx = ivf_flat_index<float, uint32_t, uint32_t>(100, 1);
-  idx.train(training_vectors, kmeans_init::kmeanspp);
-  idx.add(training_vectors);
-  idx.write_index(ctx, uri, true);
 
-  auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);
-  auto x = ivf_flat_index_metadata();
-  x.load_metadata(read_group);
+  std::vector<std::tuple<std::string, size_t>> expected_arithmetic{
+      {"temp_size", 0},
+      {"dimension", 128},
+      {"feature_datatype", 2},
+      {"id_datatype", 9},
+      {"px_datatype", 9},
+  };
 
-  SECTION("Validate metadata.") {
+  {
+    // Check the metadata after an initial write_index().
+    idx.train(training_vectors);
+    idx.add(training_vectors);
+    idx.write_index(ctx, uri, true);
+
+    auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);
     auto x = ivf_flat_index_metadata();
     x.load_metadata(read_group);
-    x.dump();
 
-    for (auto& [name, value] : expected_str) {
-      tiledb_datatype_t v_type;
-      uint32_t v_num;
-      const void* v;
-      CHECK(read_group.has_metadata(name, &v_type));
-      if (!read_group.has_metadata(name, &v_type)) {
-        continue;
-      }
+    std::vector<std::tuple<std::string, std::string>> expected_str{
+        {"dataset_type", "vector_search"},
+        {"storage_version", current_storage_version},
+        {"dtype", "float32"},
+        {"feature_type", "float32"},
+        {"id_type", "uint32"},
+        {"indices_type", "uint32"},
+        {"index_type", "IVF_FLAT"},
+        {"base_sizes", "[0,10000]"},
+        {"partition_history", "[0,100]"},
+    };
 
-      read_group.get_metadata(name, &v_type, &v_num, &v);
-      CHECK((v_type == TILEDB_STRING_ASCII || v_type == TILEDB_STRING_UTF8));
-      std::string tmp = std::string(static_cast<const char*>(v), v_num);
-      CHECK(!empty(value));
-      CHECK(tmp == value);
-    }
-    for (auto& [name, value] : expected_arithmetic) {
-      tiledb_datatype_t v_type;
-      uint32_t v_num;
-      const void* v;
-      CHECK(read_group.has_metadata(name, &v_type));
-      if (!read_group.has_metadata(name, &v_type)) {
-        continue;
-      }
+    validate_metadata(read_group, expected_str, expected_arithmetic);
+  }
 
-      read_group.get_metadata(name, &v_type, &v_num, &v);
+  {
+    // Check the metadata after a second write_index().
+    idx.train(training_vectors);
+    idx.add(training_vectors);
+    idx.write_index(ctx, uri, true);
 
-      if (name == "temp_size") {
-        CHECK((v_type == TILEDB_INT64 || v_type == TILEDB_FLOAT64));
-        if (v_type == TILEDB_INT64) {
-          CHECK(value == *static_cast<const int64_t*>(v));
-        } else if (v_type == TILEDB_FLOAT64) {
-          CHECK(value == (int64_t) * static_cast<const double*>(v));
-        }
-      }
-      CHECK(
-          (v_type == TILEDB_UINT32 || v_type == TILEDB_INT64 ||
-           v_type == TILEDB_UINT64 || v_type == TILEDB_FLOAT64 ||
-           v_type == TILEDB_FLOAT32));
+    auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);
+    auto x = ivf_flat_index_metadata();
+    x.load_metadata(read_group);
 
-      std::cout << "name: " << name << std::endl;
-      switch (v_type) {
-        case TILEDB_FLOAT64:
-          CHECK(value == *static_cast<const double*>(v));
-          break;
-        case TILEDB_FLOAT32:
-          CHECK(value == *static_cast<const float*>(v));
-          break;
-        case TILEDB_INT64:
-          CHECK(value == *static_cast<const int64_t*>(v));
-          break;
-        case TILEDB_UINT64:
-          CHECK(value == *static_cast<const uint64_t*>(v));
-          break;
-        case TILEDB_UINT32:
-          CHECK(value == *static_cast<const uint32_t*>(v));
-          break;
-        default:
-          CHECK(false);
-          break;
-      }
-    }
-
-    SECTION("Compare with another load of the metadata.") {
-      ivf_flat_index_metadata y;
-      y.load_metadata(read_group);
-      CHECK(x.compare_metadata(y));
-    }
+    std::vector<std::tuple<std::string, std::string>> expected_str{
+        {"dataset_type", "vector_search"},
+        {"storage_version", current_storage_version},
+        {"dtype", "float32"},
+        {"feature_type", "float32"},
+        {"id_type", "uint32"},
+        {"indices_type", "uint32"},
+        {"index_type", "IVF_FLAT"},
+        {"base_sizes", "[0,10000,10000]"},
+        {"partition_history", "[0,100,100]"},
+    };
+    validate_metadata(read_group, expected_str, expected_arithmetic);
   }
 }

--- a/src/include/test/unit_vamana_metadata.cc
+++ b/src/include/test/unit_vamana_metadata.cc
@@ -36,26 +36,7 @@
 #include "detail/linalg/tdb_matrix.h"
 #include "index/vamana_index.h"
 #include "index/vamana_metadata.h"
-
-std::vector<std::tuple<std::string, std::string>> expected_str{
-    {"dataset_type", "vector_search"},
-    {"storage_version", current_storage_version},
-    {"dtype", "float32"},
-    {"feature_type", "float32"},
-    {"id_type", "uint64"},
-    {"base_sizes", "[0,10000]"},
-    {"adjacency_scores_type", "float32"},
-    {"adjacency_row_index_type", "uint64"},
-};
-
-std::vector<std::tuple<std::string, size_t>> expected_arithmetic{
-    {"temp_size", 0},
-    {"dimension", 128},
-    {"feature_datatype", 2},
-    {"id_datatype", 10},
-    {"adjacency_scores_datatype", 2},
-    {"adjacency_row_index_datatype", 10},
-};
+#include "test_utils.h"
 
 TEST_CASE("vamana_metadata: test test", "[vamana_metadata]") {
   REQUIRE(true);
@@ -74,20 +55,6 @@ TEST_CASE("vamana_metadata: default constructor compare", "[vamana_metadata]") {
   CHECK(y.compare_metadata(x));
 }
 
-TEST_CASE("vamana_metadata: default constructor dump", "[vamana_metadata]") {
-  bool debug = false;
-
-  auto x = vamana_index_metadata();
-  if (debug) {
-    x.dump();
-  }
-
-  vamana_index_metadata y;
-  if (debug) {
-    y.dump();
-  }
-}
-
 // TODO(paris): Modify the index and then also check for ingestion_timestamps
 // and num_edges_history.
 TEST_CASE("vamana_metadata: load metadata from index", "[vamana_metadata]") {
@@ -104,86 +71,59 @@ TEST_CASE("vamana_metadata: load metadata from index", "[vamana_metadata]") {
       tdbColMajorPreLoadMatrix<float>(ctx, siftsmall_inputs_uri);
   auto idx =
       vamana_index<float, uint64_t>(num_vectors(training_vectors), 20, 40, 30);
-  idx.train(training_vectors);
-  idx.add(training_vectors);
-  idx.write_index(ctx, uri, true);
 
-  auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);
-  auto x = vamana_index_metadata();
-  x.load_metadata(read_group);
+  std::vector<std::tuple<std::string, size_t>> expected_arithmetic{
+      {"temp_size", 0},
+      {"dimension", 128},
+      {"feature_datatype", 2},
+      {"id_datatype", 10},
+      {"adjacency_scores_datatype", 2},
+      {"adjacency_row_index_datatype", 10},
+  };
 
   {
+    // Check the metadata after an initial write_index().
+    idx.train(training_vectors);
+    idx.add(training_vectors);
+    idx.write_index(ctx, uri, true);
+
+    auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);
     auto x = vamana_index_metadata();
     x.load_metadata(read_group);
 
-    for (auto& [name, value] : expected_str) {
-      tiledb_datatype_t v_type;
-      uint32_t v_num;
-      const void* v;
-      CHECK(read_group.has_metadata(name, &v_type));
-      if (!read_group.has_metadata(name, &v_type)) {
-        continue;
-      }
-
-      read_group.get_metadata(name, &v_type, &v_num, &v);
-      CHECK((v_type == TILEDB_STRING_ASCII || v_type == TILEDB_STRING_UTF8));
-      std::string tmp = std::string(static_cast<const char*>(v), v_num);
-      CHECK(!empty(value));
-      CHECK(tmp == value);
-    }
-    for (auto& [name, value] : expected_arithmetic) {
-      tiledb_datatype_t v_type;
-      uint32_t v_num;
-      const void* v;
-      CHECK(read_group.has_metadata(name, &v_type));
-      if (!read_group.has_metadata(name, &v_type)) {
-        continue;
-      }
-
-      read_group.get_metadata(name, &v_type, &v_num, &v);
-
-      if (name == "temp_size") {
-        CHECK((v_type == TILEDB_INT64 || v_type == TILEDB_FLOAT64));
-        if (v_type == TILEDB_INT64) {
-          CHECK(value == *static_cast<const int64_t*>(v));
-        } else if (v_type == TILEDB_FLOAT64) {
-          CHECK(value == (int64_t) * static_cast<const double*>(v));
-        }
-      }
-      CHECK(
-          (v_type == TILEDB_UINT32 || v_type == TILEDB_INT64 ||
-           v_type == TILEDB_UINT64 || v_type == TILEDB_FLOAT64 ||
-           v_type == TILEDB_FLOAT32));
-
-      switch (v_type) {
-        case TILEDB_FLOAT64:
-          CHECK(value == *static_cast<const double*>(v));
-          break;
-        case TILEDB_FLOAT32:
-          CHECK(value == *static_cast<const float*>(v));
-          break;
-        case TILEDB_INT64:
-          CHECK(value == *static_cast<const int64_t*>(v));
-          break;
-        case TILEDB_UINT64:
-          CHECK(value == *static_cast<const uint64_t*>(v));
-          break;
-        case TILEDB_UINT32:
-          CHECK(value == *static_cast<const uint32_t*>(v));
-          break;
-        case TILEDB_STRING_UTF8:
-          CHECK(name == "mystery string utf8");
-          break;
-        default:
-          CHECK(false);
-          break;
-      }
-    }
+    std::vector<std::tuple<std::string, std::string>> expected_str{
+        {"dataset_type", "vector_search"},
+        {"storage_version", current_storage_version},
+        {"dtype", "float32"},
+        {"feature_type", "float32"},
+        {"id_type", "uint64"},
+        {"base_sizes", "[0,10000]"},
+        {"adjacency_scores_type", "float32"},
+        {"adjacency_row_index_type", "uint64"},
+    };
+    validate_metadata(read_group, expected_str, expected_arithmetic);
   }
 
   {
-    vamana_index_metadata y;
-    y.load_metadata(read_group);
-    CHECK(x.compare_metadata(y));
+    // Check the metadata after a second write_index().
+    idx.train(training_vectors);
+    idx.add(training_vectors);
+    idx.write_index(ctx, uri, true);
+
+    auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);
+    auto x = vamana_index_metadata();
+    x.load_metadata(read_group);
+
+    std::vector<std::tuple<std::string, std::string>> expected_str{
+        {"dataset_type", "vector_search"},
+        {"storage_version", current_storage_version},
+        {"dtype", "float32"},
+        {"feature_type", "float32"},
+        {"id_type", "uint64"},
+        {"base_sizes", "[0,10000,10000]"},
+        {"adjacency_scores_type", "float32"},
+        {"adjacency_row_index_type", "uint64"},
+    };
+    validate_metadata(read_group, expected_str, expected_arithmetic);
   }
 }

--- a/src/include/test/unit_vamana_metadata.cc
+++ b/src/include/test/unit_vamana_metadata.cc
@@ -96,6 +96,10 @@ TEST_CASE("vamana_metadata: load metadata from index", "[vamana_metadata]") {
 
   std::string uri =
       (std::filesystem::temp_directory_path() / "tmp_vamana_index").string();
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(uri)) {
+    vfs.remove_dir(uri);
+  }
   auto training_vectors =
       tdbColMajorPreLoadMatrix<float>(ctx, siftsmall_inputs_uri);
   auto idx =
@@ -108,7 +112,7 @@ TEST_CASE("vamana_metadata: load metadata from index", "[vamana_metadata]") {
   auto x = vamana_index_metadata();
   x.load_metadata(read_group);
 
-  SECTION("Validate metadata.") {
+  {
     auto x = vamana_index_metadata();
     x.load_metadata(read_group);
 
@@ -175,11 +179,11 @@ TEST_CASE("vamana_metadata: load metadata from index", "[vamana_metadata]") {
           break;
       }
     }
+  }
 
-    SECTION("Compare with another load of the metadata.") {
-      vamana_index_metadata y;
-      y.load_metadata(read_group);
-      CHECK(x.compare_metadata(y));
-    }
+  {
+    vamana_index_metadata y;
+    y.load_metadata(read_group);
+    CHECK(x.compare_metadata(y));
   }
 }


### PR DESCRIPTION
### What
In C++ we were not appendings to the arrays in metadata, instead we just end up with `[0, last_updated_value]`.

This is different from Python where after doing `update_batch()` / `delete_batch()` / `consolidate_updates()` / etc. we can end up with metadata that looks like this:
```
'base_sizes': '[0, 5, 3, 5]', 
'dataset_type': 'vector_search', 
'dtype': 'uint8', 
'has_updates': 1, 
'index_type': 'FLAT', 
'ingestion_timestamps': '[0, 1711637929586, 1711637929748, 1711637929958]', 
'partition_history': '[1, 2, 1]', 
'storage_version': '0.3', 
'temp_size': 5
```
But in C++ we'll just end up with this, even after doing several updates:
```
base_sizes: [0,4]
dataset_type: vector_search
dtype: float32
index_type: VAMANA
ingestion_timestamps: [0,1711637230952]
storage_version: 0.3
temp_size: 0
(these below are unique to Vamana, Flat doesn't have them):
feature_type: float32
id_type: uint32
adjacency_scores_type: float32
adjacency_row_index_type: uint32
num_edges_history: [0,14]
dimension: 3
feature_datatype: FLOAT32
id_datatype: UINT32
adjacency_scores_datatype: 2
adjacency_row_index_datatype: 9
L: 100
R: 64
B: 100
alpha_min: 1
alpha_max: 1.2
medoid: 3
adjacency_row_index_datatype: 9
```
This happens because in `write_index()`, if we have passed in a `group_uri` to an existing index, we have two options:
1. `overwrite = false`: In this case we return early and do not write any new data to the index
2. `overwrite = true`: In this case we delete the group_uri and re-create the metadata from scratch. But because we just do an `append()`, we only get the most recent element in the array added, not all the ones before that:
```
src/include/index/ivf_flat_index.h
    write_group.append_ingestion_timestamp(timestamp_);
    write_group.append_base_size(::num_vectors(*partitioned_vectors_));
    write_group.append_num_partitions(num_partitions_);
```
This is the relevant C++ code:
```
src/include/index/ivf_flat_index.h
  /**
   * @brief Write the index to storage.  This would typically be done after a
   * set of input vectors has been read and a new group is created.  Or after
   * consolidation.
   *
   * We assume we have all of the data in memory, and that we are writing
   * all of it to a TileDB group.  Since we have all of it in memory,
   * we write from the PartitionedMatrix base class.
   *
   * @param group_uri
   * @param overwrite
   * @return bool indicating success or failure
   */
  auto write_index(const tiledb::Context& ctx, const std::string& group_uri, bool overwrite) const {
    tiledb::VFS vfs(ctx);

    // @todo Deal with this in right way vis a vis timestamping
    if (vfs.is_dir(group_uri)) {
      if (overwrite == false) {
        return false;
      }
      vfs.remove_dir(group_uri);
    }

    // Write the group
    auto write_group = ivf_flat_index_group(*this, ctx, group_uri, TILEDB_WRITE);
```
A simple fix seems to be to remove the `vfs.remove_dir(group_uri);` line. If we do that then the `ivf_flat_index_group` constructor will call the `base_index_group` constructor:
```
src/include/index/index_group.h
  base_index_group(
      const tiledb::Context& ctx,
      const std::string& uri,
      uint64_t dimension,
      tiledb_query_type_t rw = TILEDB_READ,
      size_t timestamp = 0,
      const std::string& version = std::string{""},
      const tiledb::Config& cfg = tiledb::Config{})
      : cached_ctx_(ctx)
      , group_uri_(uri)
      , index_timestamp_(timestamp)
      , version_(version)
      , opened_for_(rw) {
      std::cout << "[index_group@base_index_group]" << std::endl;
    switch (opened_for_) {
      case TILEDB_WRITE:
        set_dimension(dimension);
        open_for_write(cfg);
```
and then in `open_for_write()` we are already set up to first read the metadata and then overwrite it:
```
src/include/index/index_group.h
/**
   * Open group for writing.  If the group does not exist, create a new one.
   *
   * If creating a new group, the version_ must be set.  If it is not set,
   * use the current default storage version.
   *
   * If opening a group for write, we open for read first to get the metadata
   * and record the timestamp at which we opened the group.  When we close the
   * group, we update the timestamp array, the sizes array, and the partitions
   * array.  We also update the metadata.
   *
   * @param ctx
   * @param uri
   * @param version
   */
  void open_for_write(const tiledb::Config& cfg) {
      std::cout << "[index_group@open_for_write] group_uri_: " << group_uri_ << std::endl;
    tiledb::VFS vfs(cached_ctx_);

    std::cout << "[index_group@open_for_write] vfs.is_dir(group_uri_): " << vfs.is_dir(group_uri_) << std::endl;
    if (vfs.is_dir(group_uri_)) {
      std::cout << "[index_group@open_for_write] reading existing metadata" << std::endl;
      /** Load the current group metadata */
      init_for_open(cfg);
      if (index_timestamp_ < metadata_.ingestion_timestamps_.back()) {
        throw std::runtime_error(
            "Requested write timestamp " + std::to_string(index_timestamp_) +
            " is not greater than " +
            std::to_string(metadata_.ingestion_timestamps_.back()));
        group_timestamp_ = index_timestamp_;
      }
    } else {
      std::cout << "[index_group@open_for_write] creating metadata from default" << std::endl;
      /** Create a new group */
      create_default(cfg);
    }
  }
```
In addition to this we also need to update to pass the timestamp to the group:
```
src/include/index/ivf_flat_index.h
  auto write_index(...) {
    ...
    auto write_group = ivf_flat_index_group(*this, ctx, group_uri, TILEDB_WRITE, timestamp_);
```
So here we do all of this.

### Testing
* Existing unit tests pass
* Updates `src/include/test/unit_vamana_metadata.cc` and `src/include/test/unit_ivf_flat_metadata.cc` to test with multiple `write_index()` calls and verify the arrays get longer.

### TODO
In a follow-up I'll remove `overwrite` entirely from the `write_index()` API, as it's functionality is unused and just adds unnecessary logic here.
