### PR TITLE
Remove `overwrite` from `write_index()`

### DIFF
--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -283,11 +283,11 @@ void init_type_erased_module(py::module_& m) {
           "write_index",
           [](IndexVamana& index,
              const tiledb::Context& ctx,
-             const std::string& group_uri,
-             bool overwrite) { index.write_index(ctx, group_uri, overwrite); },
+             const std::string& group_uri) {
+            index.write_index(ctx, group_uri);
+          },
           py::arg("ctx"),
-          py::arg("group_uri"),
-          py::arg_v("overwrite", true))
+          py::arg("group_uri"))
       .def("feature_type_string", &IndexVamana::feature_type_string)
       .def("id_type_string", &IndexVamana::id_type_string)
       .def(

--- a/src/include/api/ivf_flat_index.h
+++ b/src/include/api/ivf_flat_index.h
@@ -427,14 +427,12 @@ class IndexIVFFlat {
   }
 
   void write_index(
-      const tiledb::Context& ctx,
-      const std::string& group_uri,
-      bool overwrite = false) const {
+      const tiledb::Context& ctx, const std::string& group_uri) const {
     if (!index_) {
       throw std::runtime_error(
           "Cannot write_index() because there is no index.");
     }
-    index_->write_index(ctx, group_uri, overwrite);
+    index_->write_index(ctx, group_uri);
   }
 
   constexpr auto dimension() const {
@@ -505,9 +503,7 @@ class IndexIVFFlat {
     virtual void remove(const IdVector& ids) const = 0;
 
     virtual void write_index(
-        const tiledb::Context& ctx,
-        const std::string& group_uri,
-        bool overwrite) const = 0;
+        const tiledb::Context& ctx, const std::string& group_uri) const = 0;
 
     [[nodiscard]] virtual size_t dimension() const = 0;
 
@@ -691,11 +687,9 @@ class IndexIVFFlat {
       //      index_.update(vectors_uri, ids, options);
     }
 
-    void write_index(
-        const tiledb::Context& ctx,
-        const std::string& group_uri,
-        bool overwrite) const override {
-      impl_index_.write_index(ctx, group_uri, overwrite);
+    void write_index(const tiledb::Context& ctx, const std::string& group_uri)
+        const override {
+      impl_index_.write_index(ctx, group_uri);
     }
 
     // WIP

--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -233,14 +233,12 @@ class IndexVamana {
   }
 
   void write_index(
-      const tiledb::Context& ctx,
-      const std::string& group_uri,
-      bool overwrite = false) const {
+      const tiledb::Context& ctx, const std::string& group_uri) const {
     if (!index_) {
       throw std::runtime_error(
           "Cannot write_index() because there is no index.");
     }
-    index_->write_index(ctx, group_uri, overwrite);
+    index_->write_index(ctx, group_uri);
   }
 
   constexpr auto dimension() const {
@@ -289,9 +287,7 @@ class IndexVamana {
         std::optional<size_t> opt_L) = 0;
 
     virtual void write_index(
-        const tiledb::Context& ctx,
-        const std::string& group_uri,
-        bool overwrite) const = 0;
+        const tiledb::Context& ctx, const std::string& group_uri) const = 0;
 
     [[nodiscard]] virtual size_t dimension() const = 0;
   };
@@ -394,11 +390,9 @@ class IndexVamana {
       }
     }
 
-    void write_index(
-        const tiledb::Context& ctx,
-        const std::string& group_uri,
-        bool overwrite) const override {
-      impl_index_.write_index(ctx, group_uri, overwrite);
+    void write_index(const tiledb::Context& ctx, const std::string& group_uri)
+        const override {
+      impl_index_.write_index(ctx, group_uri);
     }
 
     size_t dimension() const override {

--- a/src/include/index/flatpq_index.h
+++ b/src/include/index/flatpq_index.h
@@ -640,15 +640,8 @@ class flatpq_index {
     return un_pq;
   }
 
-  auto write_index(const std::string& group_uri, bool overwrite) {
+  auto write_index(const std::string& group_uri) {
     tiledb::Context ctx;
-    tiledb::VFS vfs(ctx);
-    if (vfs.is_dir(group_uri)) {
-      if (overwrite == false) {
-        return false;
-      }
-      vfs.remove_dir(group_uri);
-    }
 
     tiledb::Config cfg;
     tiledb::Group::create(ctx, group_uri);

--- a/src/include/index/ivf_flat_index.h
+++ b/src/include/index/ivf_flat_index.h
@@ -738,22 +738,10 @@ class ivf_flat_index {
    * we write from the PartitionedMatrix base class.
    *
    * @param group_uri
-   * @param overwrite
    * @return bool indicating success or failure
    */
   auto write_index(
-      const tiledb::Context& ctx,
-      const std::string& group_uri,
-      bool overwrite) const {
-    tiledb::VFS vfs(ctx);
-
-    // @todo Deal with this in right way vis a vis timestamping
-    if (vfs.is_dir(group_uri)) {
-      if (overwrite == false) {
-        return false;
-      }
-    }
-
+      const tiledb::Context& ctx, const std::string& group_uri) const {
     // Write the group
     auto write_group =
         ivf_flat_index_group(*this, ctx, group_uri, TILEDB_WRITE, timestamp_);
@@ -799,8 +787,7 @@ class ivf_flat_index {
       const std::string& centroids_uri,
       const std::string& parts_uri,
       const std::string& ids_uri,
-      const std::string& indices_uri,
-      bool overwrite) const {
+      const std::string& indices_uri) const {
     tiledb::VFS vfs(ctx);
 
     write_matrix(ctx, centroids_, centroids_uri, 0, true);

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -824,7 +824,6 @@ class vamana_index {
   /**
    * @brief Write the index to a TileDB group
    * @param group_uri The URI of the TileDB group where the index will be saved
-   * @param overwrite Whether to overwrite an existing group
    * @return Whether the write was successful
    *
    * The group consists of the original feature vectors, and the graph index,
@@ -837,18 +836,9 @@ class vamana_index {
    * the group?
    */
   auto write_index(
-      const tiledb::Context& ctx,
-      const std::string& group_uri,
-      bool overwrite = false) const {
+      const tiledb::Context& ctx, const std::string& group_uri) const {
     // metadata: dimension, ntotal, L, R, B, alpha_min, alpha_max, medoid
     // Save as a group: metadata, feature_vectors, graph edges, offsets
-
-    tiledb::VFS vfs(ctx);
-    if (vfs.is_dir(group_uri)) {
-      if (overwrite == false) {
-        return false;
-      }
-    }
 
     auto write_group =
         vamana_index_group(*this, ctx, group_uri, TILEDB_WRITE, timestamp_);

--- a/src/include/test/query_common.h
+++ b/src/include/test/query_common.h
@@ -181,7 +181,7 @@ struct siftsmall_test_init : public siftsmall_test_init_defaults {
     if (vfs.is_dir(tmp_ivf_index_uri)) {
       vfs.remove_dir(tmp_ivf_index_uri);
     }
-    idx.write_index(ctx_, tmp_ivf_index_uri, true);
+    idx.write_index(ctx_, tmp_ivf_index_uri);
     auto idx0 =
         // ivf_flat_l2_index<feature_type, id_type, px_type>(ctx_,
         // tmp_ivf_index_uri);

--- a/src/include/test/unit_api_ivf_flat_index.cc
+++ b/src/include/test/unit_api_ivf_flat_index.cc
@@ -172,7 +172,7 @@ TEST_CASE(
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   a.train(training_set, kmeans_init::random);
   a.add(training_set);
-  a.write_index(ctx, api_ivf_flat_index_uri, true);
+  a.write_index(ctx, api_ivf_flat_index_uri);
 
   auto b = IndexIVFFlat(ctx, api_ivf_flat_index_uri);
 
@@ -244,7 +244,7 @@ TEST_CASE(
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   a.train(training_set, kmeans_init::random);
   a.add(training_set);
-  a.write_index(ctx, api_ivf_flat_index_uri, true);
+  a.write_index(ctx, api_ivf_flat_index_uri);
   auto b = IndexIVFFlat(ctx, api_ivf_flat_index_uri);
 
   auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -181,7 +181,7 @@ TEST_CASE(
     auto training_vector_array = FeatureVectorArray(training);
     index.train(training_vector_array);
     index.add(training_vector_array);
-    index.write_index(ctx, index_uri, true);
+    index.write_index(ctx, index_uri);
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
@@ -255,7 +255,7 @@ TEST_CASE(
     auto training_vector_array = FeatureVectorArray(training);
     index.train(training_vector_array);
     index.add(training_vector_array);
-    index.write_index(ctx, index_uri, true);
+    index.write_index(ctx, index_uri);
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
@@ -306,7 +306,7 @@ TEST_CASE(
         siftsmall_dimension, num_vectors, feature_type, id_type);
     index.train(empty_training_vector_array);
     index.add(empty_training_vector_array);
-    index.write_index(ctx, index_uri, true);
+    index.write_index(ctx, index_uri);
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
@@ -323,7 +323,7 @@ TEST_CASE(
     auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
     index.train(training_set);
     index.add(training_set);
-    index.write_index(ctx, index_uri, true);
+    index.write_index(ctx, index_uri);
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
@@ -376,7 +376,7 @@ TEST_CASE(
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   a.train(training_set);
   a.add(training_set);
-  a.write_index(ctx, api_vamana_index_uri, true);
+  a.write_index(ctx, api_vamana_index_uri);
 
   auto b = IndexVamana(ctx, api_vamana_index_uri);
 
@@ -423,7 +423,7 @@ TEST_CASE("api_vamana_index: read index and query", "[api_vamana_index]") {
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   a.train(training_set);
   a.add(training_set);
-  a.write_index(ctx, api_vamana_index_uri, true);
+  a.write_index(ctx, api_vamana_index_uri);
   auto b = IndexVamana(ctx, api_vamana_index_uri);
 
   auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);

--- a/src/include/test/unit_flatpq_index.cc
+++ b/src/include/test/unit_flatpq_index.cc
@@ -841,7 +841,7 @@ TEST_CASE("flatpq_index: flatpq_index write and read", "[flatpq_index]") {
   idx.train(training_set);
   idx.add(training_set);
 
-  idx.write_index(flatpq_index_uri, true);
+  idx.write_index(flatpq_index_uri);
   auto idx2 = flatpq_index<
       siftsmall_feature_type,
       siftsmall_ids_type,

--- a/src/include/test/unit_ivf_flat_index.cc
+++ b/src/include/test/unit_ivf_flat_index.cc
@@ -263,7 +263,7 @@ TEST_CASE("ivf_index: ivf_index write and read", "[ivf_index]") {
   idx.train(training_set, kmeans_init::kmeanspp);
   idx.add(training_set);
 
-  idx.write_index(ctx, ivf_index_uri, true);
+  idx.write_index(ctx, ivf_index_uri);
   auto idx2 = ivf_flat_index<float, uint32_t, uint32_t>(ctx, ivf_index_uri);
   idx2.read_index_infinite();
 
@@ -568,7 +568,7 @@ TEST_CASE("Read from externally written index", "[ivf_index]") {
   if (vfs.is_dir(tmp_ivf_index_uri)) {
     vfs.remove_dir(tmp_ivf_index_uri);
   }
-  init.idx.write_index(ctx, tmp_ivf_index_uri, true);
+  init.idx.write_index(ctx, tmp_ivf_index_uri);
 
 // Just some sanity checking and for interactive debugging
 #if 0

--- a/src/include/test/unit_ivf_flat_metadata.cc
+++ b/src/include/test/unit_ivf_flat_metadata.cc
@@ -78,7 +78,7 @@ TEST_CASE(
     // Check the metadata after an initial write_index().
     idx.train(training_vectors);
     idx.add(training_vectors);
-    idx.write_index(ctx, uri, true);
+    idx.write_index(ctx, uri);
 
     auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);
     auto x = ivf_flat_index_metadata();
@@ -103,7 +103,7 @@ TEST_CASE(
     // Check the metadata after a second write_index().
     idx.train(training_vectors);
     idx.add(training_vectors);
-    idx.write_index(ctx, uri, true);
+    idx.write_index(ctx, uri);
 
     auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);
     auto x = ivf_flat_index_metadata();

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -1247,7 +1247,7 @@ TEST_CASE("vamana: vamana_index write and read", "[vamana]") {
       num_vectors(training_set), l_build, r_max_degree, Backtrack);
   idx.train(training_set, ids);
 
-  idx.write_index(ctx, vamana_index_uri, true);
+  idx.write_index(ctx, vamana_index_uri);
   auto idx2 = vamana_index<siftsmall_feature_type, siftsmall_ids_type>(
       ctx, vamana_index_uri);
 

--- a/src/include/test/unit_vamana_metadata.cc
+++ b/src/include/test/unit_vamana_metadata.cc
@@ -86,7 +86,7 @@ TEST_CASE("vamana_metadata: load metadata from index", "[vamana_metadata]") {
     // Check the metadata after an initial write_index().
     idx.train(training_vectors, training_vectors.ids());
     idx.add(training_vectors);
-    idx.write_index(ctx, uri, true);
+    idx.write_index(ctx, uri);
 
     auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);
     auto x = vamana_index_metadata();
@@ -109,7 +109,7 @@ TEST_CASE("vamana_metadata: load metadata from index", "[vamana_metadata]") {
     // Check the metadata after a second write_index().
     idx.train(training_vectors, training_vectors.ids());
     idx.add(training_vectors);
-    idx.write_index(ctx, uri, true);
+    idx.write_index(ctx, uri);
 
     auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);
     auto x = vamana_index_metadata();

--- a/src/src/README.md
+++ b/src/src/README.md
@@ -245,7 +245,6 @@ The options used by `index` are
 - The name of a partition sizes array to be written (`--sizes_uri`). The `--sizes_uri` option and the `index_uri` options are mutually exclusive.
 - The name of the ids array to be written (`ids_uri`)
 - The initialization algorithm to be used by kmeans (`--init`). Current options are `kmeanspp` and `random`. The default is `random`.
-- Whether to overwrite existing array (`--force`)
 
 Example:
 
@@ -258,9 +257,6 @@ Example:
              centroids_uri s3://tiledb-lums/kmeans/ivf_flat/centroids
 
 ```
-
-Note that if the `--force` option is not given,
-the program will **not** overwrite any existing arrays. In that case, it is the responsibility of the user to make sure that the arrays to be written do not exist when the program is executed. If the `--force` option is given, if any of the arrays specified as options to the program already exist, they will be overwritten.
 
 ## The `flat_l2` Search Driver
 

--- a/src/src/ivf/README.md
+++ b/src/src/ivf/README.md
@@ -5,7 +5,7 @@
 ```c++
     ivf_index (-h | --help)
     ivf_index --db_uri URI --index_uri URI [--ftype TYPE] [--idtype TYPE] [--pxtype TYPE]
-                 [--init TYPE] [--num_clusters NN] [--max_iter NN] [--tol NN] [--force]
+                 [--init TYPE] [--num_clusters NN] [--max_iter NN] [--tol NN]
                  [--nthreads NN] [--log FILE] [--stats] [-d] [-v] [--dump NN]
 
 Options:
@@ -15,7 +15,6 @@ Options:
     --ftype TYPE            data type of feature vectors [default: float]
     --idtype TYPE           data type of ids [default: uint64]
     --pxtype TYPE           data type of partition index [default: uint64]
-    -f, --force             overwrite index if it exists [default:false]
     -i, --init TYPE         initialization type, kmeans++ or random [default: random]
     --num_clusters NN       number of clusters/partitions, 0 = sqrt(N) [default: 0]
     --max_iter NN           max number of iterations for kmeans [default: 10]
@@ -30,5 +29,5 @@ Options:
 ### Example
 
 ```bash
-ivf_index --db_uri siftsmall_base --ftype float --index_uri flatIVF_index_siftsmall_base --pxtype uint64 --idtype uint32  -v -d --log - --force
+ivf_index --db_uri siftsmall_base --ftype float --index_uri flatIVF_index_siftsmall_base --pxtype uint64 --idtype uint32  -v -d --log -
 ```

--- a/src/src/ivf/ivf_index.cc
+++ b/src/src/ivf/ivf_index.cc
@@ -56,7 +56,7 @@ static constexpr const char USAGE[] =
 Usage:
     ivf_index (-h | --help)
     ivf_index --db_uri URI --index_uri URI [--ftype TYPE] [--idtype TYPE] [--pxtype TYPE]
-                 [--init TYPE] [--num_clusters NN] [--max_iter NN] [--tol NN] [--force]
+                 [--init TYPE] [--num_clusters NN] [--max_iter NN] [--tol NN]
                  [--nthreads NN] [--log FILE] [--stats] [-d] [-v] [--dump NN]
 
 Options:
@@ -66,7 +66,6 @@ Options:
     --ftype TYPE            data type of feature vectors [default: float]
     --idtype TYPE           data type of ids [default: uint64]
     --pxtype TYPE           data type of partition index [default: uint64]
-    -f, --force             overwrite index if it exists [default:false]
     -i, --init TYPE         initialization type, kmeans++ or random [default: random]
     --num_clusters NN       number of clusters/partitions, 0 = sqrt(N) [default: 0]
     --max_iter NN           max number of iterations for kmeans [default: 10]
@@ -87,7 +86,6 @@ int main(int argc, char* argv[]) {
     return 0;
   }
 
-  bool overwrite = args["--force"].asBool();
   debug = args["--debug"].asBool();
   verbose = args["--verbose"].asBool();
   enable_stats = args["--stats"].asBool();
@@ -115,7 +113,7 @@ int main(int argc, char* argv[]) {
         /* dim, */ num_clusters, max_iter, tolerance);
     idx.train(X, init_type);
     idx.add(X);
-    idx.write_index(ctx, index_uri, overwrite);
+    idx.write_index(ctx, index_uri);
 
     if (args["--log"]) {
       //     idx.log_index();


### PR DESCRIPTION
### What
Here we remove `overwrite` from `write_index()` based on this conversation:

<img width="1738" alt="Screenshot 2024-04-10 at 11 56 28 AM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/80d8efb2-af86-4079-ac8c-e9a8d2a7085e">

The tl;dr is that `overwrite was a holdover from very early development of writing arrays do deal with “array exists”`. But now we don't use this in the type-erased flow, we instead always want `write_index()` to overwrite the index if it exists, but still read from it's metadata. This lets us do:
```
index = vspy.IndexVamana(
    feature_type=np.dtype(vector_type).name,
    id_type=np.dtype(np.uint64).name,
    adjacency_row_index_type=np.dtype(np.uint64).name,
    dimension=dimensions,
)
# TODO(paris): Run all of this with a single C++ call.
empty_vector = vspy.FeatureVectorArray(
    dimensions, 0, np.dtype(vector_type).name, np.dtype(np.uint64).name
)
index.train(empty_vector)
index.add(empty_vector)
index.write_index(ctx, uri)
```
and then later do:
```
index = vspy.IndexVamana(ctx, index_group_uri)
data = vspy.FeatureVectorArray(ctx, parts_array_uri, ids_array_uri)
index.train(data)
index.add(data)
index.write_index(ctx, index_group_uri)
```
One question that could be asked is: yes we don't need this in type-erased code as writtent, but do we need it elsewhere or will we need it in the future? And from my reading the answer is no. Instead we can have an explicit `index.delete()` method, or likely we just handle it in Python. But either way, removing this simplifies the code which is nice.

### Testing
* Existing unit tests pass.



