### PR TITLE
Remove `std::reference_wrapper` around `tiledb::Context`

### DIFF
--- a/src/include/detail/linalg/tdb_matrix.h
+++ b/src/include/detail/linalg/tdb_matrix.h
@@ -80,7 +80,7 @@ class tdbBlockedMatrix : public MatrixBase {
 
   log_timer constructor_timer{"tdbBlockedMatrix constructor"};
 
-  std::reference_wrapper<const tiledb::Context> ctx_;
+  tiledb::Context ctx_;
   std::string uri_;
   std::unique_ptr<tiledb::Array> array_;
   tiledb::ArraySchema schema_;

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -134,8 +134,7 @@ class tdbPartitionedMatrix
   // We don't actually use this
   // size_t num_array_cols_{0};
 
-  std::reference_wrapper<const tiledb::Context> ctx_;
-  // tiledb::Context ctx_;
+  tiledb::Context ctx_;
 
   std::string partitioned_vectors_uri_;
   std::unique_ptr<tiledb::Array> partitioned_vectors_array_;

--- a/src/include/index/index_group.h
+++ b/src/include/index/index_group.h
@@ -93,7 +93,7 @@ class base_index_group {
   friend IndexGroup;
 
  protected:
-  std::reference_wrapper<const tiledb::Context> cached_ctx_;
+  tiledb::Context cached_ctx_;
   std::string group_uri_;
   size_t index_timestamp_{0};
   size_t group_timestamp_{0};


### PR DESCRIPTION
### What

@lums658 did a great investigation and found that we don't need to be using `std::reference_wrapper` around `tiledb::Context`, as `tiledb::Context` uses a shared pointer under the hood anyways so is fine to copy:

<img width="1064" alt="Screenshot 2024-04-19 at 6 13 25 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/453983a6-6bed-41f5-bf54-a826af064504">

Here we just remove `std::reference_wrapper` around `tiledb::Context`, and in a follow-up I'll update https://github.com/TileDB-Inc/TileDB-Vector-Search/pull/332 to use a `unique_ptr` around a `tiledb::Group` which should work now that the context won't go out of scope.

### Testing
* Existing tests pass