### PR TITLE
Increment TileDB core version to 2.22.0

### DIFF
--- a/apis/python/requirements-py.txt
+++ b/apis/python/requirements-py.txt
@@ -1,4 +1,4 @@
 numpy==1.24.3
 tiledb-cloud==0.10.24
-tiledb==0.27.0
+tiledb==0.28.0
 scikit-learn==1.3.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 dependencies = [
     "tiledb-cloud>=0.11",
-    "tiledb>=0.27.0",
+    "tiledb>=0.28.0",
     "typing-extensions", # for tiledb-cloud indirect, x-ref https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/428
     "scikit-learn",
 ]

--- a/src/cmake/Modules/FindTileDB_EP.cmake
+++ b/src/cmake/Modules/FindTileDB_EP.cmake
@@ -53,9 +53,9 @@ else()
 
     # Try to download prebuilt artifacts unless the user specifies to build from source
     if(DOWNLOAD_TILEDB_PREBUILT)
-        fetch_prebuilt_tiledb(VERSION 2.21.1)
+        fetch_prebuilt_tiledb(VERSION 2.22.0)
     else() # Build from source
-        fetch_source_tiledb(VERSION 2.21.1)
+        fetch_source_tiledb(VERSION 2.22.0)
     endif()
 
     list(APPEND FORWARD_EP_CMAKE_ARGS -DEP_TILEDB_BUILT=TRUE)


### PR DESCRIPTION
### What
Increment TileDB core version to 2.22.0.