### PR TITLE
Add needs dependency on backwards_compatibility_data

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -86,8 +86,6 @@ jobs:
 
   build_wheels:
     name: Wheel ${{ matrix.buildplat[0] }}-${{ matrix.buildplat[1] }}-${{ matrix.python }}
-    # TODO(paris): Add this back once generate_backwards_compatibility_data is confirmed to work.
-    # needs: generate_backwards_compatibility_data
     runs-on: ${{ matrix.buildplat[0] }}
     strategy:
       matrix:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -144,7 +144,7 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheels, build_sdist, generate_backwards_compatibility_data]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
This PR adds dependency to upload step to wait for generate backwards compatibility data before actually uploading pip wheels to pypi. This way we can decrease number of micro version bumps if generate backwards compatibility data step fails.