### PR TITLE
Fix `consolidate_updates` error for `tiledb://` URIs.

### DIFF
--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -395,18 +395,18 @@ class Index:
         """
         from tiledb.vector_search.ingestion import ingest
 
+        fragments_info = tiledb.array_fragments(
+            self.updates_array_uri, ctx=tiledb.Ctx(self.config)
+        )
+        max_timestamp = self.base_array_timestamp
+        for fragment_info in fragments_info:
+            if fragment_info.timestamp_range[1] > max_timestamp:
+                max_timestamp = fragment_info.timestamp_range[1]
+        max_timestamp += 1
         # Consolidate all updates since the previous ingestion_timestamp.
         # This is a performance optimization. We skip this for remote arrays as consolidation
         # of remote arrays currently only supports modes `fragment_meta, commits, metadata`.
         if not self.updates_array_uri.startswith("tiledb://"):
-            fragments_info = tiledb.array_fragments(
-                self.updates_array_uri, ctx=tiledb.Ctx(self.config)
-            )
-            max_timestamp = self.base_array_timestamp
-            for fragment_info in fragments_info:
-                if fragment_info.timestamp_range[1] > max_timestamp:
-                    max_timestamp = fragment_info.timestamp_range[1]
-            max_timestamp += 1
             conf = tiledb.Config(self.config)
             conf["sm.consolidation.timestamp_start"] = self.latest_ingestion_timestamp
             conf["sm.consolidation.timestamp_end"] = max_timestamp

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -160,6 +160,10 @@ class CloudTests(unittest.TestCase):
                 resources=resources,
             )
 
+        index = vs.ivf_flat_index.IVFFlatIndex(
+            uri=index_uri,
+            config=tiledb.cloud.Config().dict(),
+        )
         index.delete(external_id=42)
         _, result_i = index.query(queries, k=k, nprobe=nprobe)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -164,6 +164,10 @@ class CloudTests(unittest.TestCase):
         _, result_i = index.query(queries, k=k, nprobe=nprobe)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
+        index = index.consolidate_updates()
+        _, result_i = index.query(queries, k=k, nprobe=nprobe)
+        assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
+
     def test_cloud_ivf_flat_random_sampling(self):
         # NOTE(paris): This was also tested with the following (and also with mode=Mode.BATCH):
         # source_uri = "tiledb://TileDB-Inc/ann_sift1b_raw_vectors_col_major"


### PR DESCRIPTION
Fix `consolidate_updates` error for `tiledb://` URIs.

`consolidate_updates` performs `timestamp` consolidation of all updates between consequent ingestions.
This caused failures for file indexing when appending to an existing `tiledb://` index.

This is an optional performance enhancement. We skip it for remote arrays as consolidation of remote arrays currently only supports modes `fragment_meta, commits, metadata`.