### PR TITLE
Update `generate_data.py` to return whether we should upload the generated indexes

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -47,7 +47,8 @@ jobs:
           pip install .
 
           # Generate data.
-          python backwards-compatibility-data/generate_data.py $release_tag
+          result=$(python backwards-compatibility-data/generate_data.py $release_tag)
+          echo "Should we upload these generated indexes? $result"
 
           # Fetch.
           echo "git fetch"

--- a/backwards-compatibility-data/README.md
+++ b/backwards-compatibility-data/README.md
@@ -2,6 +2,8 @@
 
 This folder contains test indices built using different versions of TileDB-Vector-Search. It is used to test the ability of the latest version of TileDB-Vector-Search to load and query arrays built by previous versions.
 
+In CI we run `generate_data.py` on each release and on major and minor version bump releases create PR with the generated data into `main`. We do not check in the generated data for patch releases.
+
 ### Usage
 
 To generate new data, run:

--- a/backwards-compatibility-data/generate_data.py
+++ b/backwards-compatibility-data/generate_data.py
@@ -83,7 +83,7 @@ def generate_indexes(version):
             assert result_d.flatten().tolist() == [0 for _ in range(len(indices))]
 
 
-def check_should_upload_release_data(version) -> bool:
+def check_should_upload_indexes(version) -> bool:
     """
     Returns True if the minor version of the version string is greater than the minor version of the last version uploaded. When we run on CI we only want to upload data when the minor version changes. Examples:
     - We have 0.1.0, 0.1.1. We get version=0.1.2. In this case we return False.
@@ -115,8 +115,8 @@ if __name__ == "__main__":
     )
     args = p.parse_args()
 
-    should_upload_release_data = check_should_upload_release_data(args.version)
+    should_upload_indexes = check_should_upload_indexes(args.version)
 
     generate_indexes(args.version)
 
-    print("true" if should_upload_release_data else "false")
+    print("true" if should_upload_indexes else "false")


### PR DESCRIPTION
### What
We would like to only save backwards compatibility indexes which have a new minor version, i.e. we don't save indexes with just a patch version bump. 

This is PR 1 out of 2 which updates `generate_data.py` to return whether we should upload the generated indexes. In a follow-up I will have the CI job exit early successfully if we don't want to upload the generated index. Just want to split it up so I can watch that it works on CI once.

### Testing
I haven't run this on CI yet. But I did check that `generate_data.py` works:
```
(TileDB-Vector-Search-4) ~/repo/TileDB-Vector-Search-4 ls backwards-compatibility-data/data
0.0.10    0.0.21    0.0.23    0.1.3     0.2.2
0.0.17    0.0.22    0.1.0     0.2.0     README.md
(TileDB-Vector-Search-4) ~/repo/TileDB-Vector-Search-4 result=$(python backwards-compatibility-data/generate_data.py 0.0.0) && echo $result
false
(TileDB-Vector-Search-4) ~/repo/TileDB-Vector-Search-4 result=$(python backwards-compatibility-data/generate_data.py 0.1.99) && echo $result
false
(TileDB-Vector-Search-4) ~/repo/TileDB-Vector-Search-4 result=$(python backwards-compatibility-data/generate_data.py 0.3.99) && echo $result
true
(TileDB-Vector-Search-4) ~/repo/TileDB-Vector-Search-4 result=$(python backwards-compatibility-data/generate_data.py invalid) && echo $result
false
```