### PR TITLE
Add metadata tests for type-erased indexes in Python

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -9,6 +9,7 @@ from tiledb.vector_search._tiledbvspy import *
 from tiledb.vector_search.storage_formats import STORAGE_VERSION
 from tiledb.vector_search.storage_formats import validate_storage_version
 from tiledb.vector_search.utils import add_to_group
+from tiledb.vector_search.utils import is_type_erased_index
 
 
 class TrainingSamplingPolicy(enum.Enum):
@@ -289,9 +290,6 @@ def ingest(
     CENTRALISED_KMEANS_MAX_SAMPLE_SIZE = 1000000
     DEFAULT_IMG_NAME = "3.9-vectorsearch"
     MAX_INT32 = 2**31 - 1
-
-    def is_type_erased_index():
-        return index_type == "VAMANA"
 
     class SourceType(enum.Enum):
         """SourceType of input vectors"""
@@ -755,7 +753,7 @@ def ingest(
 
         # Note that we don't create type-erased indexes (i.e. Vamana) here. Instead we create them
         # at very start of ingest() in C++.
-        elif not is_type_erased_index():
+        elif not is_type_erased_index(index_type):
             raise ValueError(f"Not supported index_type {index_type}")
 
     def read_external_ids(
@@ -2825,7 +2823,7 @@ def ingest(
         temp_size = int(group.meta.get("temp_size", "0"))
         group.close()
 
-        if not is_type_erased_index():
+        if not is_type_erased_index(index_type):
             # For type-erased indexes (i.e. Vamana), we update this metadata in the write_index()
             # call during create_ingestion_dag(), so don't do it here.
             group = tiledb.Group(index_group_uri, "w")

--- a/apis/python/src/tiledb/vector_search/utils.py
+++ b/apis/python/src/tiledb/vector_search/utils.py
@@ -5,6 +5,10 @@ import numpy as np
 import tiledb
 
 
+def is_type_erased_index(index_type: str) -> bool:
+    return index_type == "VAMANA"
+
+
 def add_to_group(group, uri, name):
     """
     Adds an object to a group. Automatically infers whether to use a relative path or absolute path.

--- a/src/include/index/index_metadata.h
+++ b/src/include/index/index_metadata.h
@@ -265,7 +265,6 @@ class base_index_metadata {
    * @todo Dispatch on storage version
    */
   auto load_metadata(tiledb::Group& read_group) {
-    std::cout << "[index_metadata@load_metadata]\n";
     tiledb_datatype_t v_type;
     uint32_t v_num;
     const void* v;
@@ -298,8 +297,6 @@ class base_index_metadata {
           "temp_size must be a int64_t or float64 not " +
           tiledb::impl::type_to_str(v_type));
     }
-    std::cout << "[index_metadata@load_metadata] base_sizes_str_: "
-              << base_sizes_str_ << "\n";
     base_sizes_ = json_to_vector<base_sizes_type>(base_sizes_str_);
     ingestion_timestamps_ =
         json_to_vector<ingestion_timestamps_type>(ingestion_timestamps_str_);
@@ -314,12 +311,9 @@ class base_index_metadata {
    * @return
    */
   auto store_metadata(tiledb::Group& write_group) {
-    std::cout << "[index_metadata@store_metadata]\n";
     base_sizes_str_ = to_string(nlohmann::json(base_sizes_));
     ingestion_timestamps_str_ =
         to_string(nlohmann::json(ingestion_timestamps_));
-    std::cout << "[index_metadata@store_metadata] base_sizes_str_: "
-              << base_sizes_str_ << "\n";
 
     static_cast<IndexMetadata*>(this)->vector_to_json_impl();
 

--- a/src/include/index/index_metadata.h
+++ b/src/include/index/index_metadata.h
@@ -297,6 +297,7 @@ class base_index_metadata {
           "temp_size must be a int64_t or float64 not " +
           tiledb::impl::type_to_str(v_type));
     }
+
     base_sizes_ = json_to_vector<base_sizes_type>(base_sizes_str_);
     ingestion_timestamps_ =
         json_to_vector<ingestion_timestamps_type>(ingestion_timestamps_str_);

--- a/src/include/index/index_metadata.h
+++ b/src/include/index/index_metadata.h
@@ -112,7 +112,7 @@ class base_index_metadata {
   using metadata_string_check_type =
       std::tuple<std::string, std::string&, bool>;
   std::vector<metadata_string_check_type> metadata_string_checks{
-      // name, member_variable, default, expected, required
+      // name, member_variable, required
       {"dataset_type", dataset_type_, true},
       {"storage_version", storage_version_, true},
       {"dtype", dtype_, false},
@@ -127,11 +127,8 @@ class base_index_metadata {
   using metadata_arithmetic_check_type =
       std::tuple<std::string, void*, tiledb_datatype_t, bool>;
   std::vector<metadata_arithmetic_check_type> metadata_arithmetic_checks{
+      // name, member_variable, type, required
       {"temp_size", &temp_size_, TILEDB_INT64, true},
-      //{"index_kind",
-      // nstatic_cast<IndexMetadata*>(this)->index_kind_,
-      // TILEDB_UINT64,
-      // false},
       {"dimension", &dimension_, TILEDB_UINT32, false},
       {"feature_datatype", &feature_datatype_, TILEDB_UINT32, false},
       {"id_datatype", &id_datatype_, TILEDB_UINT32, false},
@@ -268,6 +265,7 @@ class base_index_metadata {
    * @todo Dispatch on storage version
    */
   auto load_metadata(tiledb::Group& read_group) {
+    std::cout << "[index_metadata@load_metadata]\n";
     tiledb_datatype_t v_type;
     uint32_t v_num;
     const void* v;
@@ -300,7 +298,8 @@ class base_index_metadata {
           "temp_size must be a int64_t or float64 not " +
           tiledb::impl::type_to_str(v_type));
     }
-
+    std::cout << "[index_metadata@load_metadata] base_sizes_str_: "
+              << base_sizes_str_ << "\n";
     base_sizes_ = json_to_vector<base_sizes_type>(base_sizes_str_);
     ingestion_timestamps_ =
         json_to_vector<ingestion_timestamps_type>(ingestion_timestamps_str_);
@@ -315,9 +314,12 @@ class base_index_metadata {
    * @return
    */
   auto store_metadata(tiledb::Group& write_group) {
+    std::cout << "[index_metadata@store_metadata]\n";
     base_sizes_str_ = to_string(nlohmann::json(base_sizes_));
     ingestion_timestamps_str_ =
         to_string(nlohmann::json(ingestion_timestamps_));
+    std::cout << "[index_metadata@store_metadata] base_sizes_str_: "
+              << base_sizes_str_ << "\n";
 
     static_cast<IndexMetadata*>(this)->vector_to_json_impl();
 
@@ -338,54 +340,6 @@ class base_index_metadata {
       write_group.put_metadata(name, type, 1, static_cast<const void*>(value));
     }
   }
-
-#if 0
-  /**************************************************************************
-   * Getters and setters
-   **************************************************************************/
-  std::string base_sizes_str() const {
-    return base_sizes_str_;
-  }
-  auto& base_sizes() {
-    return base_sizes_;
-  }
-  auto& base_sizes() const {
-    return base_sizes_;
-  }
-  void set_base_sizes(const std::vector<base_sizes_type>& base_sizes) {
-    base_sizes_ = base_sizes;
-  }
-  auto storage_version() const {
-    return storage_version_;
-  }
-  auto& storage_version()  {
-    return storage_version_;
-  }
-  auto dtype() const {
-    return dtype_;
-  }
-  auto& dtype()  {
-    return dtype_;
-  }
-  auto feature_datatype() const {
-    return feature_datatype_;
-  }
-  auto& feature_datatype()  {
-    return feature_datatype_;
-  }
-  auto id_datatype() const {
-    return id_datatype_;
-  }
-  auto& id_datatype()  {
-    return id_datatype_;
-  }
-  auto px_datatype() const {
-    return px_datatype_;
-  }
-  auto& px_datatype()  {
-    return px_datatype_;
-  }
-#endif
 
   /**************************************************************************
    * Helpful functions for debugging, testing, etc


### PR DESCRIPTION
### What
Add metadata tests for type-erased indexes in Python.

### Testing
Tests pass.