### PR TITLE
Explicitly define some missing build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ homepage = "https://tiledb.com"
 repository = "https://github.com/TileDB-Inc/tiledb-vector-search"
 
 [build-system]
-requires = ["scikit-build-core", "pybind11"]
+requires = ["scikit-build-core[pyproject]", "pybind11", "setuptools-scm"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]


### PR DESCRIPTION
While adding TileDB-Vector-Search to my repo [centralized-tiledb-nightlies](https://github.com/jdblischak/centralized-tiledb-nightlies), I ran into some missing build requirements. This PR explicitly adds them to `pyproject.toml`.

One error I received was `ModuleNotFoundError: No module named 'pyproject_metadata'`. This is a known issue due to pyproject-metadata being an optional dependency of scikit-build-core (https://github.com/scikit-build/scikit-build-core/issues/280). The solution is to install pyproject-metadata via `scikit-build-core[pyproject]`.

I also got the error `ModuleNotFoundError: No module named 'setuptools_scm'`. According to the setuptools-scm documentation on [`pyproject.toml` usage](https://github.com/pypa/setuptools_scm/blob/d081257ea39dfae710603796a9e85033256cc012/README.md#pyprojecttoml-usage), setuptools-scm should be added to the build-system requirements.

Note that the setuptools-scm docs also say to explicitly include setuptools in the build-system requirements because [setuptools is an optional dependency](https://github.com/pypa/setuptools_scm/blob/d081257ea39dfae710603796a9e85033256cc012/docs/index.md?plain=1#L16). However, I don't believe that is necessary because [setuptools-scm depends on setuptools](https://github.com/pypa/setuptools_scm/blob/d081257ea39dfae710603796a9e85033256cc012/pyproject.toml#L44), so it will always be installed (ie according to its own `pyproject.toml` setuptools is a _required_ dependency).