### PR TITLE
Fix unit_slicing and re-enable in CI

### DIFF
--- a/src/cmake/Superbuild.cmake
+++ b/src/cmake/Superbuild.cmake
@@ -156,5 +156,5 @@ add_custom_target(check
 )
 
 add_custom_target(check-ci
-  COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG> --test-dir ${CMAKE_CURRENT_BINARY_DIR}/libtiledbvectorsearch --output-on-failure --extra-verbose -E \"unit_slicing|unit_ivf_index\"
+  COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG> --test-dir ${CMAKE_CURRENT_BINARY_DIR}/libtiledbvectorsearch --output-on-failure --extra-verbose
 )

--- a/src/include/test/unit_ivf_flat_index.cc
+++ b/src/include/test/unit_ivf_flat_index.cc
@@ -1,5 +1,5 @@
 /**
- * @file   unit_ivf_index.cc
+ * @file   unit_ivf_flat_index.cc
  *
  * @section LICENSE
  *

--- a/src/include/test/unit_slicing.cc
+++ b/src/include/test/unit_slicing.cc
@@ -61,7 +61,7 @@ TEST_CASE("slice", "[linalg]") {
       .set_layout(TILEDB_COL_MAJOR)
       .set_data_buffer("cols", data2_.data(), 288)
       .set_data_buffer("rows", data_.data(), 288)
-      .set_data_buffer("a", value_.data(), 288);
+      .set_data_buffer("values", value_.data(), 288);
 
   tiledb_helpers::submit_query(tdb_func__, sift_inputs_uri, query);
 


### PR DESCRIPTION
### What
We had previously skipped `unit_slicing` in CI and it was failing. Fix and re-enable in CI.

### Testing
CI passes.