### PR TITLE
Run Python ingestion tests on all indexes

### DIFF
--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -86,6 +86,7 @@ class FlatIndex(index.Index):
         queries: np.ndarray,
         k: int = 10,
         nthreads: int = 8,
+        **kwargs,
     ):
         """
         Query a flat index

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -257,6 +257,11 @@ def test_ingestion_fvec(tmp_path):
     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
     for index_type, index_class in zip(INDEXES, INDEX_CLASSES):
+        # TODO(paris): Fix Vamana bug and re-enable:
+        # RuntimeError: IndexError: index 100 is out of bounds for axis 0 with size 100
+        if index_type == "VAMANA":
+            continue
+
         index_uri = os.path.join(tmp_path, f"array_{index_type}")
         index = ingest(
             index_type=index_type,
@@ -285,7 +290,7 @@ def test_ingestion_fvec(tmp_path):
         assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
-def test_ivf_flat_ingestion_numpy(tmp_path):
+def test_ingestion_numpy(tmp_path):
     source_uri = siftsmall_inputs_file
     queries_uri = siftsmall_query_file
     gt_uri = siftsmall_groundtruth_file
@@ -300,6 +305,11 @@ def test_ivf_flat_ingestion_numpy(tmp_path):
     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
     for index_type, index_class in zip(INDEXES, INDEX_CLASSES):
+        # TODO(paris): Fix Vamana bug and re-enable:
+        # RuntimeError: IndexError: index 100 is out of bounds for axis 0 with size 100
+        if index_type == "VAMANA":
+            continue
+
         index_uri = os.path.join(tmp_path, f"array_{index_type}")
         index = ingest(
             index_type=index_type,

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -1,6 +1,7 @@
 import time
 
 import numpy as np
+import pytest
 from array_paths import *
 from common import *
 
@@ -210,11 +211,6 @@ def test_ivf_flat_ingestion_f32(tmp_path):
     gt_i, gt_d = get_groundtruth(dataset_dir, k)
 
     for index_type, index_class in zip(INDEXES, INDEX_CLASSES):
-        # TODO(paris): Fix Vamana bug and re-enable:
-        # RuntimeError: Invalid key when getting the URI: adjacency_scores_array_name. Name does not exist: adjacency_scores
-        if index_type == "VAMANA":
-            continue
-
         index_uri = os.path.join(tmp_path, f"array_{index_type}")
         index = ingest(
             index_type=index_type,
@@ -261,11 +257,6 @@ def test_ingestion_fvec(tmp_path):
     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
     for index_type, index_class in zip(INDEXES, INDEX_CLASSES):
-        # TODO(paris): Fix Vamana bug and re-enable:
-        # RuntimeError: Invalid key when getting the URI: adjacency_scores_array_name. Name does not exist: adjacency_scores
-        if index_type == "VAMANA":
-            continue
-
         index_uri = os.path.join(tmp_path, f"array_{index_type}")
         index = ingest(
             index_type=index_type,
@@ -309,11 +300,6 @@ def test_ivf_flat_ingestion_numpy(tmp_path):
     gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
     for index_type, index_class in zip(INDEXES, INDEX_CLASSES):
-        # TODO(paris): Fix Vamana bug and re-enable:
-        # RuntimeError: Invalid key when getting the URI: adjacency_scores_array_name. Name does not exist: adjacency_scores
-        if index_type == "VAMANA":
-            continue
-
         index_uri = os.path.join(tmp_path, f"array_{index_type}")
         index = ingest(
             index_type=index_type,

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -803,16 +803,12 @@ def test_ingestion_with_additions_and_timetravel(tmp_path):
             index_type=index_type,
             index_uri=index_uri,
             source_uri=os.path.join(dataset_dir, "data.u8bin"),
-            **({"partitions": partitions} if index_type == "IVF_FLAT" else {}),
+            partitions=partitions,
             index_timestamp=1,
         )
         if index_type == "IVF_FLAT":
             assert index.partitions == partitions
-        _, result = index.query(
-            queries,
-            k=k,
-            **({"nprobe": partitions} if index_type == "IVF_FLAT" else {}),
-        )
+        _, result = index.query(queries, k=k, nprobe=partitions)
         assert accuracy(result, gt_i) == 1.0
 
         update_ids_offset = MAX_UINT64 - size
@@ -827,19 +823,11 @@ def test_ingestion_with_additions_and_timetravel(tmp_path):
 
         index_uri = move_local_index_to_new_location(index_uri)
         index = index_class(uri=index_uri)
-        _, result = index.query(
-            queries,
-            k=k,
-            **({"nprobe": partitions} if index_type == "IVF_FLAT" else {}),
-        )
+        _, result = index.query(queries, k=k, nprobe=partitions)
         assert 0.45 < accuracy(result, gt_i) < 0.55
 
         index = index.consolidate_updates()
-        _, result = index.query(
-            queries,
-            k=k,
-            **({"nprobe": partitions} if index_type == "IVF_FLAT" else {}),
-        )
+        _, result = index.query(queries, k=k, nprobe=partitions)
         assert 0.45 < accuracy(result, gt_i) < 0.55
 
 
@@ -1015,9 +1003,6 @@ def test_storage_versions(tmp_path):
             assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
 
-SKIP
-
-
 def test_ivf_flat_copy_centroids_uri(tmp_path):
     dataset_dir = os.path.join(tmp_path, "dataset")
     os.mkdir(dataset_dir)
@@ -1185,9 +1170,6 @@ def test_kmeans():
     assert tdb_score < 1.5 * sklearn_score
 
 
-SKIP
-
-
 def test_ivf_flat_ingestion_with_training_source_uri_f32(tmp_path):
     dataset_dir = os.path.join(tmp_path, "dataset")
     data = np.array(
@@ -1233,9 +1215,6 @@ def test_ivf_flat_ingestion_with_training_source_uri_f32(tmp_path):
         training_source_uri=os.path.join(dataset_dir, "training_data.f32bin"),
         training_source_type="F32BIN",
     )
-
-
-SKIP
 
 
 def test_ivf_flat_ingestion_with_training_source_uri_tdb(tmp_path):


### PR DESCRIPTION
### What
Right now the IVF Flat python tests in `test_ingestion.py` are very thorough. Rather than re-writing these for Vamana (and hypothetically Flat, as we don't test it very well), we just loop through all indexes in these tests.

### Testing
Unit tests pass.