### PR TITLE
Explicitly define some missing build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ homepage = "https://tiledb.com"
 repository = "https://github.com/TileDB-Inc/tiledb-vector-search"
 
 [build-system]
-requires = ["scikit-build-core", "pybind11"]
+requires = ["scikit-build-core[pyproject]", "pybind11", "setuptools-scm"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]


### PR DESCRIPTION
Same as PR #304 but from an internal branch to access `TILEDB_REST_TOKEN` for the Python CI job