### PR TITLE
Add support for `ingest()` with `index_timestamp` for type-erased indexes

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -90,7 +90,7 @@ def ingest(
     updates_uri: str
         Updates
     index_timestamp: int
-        Timestamp to use for writing and reading data. By default it sues the current unix ms timestamp.
+        Timestamp to use for writing and reading data. By default it uses the current unix ms timestamp.
     config: None
         config dictionary, defaults to None
     namespace: str
@@ -1633,7 +1633,7 @@ def ingest(
             data = vspy.FeatureVectorArray(ctx, parts_array_uri, ids_array_uri)
             index.train(data)
             index.add(data)
-            index.write_index(ctx, index_group_uri)
+            index.write_index(ctx, index_group_uri, index_timestamp)
 
     def write_centroids(
         centroids: np.ndarray,

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -141,6 +141,7 @@ class IVFFlatIndex(index.Index):
         resources: Optional[Mapping[str, Any]] = None,
         num_partitions: int = -1,
         num_workers: int = -1,
+        **kwargs,
     ):
         """
         Query an IVF_FLAT index

--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -284,11 +284,13 @@ void init_type_erased_module(py::module_& m) {
           [](IndexVamana& index,
              const tiledb::Context& ctx,
              const std::string& group_uri,
+             std::optional<size_t> timestamp,
              const std::string& storage_version) {
-            index.write_index(ctx, group_uri, storage_version);
+            index.write_index(ctx, group_uri, timestamp, storage_version);
           },
           py::arg("ctx"),
           py::arg("group_uri"),
+          py::arg("timestamp") = py::none(),
           py::arg("storage_version") = "")
       .def("feature_type_string", &IndexVamana::feature_type_string)
       .def("id_type_string", &IndexVamana::id_type_string)

--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -121,5 +121,5 @@ def create(
     )
     index.train(empty_vector)
     index.add(empty_vector)
-    index.write_index(ctx, uri, storage_version)
+    index.write_index(ctx, uri, 0, storage_version)
     return VamanaIndex(uri=uri, config=config, memory_budget=1000000)

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -57,24 +57,11 @@ def check_default_metadata(
     assert type(group.meta["index_type"]) == str
 
     assert "base_sizes" in group.meta
-    if is_type_erased_index(expected_index_type):
-        # NOTE(paris): Type-erased indexes have two values upon creation.
-        assert group.meta["base_sizes"] == "[0,0]"
-    else:
-        assert group.meta["base_sizes"] == json.dumps([0])
+    assert group.meta["base_sizes"] == json.dumps([0])
     assert type(group.meta["base_sizes"]) == str
 
     assert "ingestion_timestamps" in group.meta
-    if is_type_erased_index(expected_index_type):
-        # NOTE(paris): Type-erased indexes have two values upon creation.
-        ingestion_timestamps = json.loads(group.meta["ingestion_timestamps"])
-        assert len(ingestion_timestamps) == 2
-        assert ingestion_timestamps[0] == 0
-        current_time_ms = int(time.time() * 1000)
-        assert ingestion_timestamps[1] < current_time_ms
-        assert ingestion_timestamps[1] > current_time_ms - 1000 * 5
-    else:
-        assert group.meta["ingestion_timestamps"] == json.dumps([0])
+    assert group.meta["ingestion_timestamps"] == json.dumps([0])
     assert type(group.meta["ingestion_timestamps"]) == str
 
     if not is_type_erased_index(expected_index_type):
@@ -82,6 +69,8 @@ def check_default_metadata(
         assert "has_updates" in group.meta
         assert group.meta["has_updates"] == 0
         assert type(group.meta["has_updates"]) == np.int64
+    else:
+        assert "has_updates" not in group.meta
 
 
 def test_flat_index(tmp_path):
@@ -279,7 +268,7 @@ def test_vamana_index(tmp_path):
 
 def test_delete_invalid_index(tmp_path):
     # We don't throw with an invalid uri.
-    Index.delete_index(uri="invalid_uri", config=tiledb.cloud.Config())
+    Index.delete_index(uri="invalid_uri", config={})
 
 
 def test_delete_index(tmp_path):
@@ -289,7 +278,7 @@ def test_delete_index(tmp_path):
     for index_type, index_class in zip(indexes, index_classes):
         index_uri = os.path.join(tmp_path, f"array_{index_type}")
         ingest(index_type=index_type, index_uri=index_uri, input_vectors=data)
-        Index.delete_index(uri=index_uri, config=tiledb.cloud.Config())
+        Index.delete_index(uri=index_uri, config={})
         with pytest.raises(tiledb.TileDBError) as error:
             index_class(uri=index_uri)
         assert "does not exist" in str(error.value)

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -1,5 +1,4 @@
 import json
-import time
 
 import numpy as np
 import pytest

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -594,11 +594,11 @@ def test_ingestion_with_updates_and_timetravel(tmp_path):
         index = index_class(uri=index_uri, timestamp=101)
         _, result = index.query(queries, k=k, nprobe=partitions)
         assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-        
+
         # TODO(paris): Fix Vamana bug and re-enable:
         if index_type == "VAMANA":
             continue
-        
+
         index_uri = move_local_index_to_new_location(index_uri)
         index = index_class(uri=index_uri, timestamp=(0, 101))
         _, result = index.query(queries, k=k, nprobe=partitions)
@@ -817,11 +817,11 @@ def test_ingestion_with_additions_and_timetravel(tmp_path):
         if index_type != "VAMANA":
             index_uri = move_local_index_to_new_location(index_uri)
         index = index_class(uri=index_uri)
-        _, result = index.query(queries, k=k, nprobe=partitions, opt_l=k*2)
+        _, result = index.query(queries, k=k, nprobe=partitions, opt_l=k * 2)
         assert 0.45 < accuracy(result, gt_i)
 
         index = index.consolidate_updates()
-        _, result = index.query(queries, k=k, nprobe=partitions, opt_l=k*2)
+        _, result = index.query(queries, k=k, nprobe=partitions, opt_l=k * 2)
         assert 0.45 < accuracy(result, gt_i)
 
 

--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -235,12 +235,13 @@ class IndexVamana {
   void write_index(
       const tiledb::Context& ctx,
       const std::string& group_uri,
-      const std::string& storage_version = "") const {
+      std::optional<size_t> timestamp = std::nullopt,
+      const std::string& storage_version = "") {
     if (!index_) {
       throw std::runtime_error(
           "Cannot write_index() because there is no index.");
     }
-    index_->write_index(ctx, group_uri, storage_version);
+    index_->write_index(ctx, group_uri, timestamp, storage_version);
   }
 
   constexpr auto dimension() const {
@@ -291,7 +292,8 @@ class IndexVamana {
     virtual void write_index(
         const tiledb::Context& ctx,
         const std::string& group_uri,
-        const std::string& storage_version) const = 0;
+        std::optional<size_t> timestamp,
+        const std::string& storage_version) = 0;
 
     [[nodiscard]] virtual size_t dimension() const = 0;
   };
@@ -397,8 +399,9 @@ class IndexVamana {
     void write_index(
         const tiledb::Context& ctx,
         const std::string& group_uri,
-        const std::string& storage_version) const override {
-      impl_index_.write_index(ctx, group_uri, storage_version);
+        std::optional<size_t> timestamp,
+        const std::string& storage_version) override {
+      impl_index_.write_index(ctx, group_uri, timestamp, storage_version);
     }
 
     size_t dimension() const override {

--- a/src/include/index/index_group.h
+++ b/src/include/index/index_group.h
@@ -239,7 +239,8 @@ class base_index_group {
     if (exists(cached_ctx_)) {
       /** Load the current group metadata */
       init_for_open(cfg);
-      if (!metadata_.ingestion_timestamps_.empty() && index_timestamp_ < metadata_.ingestion_timestamps_.back()) {
+      if (!metadata_.ingestion_timestamps_.empty() &&
+          index_timestamp_ < metadata_.ingestion_timestamps_.back()) {
         throw std::runtime_error(
             "Requested write timestamp " + std::to_string(index_timestamp_) +
             " is not greater than " +

--- a/src/include/index/index_group.h
+++ b/src/include/index/index_group.h
@@ -239,7 +239,7 @@ class base_index_group {
     if (exists(cached_ctx_)) {
       /** Load the current group metadata */
       init_for_open(cfg);
-      if (index_timestamp_ < metadata_.ingestion_timestamps_.back()) {
+      if (!metadata_.ingestion_timestamps_.empty() && index_timestamp_ < metadata_.ingestion_timestamps_.back()) {
         throw std::runtime_error(
             "Requested write timestamp " + std::to_string(index_timestamp_) +
             " is not greater than " +
@@ -372,9 +372,6 @@ class base_index_group {
   /** Temporary until time traveling is implemented */
   auto get_previous_ingestion_timestamp() const {
     return metadata_.ingestion_timestamps_.back();
-  }
-  auto get_ingestion_timestamp() const {
-    return metadata_.ingestion_timestamps_[timetravel_index_];
   }
   auto append_ingestion_timestamp(size_t timestamp) {
     metadata_.ingestion_timestamps_.push_back(timestamp);

--- a/src/include/index/vamana_group.h
+++ b/src/include/index/vamana_group.h
@@ -257,9 +257,9 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
     metadata_.adjacency_row_index_type_str_ =
         type_to_string_v<typename index_type::adjacency_row_index_type>;
 
-    metadata_.ingestion_timestamps_ = {0};
-    metadata_.base_sizes_ = {0};
-    metadata_.num_edges_history_ = {0};
+    metadata_.ingestion_timestamps_ = {};
+    metadata_.base_sizes_ = {};
+    metadata_.num_edges_history_ = {};
     metadata_.temp_size_ = 0;
     metadata_.dimension_ = this->get_dimension();
 

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -840,7 +840,11 @@ class vamana_index {
   auto write_index(
       const tiledb::Context& ctx,
       const std::string& group_uri,
-      const std::string& storage_version = "") const {
+      std::optional<size_t> timestamp = std::nullopt,
+      const std::string& storage_version = "") {
+    if (timestamp.has_value()) {
+      timestamp_ = timestamp.value();
+    }
     // metadata: dimension, ntotal, L, R, B, alpha_min, alpha_max, medoid
     // Save as a group: metadata, feature_vectors, graph edges, offsets
 

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -368,6 +368,10 @@ TEST_CASE(
   auto ctx = tiledb::Context{};
   std::string api_vamana_index_uri =
       (std::filesystem::temp_directory_path() / "api_vamana_index").string();
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(api_vamana_index_uri)) {
+    vfs.remove_dir(api_vamana_index_uri);
+  }
 
   auto a = IndexVamana(std::make_optional<IndexOptions>(
       {{"feature_type", "float32"},

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -470,7 +470,7 @@ TEST_CASE("api_vamana_index: storage_version", "[api_vamana_index]") {
         FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
     index.train(empty_training_vector_array);
     index.add(empty_training_vector_array);
-    index.write_index(ctx, index_uri, "0.3");
+    index.write_index(ctx, index_uri, std::nullopt, "0.3");
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
@@ -490,11 +490,11 @@ TEST_CASE("api_vamana_index: storage_version", "[api_vamana_index]") {
 
     // Throw with the wrong version.
     CHECK_THROWS_WITH(
-        index.write_index(ctx, index_uri, "0.4"),
+        index.write_index(ctx, index_uri, std::nullopt, "0.4"),
         "Version mismatch. Requested 0.4 but found 0.3");
     // Succeed without a version.
     index.write_index(ctx, index_uri);
     // Succeed with the same version.
-    index.write_index(ctx, index_uri, "0.3");
+    index.write_index(ctx, index_uri, std::nullopt, "0.3");
   }
 }

--- a/src/include/test/unit_vamana_group.cc
+++ b/src/include/test/unit_vamana_group.cc
@@ -110,16 +110,25 @@ TEST_CASE(
     vfs.remove_dir(tmp_uri);
   }
 
-  vamana_index_group x =
-      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+  {
+    vamana_index_group x =
+        vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+    x.append_num_edges(0);
+    x.append_base_size(0);
+    x.append_ingestion_timestamp(0);
+
+    // We throw b/c the vamana_index_group hasn't actually been written (the write happens in the destructor).
+    CHECK_THROWS_WITH(
+       vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ),
+       "No ingestion timestamps found.");
+  }
 
   vamana_index_group y =
       vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
 }
 
 TEST_CASE(
-    "vamana_group: write constructor - create, write, and read",
-    "[vamana_group]") {
+    "vamana_group: write constructor - invalid create and read", "[vamana_group]") {
   std::string tmp_uri = (std::filesystem::temp_directory_path() /
                          "vamana_group_test_write_constructor")
                             .string();
@@ -130,14 +139,19 @@ TEST_CASE(
     vfs.remove_dir(tmp_uri);
   }
 
-  vamana_index_group x =
-      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+  {
+    vamana_index_group x =
+        vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+    // We throw b/c the vamana_index_group hasn't actually been written (the write happens in the destructor).
+    CHECK_THROWS_WITH(
+       vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ),
+       "No ingestion timestamps found.");
+  }
 
-  vamana_index_group y =
-      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
-
-  vamana_index_group z =
-      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+  // If we don't append to the group, even if it's been written there will be no timestamps.
+  CHECK_THROWS_WITH(
+     vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ),
+     "No ingestion timestamps found.");
 }
 
 TEST_CASE(
@@ -161,8 +175,14 @@ TEST_CASE(
 
   size_t offset = 0;
 
-  vamana_index_group x =
-      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+  {
+      vamana_index_group x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x.append_num_edges(0);
+      x.append_base_size(0);
+      x.append_ingestion_timestamp(0);
+  }
+
+  vamana_index_group x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
 
   SECTION("Just set") {
     SECTION("After create") {
@@ -333,11 +353,17 @@ TEST_CASE("vamana_group: storage version", "[vamana_group]") {
 
   SECTION("0.3") {
     x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE, 0, "0.3");
+    x.append_num_edges(0);
+    x.append_base_size(0);
+    x.append_ingestion_timestamp(0);
   }
 
   SECTION("current_storage_version") {
     x = vamana_index_group(
         dummy_index{}, ctx, tmp_uri, TILEDB_WRITE, 0, current_storage_version);
+    x.append_num_edges(0);
+    x.append_base_size(0);
+    x.append_ingestion_timestamp(0);
   }
 
   x.set_ingestion_timestamp(expected_ingestion + offset);

--- a/src/include/test/unit_vamana_group.cc
+++ b/src/include/test/unit_vamana_group.cc
@@ -117,10 +117,11 @@ TEST_CASE(
     x.append_base_size(0);
     x.append_ingestion_timestamp(0);
 
-    // We throw b/c the vamana_index_group hasn't actually been written (the write happens in the destructor).
+    // We throw b/c the vamana_index_group hasn't actually been written (the
+    // write happens in the destructor).
     CHECK_THROWS_WITH(
-       vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ),
-       "No ingestion timestamps found.");
+        vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ),
+        "No ingestion timestamps found.");
   }
 
   vamana_index_group y =
@@ -128,7 +129,8 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "vamana_group: write constructor - invalid create and read", "[vamana_group]") {
+    "vamana_group: write constructor - invalid create and read",
+    "[vamana_group]") {
   std::string tmp_uri = (std::filesystem::temp_directory_path() /
                          "vamana_group_test_write_constructor")
                             .string();
@@ -142,16 +144,18 @@ TEST_CASE(
   {
     vamana_index_group x =
         vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
-    // We throw b/c the vamana_index_group hasn't actually been written (the write happens in the destructor).
+    // We throw b/c the vamana_index_group hasn't actually been written (the
+    // write happens in the destructor).
     CHECK_THROWS_WITH(
-       vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ),
-       "No ingestion timestamps found.");
+        vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ),
+        "No ingestion timestamps found.");
   }
 
-  // If we don't append to the group, even if it's been written there will be no timestamps.
+  // If we don't append to the group, even if it's been written there will be no
+  // timestamps.
   CHECK_THROWS_WITH(
-     vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ),
-     "No ingestion timestamps found.");
+      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ),
+      "No ingestion timestamps found.");
 }
 
 TEST_CASE(
@@ -176,13 +180,15 @@ TEST_CASE(
   size_t offset = 0;
 
   {
-      vamana_index_group x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
-      x.append_num_edges(0);
-      x.append_base_size(0);
-      x.append_ingestion_timestamp(0);
+    vamana_index_group x =
+        vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+    x.append_num_edges(0);
+    x.append_base_size(0);
+    x.append_ingestion_timestamp(0);
   }
 
-  vamana_index_group x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+  vamana_index_group x =
+      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
 
   SECTION("Just set") {
     SECTION("After create") {

--- a/src/include/test/unit_vamana_metadata.cc
+++ b/src/include/test/unit_vamana_metadata.cc
@@ -98,7 +98,7 @@ TEST_CASE("vamana_metadata: load metadata from index", "[vamana_metadata]") {
         {"dtype", "float32"},
         {"feature_type", "float32"},
         {"id_type", "uint64"},
-        {"base_sizes", "[0,10000]"},
+        {"base_sizes", "[10000]"},
         {"adjacency_scores_type", "float32"},
         {"adjacency_row_index_type", "uint64"},
     };
@@ -121,7 +121,7 @@ TEST_CASE("vamana_metadata: load metadata from index", "[vamana_metadata]") {
         {"dtype", "float32"},
         {"feature_type", "float32"},
         {"id_type", "uint64"},
-        {"base_sizes", "[0,10000,10000]"},
+        {"base_sizes", "[10000,10000]"},
         {"adjacency_scores_type", "float32"},
         {"adjacency_row_index_type", "uint64"},
     };


### PR DESCRIPTION
### What
Here we add support for `index_timestamp` to the Vamana index.

To get this to work we changed to not automatically initialize the metadata with `ingestion_timestamps = [0]`, `base_sizes = [0]`, etc. This is because in Python during `ingest()` we will 

1. Call `write_index()` with an empty `FeatureVectorArray` 
2. Call `write_index()` with the actual vectors in `FeatureVectorArray`

In **1.** we will call with `index_timestamp = 0`, and in **2.** we call with `index_timestamp = index_timestamp` (which will default to the current timestamp if `index_timestamp = None`). If we hadn't removed the default of `ingestion_timestamps = [0]`, in **1.** we would fail because we'd be writing with `timestamp = 0`, but we would already have `timestamp = 0` in metadata (and you cannot have two equivalent timestamps saved in metadata).

### Testing
* Existing tests pass
* More `test_ingestion.py` tests pass

### TODO
* In a follow-up I'll also add support for other indexes, but just starting with Vamana to make the PR easier to review.
* The `test_ingestion.py` tests do not all pass yet, so will continue working to get more to pass.