### PR TITLE
Refactor and cleanup `index_group.h`

### DIFF
--- a/src/include/index/ivf_flat_group.h
+++ b/src/include/index/ivf_flat_group.h
@@ -61,12 +61,12 @@ class ivf_flat_index_group
   using Base = base_index_group<ivf_flat_index_group>;
   // using Base::Base;
 
-  using Base::array_name_map_;
+  using Base::array_key_to_array_name_;
   using Base::cached_ctx_;
   using Base::group_uri_;
   using Base::metadata_;
+  using Base::valid_array_keys_;
   using Base::valid_array_names_;
-  using Base::valid_key_names_;
   using Base::version_;
 
   using index_type = Index;
@@ -94,9 +94,9 @@ class ivf_flat_index_group
  public:
   void append_valid_array_names_impl() {
     for (auto&& [array_key, array_name] : ivf_flat_storage_formats[version_]) {
-      valid_key_names_.insert(array_key);
+      valid_array_keys_.insert(array_key);
       valid_array_names_.insert(array_name);
-      array_name_map_[array_key] = array_name;
+      array_key_to_array_name_[array_key] = array_name;
     }
   }
 

--- a/src/include/index/vamana_group.h
+++ b/src/include/index/vamana_group.h
@@ -83,12 +83,12 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
   using Base = base_index_group<vamana_index_group>;
   // using Base::Base;
 
-  using Base::array_name_map_;
+  using Base::array_key_to_array_name_;
   using Base::cached_ctx_;
   using Base::group_uri_;
   using Base::metadata_;
+  using Base::valid_array_keys_;
   using Base::valid_array_names_;
-  using Base::valid_key_names_;
   using Base::version_;
 
   using index_type = Index;
@@ -117,9 +117,9 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
  public:
   void append_valid_array_names_impl() {
     for (auto&& [array_key, array_name] : vamana_storage_formats[version_]) {
-      valid_key_names_.insert(array_key);
+      valid_array_keys_.insert(array_key);
       valid_array_names_.insert(array_name);
-      array_name_map_[array_key] = array_name;
+      array_key_to_array_name_[array_key] = array_name;
     }
   }
 


### PR DESCRIPTION
### What
This code is somewhat confusing to read as-is, so refactor to use consistent naming for each concept, i.e. we now have an `array_key` and we have an `array_name`.
* Rename `valid_key_names_` to `valid_array_keys_`
* Rename `array_name_map_` to `array_key_to_array_name_`
* Remove `active_array_names_` because it is unused

### Testing
Existing tests pass.