### PR TITLE
Support access credentials name for vamana ingestion

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -2131,6 +2131,7 @@ def ingest(
                 name="ingest",
                 resources={"cpu": str(threads), "memory": "16Gi"},
                 image_name=DEFAULT_IMG_NAME,
+                **kwargs,
             )
             return d
         elif index_type == "IVF_FLAT":


### PR DESCRIPTION
This adds the kwargs argument used for other ingestors to vamana to support batch task graph credentials.