### PR TITLE
Fix bug with relative Vamana indexes in Python

### DIFF
--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping, Optional
 from tiledb.vector_search import _tiledbvspy as vspy
 from tiledb.vector_search.module import *
 from tiledb.vector_search.storage_formats import storage_formats
+from tiledb.vector_search.utils import add_to_group
 
 MAX_UINT64 = np.iinfo(np.dtype("uint64")).max
 MAX_INT32 = np.iinfo(np.dtype("int32")).max
@@ -375,7 +376,7 @@ class Index:
                 tiledb.Array.create(self.updates_array_uri, updates_schema)
                 self.group.close()
                 self.group = tiledb.Group(self.uri, "w")
-                self.group.add(self.updates_array_uri, name=updates_array_name)
+                add_to_group(self.group, self.updates_array_uri, updates_array_name)
                 self.group.close()
                 self.group = tiledb.Group(self.uri, "r")
             if timestamp is None:

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -642,14 +642,13 @@ def test_ingestion_with_updates_and_timetravel(tmp_path):
         index = index_class(uri=index_uri, timestamp=101)
         _, result = index.query(queries, k=k, nprobe=partitions)
         assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
-
-        # TODO(paris): Fix Vamana bug and re-enable:
-        if index_type == "VAMANA":
-            continue
-
         index_uri = move_local_index_to_new_location(index_uri)
         index = index_class(uri=index_uri, timestamp=(0, 101))
         _, result = index.query(queries, k=k, nprobe=partitions)
+        # TODO(paris): Fix Vamana accuracy bug and re-enable:
+        # assert 0.105 == 1.0
+        if index_type == "VAMANA":
+            continue
         assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
         index = index_class(uri=index_uri, timestamp=(0, None))
         _, result = index.query(queries, k=k, nprobe=partitions)
@@ -860,10 +859,7 @@ def test_ingestion_with_additions_and_timetravel(tmp_path):
             )
             updated_ids[i] = i + update_ids_offset
 
-        # TODO(paris): Fix Vamana bug and re-enable:
-        # tiledb.cc.TileDBError: [TileDB::ArrayDirectory] Error: Cannot open array; Array does not exist.
-        if index_type != "VAMANA":
-            index_uri = move_local_index_to_new_location(index_uri)
+        index_uri = move_local_index_to_new_location(index_uri)
         index = index_class(uri=index_uri)
         _, result = index.query(queries, k=k, nprobe=partitions, opt_l=k * 2)
         assert 0.45 < accuracy(result, gt_i)


### PR DESCRIPTION
### What
Previously we would not create the updates array with relative = True, so we would fail when trying to move the Vamana index. Not sure why this wasn't failing for other indexes, but guessing it's because they create it themselves at some point. Either way, everywhere else uses `add_to_group()` and is relative, so we make the update here.

### Testing
* Existing tests pass
* More Vamana `test_ingestion.py` tests pass