### PR TITLE
Fix type-erased Vamana `query()`

### DIFF
--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -130,6 +130,9 @@ class Index:
         self.thread_executor = futures.ThreadPoolExecutor()
         self.has_updates = self.check_has_updates()
 
+    def is_type_erased_index(self):
+        return self.index_type == "VAMANA"
+
     def query(self, queries: np.ndarray, k, **kwargs):
         if queries.ndim != 2:
             raise TypeError(
@@ -185,7 +188,9 @@ class Index:
                 if (
                     internal_results_d[query_id, res_id] == 0
                     and internal_results_i[query_id, res_id] == 0
+                    and not self.is_type_erased_index()
                 ):
+                    # NOTE(paris): This is skipped for type-erased modules because they will explicitly handle this case internally. It is valid to have an ID of 0 with a score of 0.
                     internal_results_d[query_id, res_id] = MAX_FLOAT_32
                     internal_results_i[query_id, res_id] = MAX_UINT64
                 res_id += 1

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -190,7 +190,7 @@ class Index:
                     and internal_results_i[query_id, res_id] == 0
                     and not self.is_type_erased_index()
                 ):
-                    # NOTE(paris): This is skipped for type-erased modules because they will explicitly handle this case internally. It is valid to have an ID of 0 with a score of 0.
+                    # NOTE(paris): This is skipped for type-erased modules because is is valid to have an ID of 0 with a score of 0.
                     internal_results_d[query_id, res_id] = MAX_FLOAT_32
                     internal_results_i[query_id, res_id] = MAX_UINT64
                 res_id += 1

--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -85,7 +85,8 @@ class VamanaIndex(index.Index):
             )
 
         assert queries.dtype == np.float32
-        assert opt_l >= k
+        if opt_l < k:
+            raise ValueError(f"opt_l ({opt_l}) should be >= k ({k})")
 
         if queries.ndim == 1:
             queries = np.array([queries])

--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -63,7 +63,7 @@ class VamanaIndex(index.Index):
         self,
         queries: np.ndarray,
         k: int = 10,
-        opt_l: Optional[int] = 1,
+        opt_l: Optional[int] = 100,
         **kwargs,
     ):
         """
@@ -76,7 +76,7 @@ class VamanaIndex(index.Index):
         k: int
             Number of top results to return per query
         opt_l: int
-            How deep to search
+            How deep to search. Should be >= k. Defaults to 100.
         """
         warnings.warn("The Vamana index is not yet supported, please use with caution.")
         if self.size == 0:
@@ -85,6 +85,7 @@ class VamanaIndex(index.Index):
             )
 
         assert queries.dtype == np.float32
+        assert opt_l >= k
 
         if queries.ndim == 1:
             queries = np.array([queries])

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -24,11 +24,6 @@ def query_and_check_distances(
 ):
     for _ in range(1):
         distances, ids = index.query(queries, k=k, **kwargs)
-        print("------------------------------------")
-        print("queries:", queries)
-        print("distances:", distances, expected_distances)
-        print("ids:", ids, expected_ids)
-        print("------------------------------------")
         assert np.array_equal(ids, expected_ids)
         assert np.array_equal(distances, expected_distances)
 
@@ -241,8 +236,9 @@ def test_vamana_index(tmp_path):
 
     index = index.consolidate_updates()
 
-    queries = np.array([[0, 0, 0]], dtype=np.float32)
-    distances, ids = index.query(queries, k=1)
+    # Check that we throw if we query with an invalid opt_l.
+    with pytest.raises(ValueError):
+        index.query(queries, k=3, opt_l=2)
 
     # Test that we can query with multiple query vectors.
     for i in range(5):

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -24,6 +24,11 @@ def query_and_check_distances(
 ):
     for _ in range(1):
         distances, ids = index.query(queries, k=k, **kwargs)
+        print("------------------------------------")
+        print("queries:", queries)
+        print("distances:", distances, expected_distances)
+        print("ids:", ids, expected_ids)
+        print("------------------------------------")
         assert np.array_equal(ids, expected_ids)
         assert np.array_equal(distances, expected_distances)
 
@@ -236,18 +241,31 @@ def test_vamana_index(tmp_path):
 
     index = index.consolidate_updates()
 
-    # TODO(paris): Does not work with k > 1 or with [0, 0, 0] as the query.
+    queries = np.array([[0, 0, 0]], dtype=np.float32)
+    distances, ids = index.query(queries, k=1)
+
+    # Test that we can query with multiple query vectors.
+    for i in range(5):
+        query_and_check_distances(
+            index,
+            np.array([[i, i, i], [i, i, i]], dtype=np.float32),
+            1,
+            [[0], [0]],
+            [[i], [i]],
+        )
+
+    # Test that we can query with k > 1.
     query_and_check_distances(
-        index, np.array([[1, 1, 1]], dtype=np.float32), 1, [[0]], [[1]]
+        index, np.array([[0, 0, 0]], dtype=np.float32), 2, [[0, 3]], [[0, 1]]
     )
+
+    # Test that we can query with multiple query vectors and k > 1.
     query_and_check_distances(
-        index, np.array([[2, 2, 2]], dtype=np.float32), 1, [[0]], [[2]]
-    )
-    query_and_check_distances(
-        index, np.array([[3, 3, 3]], dtype=np.float32), 1, [[0]], [[3]]
-    )
-    query_and_check_distances(
-        index, np.array([[4, 4, 4]], dtype=np.float32), 1, [[0]], [[4]]
+        index,
+        np.array([[0, 0, 0], [4, 4, 4]], dtype=np.float32),
+        2,
+        [[0, 3], [0, 3]],
+        [[0, 1], [4, 3]],
     )
 
 

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -49,14 +49,12 @@ def test_vamana_ingestion_u8(tmp_path):
         source_uri=os.path.join(dataset_dir, "data.u8bin"),
     )
     _, result = index.query(queries, k=k)
-    # TODO(paris): Fix IDs and re-enable.
-    # assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
     index_uri = move_local_index_to_new_location(index_uri)
     index_ram = VamanaIndex(uri=index_uri)
     _, result = index_ram.query(queries, k=k)
-    # TODO(paris): Fix IDs and re-enable.
-    # assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+    assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
 def test_flat_ingestion_u8(tmp_path):


### PR DESCRIPTION
### What
When `opt_l < k`, we only return `opt_l` vectors instead of `k` vectors. So here we update the default value of `opt_l` to be based on the C++ implementation and then throw if it is not. With this we can now query with Vamana.

### Testing
* Unit tests pass
* Adds a new unit tests