### PR TITLE
Fix TileDB URIs with type-erased indexes, add Vamana test to test_cloud.py

### DIFF
--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -8,6 +8,7 @@ from tiledb.vector_search import index
 from tiledb.vector_search.module import *
 from tiledb.vector_search.storage_formats import STORAGE_VERSION
 from tiledb.vector_search.storage_formats import storage_formats
+from tiledb.vector_search.storage_formats import validate_storage_version
 
 MAX_UINT64 = np.iinfo(np.dtype("uint64")).max
 INDEX_TYPE = "VAMANA"
@@ -107,6 +108,7 @@ def create(
     **kwargs,
 ) -> VamanaIndex:
     warnings.warn("The Vamana index is not yet supported, please use with caution.")
+    validate_storage_version(storage_version)
     ctx = vspy.Ctx(config)
     index = vspy.IndexVamana(
         feature_type=np.dtype(vector_type).name,

--- a/src/include/detail/linalg/tdb_helpers.h
+++ b/src/include/detail/linalg/tdb_helpers.h
@@ -36,6 +36,7 @@
 
 #include <tiledb/array.h>
 #include <tiledb/tiledb>
+#include "tiledb/group_experimental.h"
 #include "stats.h"
 
 namespace tiledb_helpers {
@@ -80,6 +81,87 @@ inline void submit_query(
   StatsCollectionScope stats_scope(uri, function_name, "submit_query");
   query.submit();
 }
+
+// bool delete_group(
+//     const tiledb::Config& cfg,
+//     const tiledb::Context& ctx,
+//     const std::string& uri) {
+////    tiledb::Object::remove(ctx, uri);
+//    try {
+//      tiledb::Group group(ctx, uri, TILEDB_MODIFY_EXCLUSIVE, cfg);
+//      group.delete_group(uri, true);
+//      group.close();
+//      return true;
+//    } catch (const std::exception& e) {
+//        std::cout << e.what() << std::endl;
+//      return false;
+//    }
+// }
+
+// Adds an object to a group. Automatically infers whether to use a relative path or absolute path.
+// NOTE(paris): We use absolute paths for tileDB URIs because of a bug tracked in SC39197, once
+// that is fixed everything can use relative paths.
+ inline void add_to_group(tiledb::Group &group, const std::string &uri, const std::string &name) {
+    if (uri.find("tiledb://") == 0) {
+      group.add_member(uri, false, name);
+    } else {
+      group.add_member(name, true, name);
+    }
+ }
+
+// bool uri_exists(
+//     const tiledb::Config& cfg,
+//     const tiledb::Context& ctx,
+//     const std::string& uri) {
+//   try {
+//     tiledb::Group group(ctx, uri, TILEDB_READ, cfg);
+//     return true;
+//   } catch (const std::exception& e) {
+//     return false;
+//   }
+// }
+
+// bool group_exists(const tiledb::Config& cfg, const tiledb::Context &ctx,
+// const std::string& uri) {
+////    tiledb::VFS vfs(ctx);
+////    if (vfs.is_dir(uri)) {
+////        return true;
+////    }
+////    return false;
+//
+//    // If it starts with tiledb://, then it is a TileDB array we we return
+//    false.
+////    std::cout << "[tdb_io@uri_exists] uri: " << uri << std::endl;
+//    bool is_tdb_array = true;
+//
+//    auto obj_type = tiledb::Object::object(ctx, uri).type();
+//    std::cout << (int)obj_type << std::endl;
+//    return false;
+//    if (obj_type == tiledb::Object::Type::Group) {
+//        is_tdb_array = false;
+//    }
+//
+//
+//    if (uri.find("tiledb://") == 0) {
+//      std::cout << "  this is a tiledb uri" << std::endl;
+//        try {
+//          std::cout << "  it exists" << std::endl;
+//            tiledb::Group group(ctx, uri, TILEDB_READ, cfg);
+//            return true;
+//        } catch (const std::exception& e) {
+//          std::cout << "  it does not exist" << std::endl;
+//            return false;
+////            std::cout << e.what() << std::endl;
+////            // This indicates that this is a tiledb URI and the group does
+///not exist at this URI. /            if (std::string(e.what()).find("does not
+///exist") != std::string::npos) { /                return false; /            }
+//        }
+//    }
+//    // At this point we know that it is not a TileDB array, so we can use VFS.
+//    tiledb::VFS vfs(ctx);
+//    std::cout << "  this is vfs uri does it exist?" << vfs.is_dir(uri) <<
+//    std::endl; return vfs.is_dir(uri);
+//}
 
 }  // namespace tiledb_helpers
 

--- a/src/include/index/flatpq_index.h
+++ b/src/include/index/flatpq_index.h
@@ -653,11 +653,11 @@ class flatpq_index {
 
     auto centroids_uri = group_uri + "/centroids";
     write_matrix(ctx, centroids_, centroids_uri);
-    write_group.add_member("centroids", true, "centroids");
+    tiledb_helpers::add_to_group(write_group, centroids_uri, "centroids");
 
     auto pq_vectors_uri = group_uri + "/pq_vectors";
     write_matrix(ctx, pq_vectors_, pq_vectors_uri);
-    write_group.add_member("pq_vectors", true, "pq_vectors");
+    tiledb_helpers::add_to_group(write_group, pq_vectors_uri, "pq_vectors");
 
     for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
       std::ostringstream oss;
@@ -666,8 +666,7 @@ class flatpq_index {
 
       auto distance_table_uri = group_uri + "/distance_table_" + number;
       write_matrix(ctx, distance_tables_[subspace], distance_table_uri);
-      write_group.add_member(
-          "distance_table_" + number, true, "distance_table_" + number);
+      tiledb_helpers::add_to_group(write_group, distance_table_uri, "distance_table_" + number);
     }
     write_group.close();
     return true;

--- a/src/include/index/index_group.h
+++ b/src/include/index/index_group.h
@@ -182,8 +182,7 @@ class base_index_group {
    * @param ctx
    */
   void init_for_open(const tiledb::Config& cfg) {
-    tiledb::VFS vfs(cached_ctx_);
-    if (!vfs.is_dir(group_uri_)) {
+    if (!exists(cached_ctx_)) {
       throw std::runtime_error(
           "Group uri " + std::string(group_uri_) + " does not exist.");
     }
@@ -264,9 +263,7 @@ class base_index_group {
    * @param version
    */
   void open_for_write(const tiledb::Config& cfg) {
-    tiledb::VFS vfs(cached_ctx_);
-
-    if (vfs.is_dir(group_uri_)) {
+    if (exists(cached_ctx_)) {
       /** Load the current group metadata */
       init_for_open(cfg);
       if (index_timestamp_ < metadata_.ingestion_timestamps_.back()) {

--- a/src/include/index/ivf_flat_group.h
+++ b/src/include/index/ivf_flat_group.h
@@ -197,9 +197,7 @@ class ivf_flat_index_group
         this->get_dimension(),
         default_tile_extent,
         default_compression);
-    // write_group.add_member(centroids_uri(), true, centroids_array_name());
-    write_group.add_member(
-        centroids_array_name(), true, centroids_array_name());
+    tiledb_helpers::add_to_group(write_group, centroids_uri(), centroids_array_name());
 
     create_empty_for_matrix<
         typename index_type::feature_type,
@@ -211,13 +209,11 @@ class ivf_flat_index_group
         this->get_dimension(),
         default_tile_extent,
         default_compression);
-    // write_group.add_member(parts_uri(), true, parts_array_name());
-    write_group.add_member(parts_array_name(), true, parts_array_name());
+    tiledb_helpers::add_to_group(write_group, parts_uri(), parts_array_name());
 
     create_empty_for_vector<typename index_type::id_type>(
         cached_ctx_, ids_uri(), default_domain, tile_size, default_compression);
-    // write_group.add_member(ids_uri(), true, ids_array_name());
-    write_group.add_member(ids_array_name(), true, ids_array_name());
+    tiledb_helpers::add_to_group(write_group, ids_uri(), ids_array_name());
 
     create_empty_for_vector<typename index_type::indices_type>(
         cached_ctx_,
@@ -225,8 +221,7 @@ class ivf_flat_index_group
         default_domain,
         default_tile_extent,
         default_compression);
-    // write_group.add_member(indices_uri(), true, indices_array_name());
-    write_group.add_member(indices_array_name(), true, indices_array_name());
+    tiledb_helpers::add_to_group(write_group, indices_uri(), indices_array_name());
 
     // Store the metadata if all of the arrays were created successfully
     metadata_.store_metadata(write_group);

--- a/src/include/index/ivf_flat_index.h
+++ b/src/include/index/ivf_flat_index.h
@@ -788,8 +788,6 @@ class ivf_flat_index {
       const std::string& parts_uri,
       const std::string& ids_uri,
       const std::string& indices_uri) const {
-    tiledb::VFS vfs(ctx);
-
     write_matrix(ctx, centroids_, centroids_uri, 0, true);
     write_matrix(ctx, *partitioned_vectors_, parts_uri, 0, true);
     write_vector(ctx, partitioned_vectors_->ids(), ids_uri, 0, true);

--- a/src/include/index/vamana_group.h
+++ b/src/include/index/vamana_group.h
@@ -35,6 +35,7 @@
 #include "index/index_defs.h"
 #include "index/index_group.h"
 #include "index/vamana_metadata.h"
+#include "detail/linalg/tdb_helpers.h"
 
 /**
  * The vamana index group stores:
@@ -280,8 +281,7 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
         this->get_dimension(),
         default_tile_extent,
         default_compression);
-    write_group.add_member(
-        feature_vectors_array_name(), true, feature_vectors_array_name());
+    tiledb_helpers::add_to_group(write_group, feature_vectors_uri(), feature_vectors_array_name());
 
     create_empty_for_vector<typename index_type::id_type>(
         cached_ctx_,
@@ -289,8 +289,7 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
         default_domain,
         tile_size,
         default_compression);
-    write_group.add_member(
-        feature_vector_ids_name(), true, feature_vector_ids_name());
+      tiledb_helpers::add_to_group(write_group, feature_vector_ids_uri(), feature_vector_ids_name());
 
     create_empty_for_vector<typename index_type::score_type>(
         cached_ctx_,
@@ -298,8 +297,7 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
         default_domain,
         tile_size,
         default_compression);
-    write_group.add_member(
-        adjacency_scores_array_name(), true, adjacency_scores_array_name());
+    tiledb_helpers::add_to_group(write_group, adjacency_scores_uri(), adjacency_scores_array_name());
 
     create_empty_for_vector<typename index_type::id_type>(
         cached_ctx_,
@@ -307,8 +305,7 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
         default_domain,
         tile_size,
         default_compression);
-    write_group.add_member(
-        adjacency_ids_array_name(), true, adjacency_ids_array_name());
+    tiledb_helpers::add_to_group(write_group, adjacency_ids_uri(), adjacency_ids_array_name());
 
     create_empty_for_vector<typename index_type::id_type>(
         cached_ctx_,
@@ -316,10 +313,7 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
         default_domain,
         tile_size,
         default_compression);
-    write_group.add_member(
-        adjacency_row_index_array_name(),
-        true,
-        adjacency_row_index_array_name());
+    tiledb_helpers::add_to_group(write_group, adjacency_row_index_uri(), adjacency_row_index_array_name());
 
     // Store the metadata if all of the arrays were created successfully
     metadata_.store_metadata(write_group);

--- a/src/include/tdb_defs.h
+++ b/src/include/tdb_defs.h
@@ -90,7 +90,7 @@ constexpr auto type_to_tiledb_v = tiledb::impl::type_to_tiledb<T>::tiledb_type;
   if (str == "uint64") {
     return TILEDB_UINT64;
   }
-  throw std::runtime_error("Unsupported datatype");
+  throw std::runtime_error("Unsupported datatype: "  + str);
 }
 
 // cf type_to_str(tiledb_datatype_t type) in tiledb/type.h


### PR DESCRIPTION
### What
* Fixes two issues when using `tiledb://` URIs with type-erased indexes
  1. You cannot use `VFS` with these or it will throw, so instead update to use `bool exists(const tiledb::Context& ctx) const { return tiledb::Object::object(ctx, group_uri_).type() == tiledb::Object::Type::Group; }`
  2. Use relative paths for objects in groups, just like we did with Python here: https://github.com/TileDB-Inc/TileDB-Vector-Search/pull/193
* Adds a Vamana test to `test_cloud.py` which exercises this code path (and is how I found these bugs).


### Testing
* Existing tests pass.
* Adds a new test.