### PR TITLE
Check releases.csv hash after download

### DIFF
--- a/src/cmake/Modules/DownloadPrebuiltTileDB.cmake
+++ b/src/cmake/Modules/DownloadPrebuiltTileDB.cmake
@@ -26,15 +26,19 @@
 
 include(FetchContent)
 
-function(fetch_tiledb_release_list VERSION EXPECTED_HASH)
+function(fetch_tiledb_release_list VERSION)
         # Local constants
         set(UPSTREAM_URL "https://github.com/TileDB-Inc/TileDB/releases/download")
+        list(LENGTH ARGV COUNT)
+        if (${COUNT} GREATER 1)
+                list(GET ARGV 1 EXPECTED_HASH)
+        endif()
 
         if(NOT VERSION)
                 set(VERSION latest)
         endif()
 
-        if(${EXPECTED_HASH})
+        if(EXPECTED_HASH)
                 file(DOWNLOAD
                         ${UPSTREAM_URL}/${VERSION}/releases.csv
                         ${CMAKE_CURRENT_BINARY_DIR}/releases.csv
@@ -95,8 +99,7 @@ endfunction()
 
 function(fetch_prebuilt_tiledb)
         # Arguments
-        set(options RELLIST_HASH)
-        set(oneValueArgs VERSION ARTIFACT_NAME)
+        set(oneValueArgs VERSION ARTIFACT_NAME RELLIST_HASH)
         set(multiValueArgs)
         cmake_parse_arguments(
                 FETCH_PREBUILT_TILEDB
@@ -133,8 +136,7 @@ endfunction()
 
 function(fetch_source_tiledb)
         # Arguments
-        set(options RELLIST_HASH)
-        set(oneValueArgs VERSION ARTIFACT_NAME)
+        set(oneValueArgs VERSION ARTIFACT_NAME RELLIST_HASH)
         set(multiValueArgs)
         cmake_parse_arguments(
                 FETCH_PREBUILT_TILEDB

--- a/src/cmake/Modules/FindTileDB_EP.cmake
+++ b/src/cmake/Modules/FindTileDB_EP.cmake
@@ -53,9 +53,15 @@ else()
 
     # Try to download prebuilt artifacts unless the user specifies to build from source
     if(DOWNLOAD_TILEDB_PREBUILT)
-        fetch_prebuilt_tiledb(VERSION 2.22.0)
+        fetch_prebuilt_tiledb(
+                VERSION 2.22.0
+                RELLIST_HASH SHA256=6ae0c1558f400cbee68b40810d29ad2cd0398e55378d158a9aafa3cd36b089b1
+        )
     else() # Build from source
-        fetch_source_tiledb(VERSION 2.22.0)
+        fetch_source_tiledb(
+                VERSION 2.22.0
+                RELLIST_HASH SHA256=6ae0c1558f400cbee68b40810d29ad2cd0398e55378d158a9aafa3cd36b089b1
+        )
     endif()
 
     list(APPEND FORWARD_EP_CMAKE_ARGS -DEP_TILEDB_BUILT=TRUE)


### PR DESCRIPTION
This PR adds logic that compares HASH of the `releases.csv` file itself.