### PR TITLE
Remove `id_type` and `adjacency_row_index_type` in Vamana type-erased index

### DIFF
--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -102,8 +102,6 @@ def create(
     uri: str,
     dimensions: int,
     vector_type: np.dtype,
-    id_type: np.dtype = np.uint64,
-    adjacency_row_index_type: np.dtype = np.uint64,
     config: Optional[Mapping[str, Any]] = None,
     storage_version: str = STORAGE_VERSION,
     **kwargs,
@@ -112,13 +110,13 @@ def create(
     ctx = vspy.Ctx(config)
     index = vspy.IndexVamana(
         feature_type=np.dtype(vector_type).name,
-        id_type=np.dtype(id_type).name,
-        adjacency_row_index_type=np.dtype(adjacency_row_index_type).name,
+        id_type=np.dtype(np.uint64).name,
+        adjacency_row_index_type=np.dtype(np.uint64).name,
         dimension=dimensions,
     )
     # TODO(paris): Run all of this with a single C++ call.
     empty_vector = vspy.FeatureVectorArray(
-        dimensions, 0, np.dtype(vector_type).name, np.dtype(id_type).name
+        dimensions, 0, np.dtype(vector_type).name, np.dtype(np.uint64).name
     )
     index.train(empty_vector)
     index.add(empty_vector)

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -202,8 +202,6 @@ def test_vamana_index(tmp_path):
         uri=uri,
         dimensions=3,
         vector_type=np.dtype(vector_type),
-        id_type=np.dtype(np.uint64),
-        adjacency_row_index_type=np.dtype(np.uint64),
     )
 
     queries = np.array([[2, 2, 2]], dtype=np.float32)


### PR DESCRIPTION
### What
The other Python indexes only support using `uint64` as the id_type, so here we follow that pattern. If we want to support more ID types, we can do it all in one pass, rather than just having Vamana support it. Also do the same for `adjacency_row_index_type`.

### Testing
Unit tests pass.