### PR TITLE
Fix `Index.delete_index()` so that it uses recursive=True and deletes the full index

### DIFF
--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -456,7 +456,7 @@ class Index:
                     return
                 else:
                     raise err
-            group.delete()
+            group.delete(recursive=True)
 
     @staticmethod
     def clear_history(

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -2505,15 +2505,20 @@ def ingest(
         config: Optional[Mapping[str, Any]] = None,
     ):
         with tiledb.Group(index_group_uri) as group:
+            write_group = tiledb.Group(index_group_uri, "w")
             try:
                 if INPUT_VECTORS_ARRAY_NAME in group:
                     tiledb.Array.delete_array(group[INPUT_VECTORS_ARRAY_NAME].uri)
+                    write_group.remove(INPUT_VECTORS_ARRAY_NAME)
                 if EXTERNAL_IDS_ARRAY_NAME in group:
                     tiledb.Array.delete_array(group[EXTERNAL_IDS_ARRAY_NAME].uri)
+                    write_group.remove(EXTERNAL_IDS_ARRAY_NAME)
             except tiledb.TileDBError as err:
                 message = str(err)
                 if "does not exist" not in message:
                     raise err
+            write_group.close()
+
             modes = ["fragment_meta", "commits", "array_meta"]
             for mode in modes:
                 conf = tiledb.Config(config)

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -2504,8 +2504,8 @@ def ingest(
         index_group_uri: str,
         config: Optional[Mapping[str, Any]] = None,
     ):
+        write_group = tiledb.Group(index_group_uri, "w")
         with tiledb.Group(index_group_uri) as group:
-            write_group = tiledb.Group(index_group_uri, "w")
             try:
                 if INPUT_VECTORS_ARRAY_NAME in group:
                     tiledb.Array.delete_array(group[INPUT_VECTORS_ARRAY_NAME].uri)
@@ -2517,7 +2517,6 @@ def ingest(
                 message = str(err)
                 if "does not exist" not in message:
                     raise err
-            write_group.close()
 
             modes = ["fragment_meta", "commits", "array_meta"]
             for mode in modes:
@@ -2532,8 +2531,7 @@ def ingest(
                 tiledb.vacuum(ids_uri, config=conf)
             partial_write_array_exists = PARTIAL_WRITE_ARRAY_DIR in group
         if partial_write_array_exists:
-            with tiledb.Group(index_group_uri, "w") as partial_write_array_group:
-                partial_write_array_group.remove(PARTIAL_WRITE_ARRAY_DIR)
+            write_group.remove(PARTIAL_WRITE_ARRAY_DIR)
             partial_write_array_dir_uri = (
                 index_group_uri + "/" + PARTIAL_WRITE_ARRAY_DIR
             )
@@ -2541,6 +2539,7 @@ def ingest(
                 partial_write_array_dir_uri, "m"
             ) as partial_write_array_group:
                 partial_write_array_group.delete(recursive=True)
+        write_group.close()
 
     # --------------------------------------------------------------------
     # End internal function definitions

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -40,6 +40,8 @@ def query_and_check_equals(index, queries, expected_result_d, expected_result_i)
 
 
 def test_vamana_ingestion_u8(tmp_path):
+    vfs = tiledb.VFS()
+
     dataset_dir = os.path.join(tmp_path, "dataset")
     index_uri = os.path.join(tmp_path, "array")
     if os.path.exists(index_uri):
@@ -63,6 +65,10 @@ def test_vamana_ingestion_u8(tmp_path):
     index_ram = VamanaIndex(uri=index_uri)
     _, result = index_ram.query(queries, k=k)
     assert accuracy(result, gt_i) > MINIMUM_ACCURACY
+
+    assert vfs.dir_size(index_uri) > 0
+    Index.delete_index(uri=index_uri, config={})
+    assert vfs.dir_size(index_uri) == 0
 
 
 def test_flat_ingestion_u8(tmp_path):
@@ -245,6 +251,8 @@ def test_ivf_flat_ingestion_f32(tmp_path):
 
 
 def test_ingestion_fvec(tmp_path):
+    vfs = tiledb.VFS()
+
     source_uri = siftsmall_inputs_file
     queries_uri = siftsmall_query_file
     gt_uri = siftsmall_groundtruth_file
@@ -289,8 +297,14 @@ def test_ingestion_fvec(tmp_path):
         _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
         assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
+        assert vfs.dir_size(index_uri) > 0
+        Index.delete_index(uri=index_uri, config={})
+        assert vfs.dir_size(index_uri) == 0
+
 
 def test_ingestion_numpy(tmp_path):
+    vfs = tiledb.VFS()
+
     source_uri = siftsmall_inputs_file
     queries_uri = siftsmall_query_file
     gt_uri = siftsmall_groundtruth_file
@@ -336,8 +350,14 @@ def test_ingestion_numpy(tmp_path):
         _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
         assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
+        assert vfs.dir_size(index_uri) > 0
+        Index.delete_index(uri=index_uri, config={})
+        assert vfs.dir_size(index_uri) == 0
+
 
 def test_ingestion_numpy_i8(tmp_path):
+    vfs = tiledb.VFS()
+
     source_uri = siftsmall_inputs_file
     queries_uri = siftsmall_query_file
     gt_uri = siftsmall_groundtruth_file
@@ -384,8 +404,14 @@ def test_ingestion_numpy_i8(tmp_path):
         _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
         assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
+        assert vfs.dir_size(index_uri) > 0
+        Index.delete_index(uri=index_uri, config={})
+        assert vfs.dir_size(index_uri) == 0
+
 
 def test_ingestion_multiple_workers(tmp_path):
+    vfs = tiledb.VFS()
+
     source_uri = siftsmall_inputs_file
     queries_uri = siftsmall_query_file
     gt_uri = siftsmall_groundtruth_file
@@ -432,8 +458,14 @@ def test_ingestion_multiple_workers(tmp_path):
         _, result = index_ram.query(queries, k=k, nprobe=nprobe, mode=Mode.LOCAL)
         assert accuracy(result, gt_i) > MINIMUM_ACCURACY
 
+        assert vfs.dir_size(index_uri) > 0
+        Index.delete_index(uri=index_uri, config={})
+        assert vfs.dir_size(index_uri) == 0
+
 
 def test_ingestion_external_ids_numpy(tmp_path):
+    vfs = tiledb.VFS()
+
     source_uri = siftsmall_inputs_file
     queries_uri = siftsmall_query_file
     gt_uri = siftsmall_groundtruth_file
@@ -474,8 +506,14 @@ def test_ingestion_external_ids_numpy(tmp_path):
         _, result = index_ram.query(queries, k=k, nprobe=nprobe)
         assert accuracy(result, gt_i, external_ids_offset) > MINIMUM_ACCURACY
 
+        assert vfs.dir_size(index_uri) > 0
+        Index.delete_index(uri=index_uri, config={})
+        assert vfs.dir_size(index_uri) == 0
+
 
 def test_ingestion_with_updates(tmp_path):
+    vfs = tiledb.VFS()
+
     dataset_dir = os.path.join(tmp_path, "dataset")
     k = 10
     size = 1000
@@ -528,8 +566,14 @@ def test_ingestion_with_updates(tmp_path):
         _, result = index.query(queries, k=k, nprobe=20)
         assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
+        assert vfs.dir_size(index_uri) > 0
+        Index.delete_index(uri=index_uri, config={})
+        assert vfs.dir_size(index_uri) == 0
+
 
 def test_ingestion_with_batch_updates(tmp_path):
+    vfs = tiledb.VFS()
+
     dataset_dir = os.path.join(tmp_path, "dataset")
     k = 10
     size = 100000
@@ -590,8 +634,14 @@ def test_ingestion_with_batch_updates(tmp_path):
         _, result = index.query(queries, k=k, nprobe=nprobe)
         assert accuracy(result, gt_i, updated_ids=updated_ids) > 0.99
 
+        assert vfs.dir_size(index_uri) > 0
+        Index.delete_index(uri=index_uri, config={})
+        assert vfs.dir_size(index_uri) == 0
+
 
 def test_ingestion_with_updates_and_timetravel(tmp_path):
+    vfs = tiledb.VFS()
+
     dataset_dir = os.path.join(tmp_path, "dataset")
     k = 10
     size = 1000
@@ -819,8 +869,14 @@ def test_ingestion_with_updates_and_timetravel(tmp_path):
         _, result = index.query(queries, k=k, nprobe=partitions)
         assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
 
+        assert vfs.dir_size(index_uri) > 0
+        Index.delete_index(uri=index_uri, config={})
+        assert vfs.dir_size(index_uri) == 0
+
 
 def test_ingestion_with_additions_and_timetravel(tmp_path):
+    vfs = tiledb.VFS()
+
     dataset_dir = os.path.join(tmp_path, "dataset")
     k = 100
     size = 100
@@ -867,6 +923,10 @@ def test_ingestion_with_additions_and_timetravel(tmp_path):
         index = index.consolidate_updates()
         _, result = index.query(queries, k=k, nprobe=partitions, opt_l=k * 2)
         assert 0.45 < accuracy(result, gt_i)
+
+        assert vfs.dir_size(index_uri) > 0
+        Index.delete_index(uri=index_uri, config={})
+        assert vfs.dir_size(index_uri) == 0
 
 
 def test_ivf_flat_ingestion_tdb_random_sampling_policy(tmp_path):


### PR DESCRIPTION
### What
In a [Vamana CI job](https://github.com/TileDB-Inc/TileDB-Vector-Search/actions/runs/8831344021/job/24246361970?pr=343#step:6:593) I saw it fail consistently when it's installing the jupyter notebook pip packages after running the Python tests because we have disk space after the unit tests:
```
================ 65 passed, 137 warnings in 8725.71s (2:25:25) =================
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   70G  2.8G  97% /                    NOTE(paris): This CI job started at 50G, so we used 20G in the tests
tmpfs           7.9G  172K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda15      105M  6.1M   99M   6% /boot/efi
/dev/sdb1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```
To fix this I tried adding `Index.delete_index(uri=index_uri, config={})` after each unit test, but I noticed when running locally that the index wasn't actually deleted, i.e. here was an index after it should have been deleted:

![Screenshot 2024-04-25 at 4 42 15 PM](https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/e7a2750e-2db3-4035-b7e5-2a57fe9154fe)

To fix this I changed to `group.delete(recursive=True)`, but then I got crashes with:
```
in delete_index
    group.delete(recursive=True)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = array_VAMANA_copied GROUP
|-- input_vectors ARRAY
|-- shuffled_vectors ARRAY
|-- adjacency_ids ARRAY
|-- adjacency_scores ARRAY
|-- adjacency_row_index ARRAY
|-- shuffled_vector_ids ARRAY

recursive = True

    def delete(self, recursive: bool = False):
        """
        Delete a Group. The group needs to be opened in 'm' mode.
    
        :param uri: The URI of the group to delete
        """
>       self._delete_group(self.uri, recursive)
E       tiledb.cc.TileDBError: TileDB internal: Cannot open array; Array does not exist.
```
It turns out these crashes just happened when `input_vectors` was passed to `ingest()`. This is because we would call `tiledb.Array.delete_array(group[INPUT_VECTORS_ARRAY_NAME].uri)`, but we wouldn't remove `INPUT_VECTORS_ARRAY_NAME` from the `group`. So here we update to do that and with it we no longer crash.

### Testing
* Added new tests which check that the size of the index is 0 after calling `Index.delete_index()`.
* Existing tests pass.


