### PR TITLE
Do not create default  `tiledb::Config` objects in C++

### DIFF
--- a/src/include/api/ivf_flat_index.h
+++ b/src/include/api/ivf_flat_index.h
@@ -150,8 +150,7 @@ class IndexIVFFlat {
         {"id_datatype", &id_datatype_, TILEDB_UINT32, "ids_array_name"},
         {"px_datatype", &px_datatype_, TILEDB_UINT32, "index_array_name"}};
 
-    tiledb::Config cfg;
-    tiledb::Group read_group(ctx, group_uri, TILEDB_READ, cfg);
+    tiledb::Group read_group(ctx, group_uri, TILEDB_READ, ctx.config());
 
     // Get the storage_version in case the metadata is not present on read_group
     // and we need to read the individual arrays.

--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -137,8 +137,7 @@ class IndexVamana {
          &adjacency_row_index_datatype_,
          TILEDB_UINT32}};
 
-    tiledb::Config cfg;
-    tiledb::Group read_group(ctx, group_uri, TILEDB_READ, cfg);
+    tiledb::Group read_group(ctx, group_uri, TILEDB_READ, ctx.config());
 
     for (auto& [name, value, datatype] : metadata) {
       if (!read_group.has_metadata(name, &datatype)) {

--- a/src/include/index/flatpq_index.h
+++ b/src/include/index/flatpq_index.h
@@ -643,7 +643,8 @@ class flatpq_index {
     tiledb::Context ctx;
 
     tiledb::Group::create(ctx, group_uri);
-    auto write_group = tiledb::Group(ctx, group_uri, TILEDB_WRITE, ctx.config());
+    auto write_group =
+        tiledb::Group(ctx, group_uri, TILEDB_WRITE, ctx.config());
 
     for (auto&& [name, value, type] : metadata) {
       write_group.put_metadata(name, type, 1, value);

--- a/src/include/index/flatpq_index.h
+++ b/src/include/index/flatpq_index.h
@@ -343,8 +343,7 @@ class flatpq_index {
    * Load constructor
    */
   flatpq_index(tiledb::Context ctx, const std::string& group_uri) {
-    tiledb::Config cfg;
-    auto read_group = tiledb::Group(ctx, group_uri, TILEDB_READ, cfg);
+    auto read_group = tiledb::Group(ctx, group_uri, TILEDB_READ, ctx.config());
 
     for (auto& [name, value, datatype] : metadata) {
       if (!read_group.has_metadata(name, &datatype)) {
@@ -643,9 +642,8 @@ class flatpq_index {
   auto write_index(const std::string& group_uri) {
     tiledb::Context ctx;
 
-    tiledb::Config cfg;
     tiledb::Group::create(ctx, group_uri);
-    auto write_group = tiledb::Group(ctx, group_uri, TILEDB_WRITE, cfg);
+    auto write_group = tiledb::Group(ctx, group_uri, TILEDB_WRITE, ctx.config());
 
     for (auto&& [name, value, type] : metadata) {
       write_group.put_metadata(name, type, 1, value);

--- a/src/include/index/index_group.h
+++ b/src/include/index/index_group.h
@@ -149,12 +149,12 @@ class base_index_group {
    *
    * @param ctx
    */
-  void init_for_open(const tiledb::Config& cfg) {
+  void init_for_open() {
     if (!exists(cached_ctx_)) {
       throw std::runtime_error(
           "Group uri " + std::string(group_uri_) + " does not exist.");
     }
-    auto read_group = tiledb::Group(cached_ctx_, group_uri_, TILEDB_READ, cfg);
+    auto read_group = tiledb::Group(cached_ctx_, group_uri_, TILEDB_READ, cached_ctx_.config());
 
     // Load the metadata and check the version.  We need to do this before
     // we can check the array names.
@@ -193,8 +193,8 @@ class base_index_group {
     }
   }
 
-  void open_for_read(const tiledb::Config& cfg) {
-    init_for_open(cfg);
+  void open_for_read() {
+    init_for_open();
 
     if (size(metadata_.ingestion_timestamps_) == 0) {
       throw std::runtime_error("No ingestion timestamps found.");
@@ -235,10 +235,10 @@ class base_index_group {
    * @param uri
    * @param version
    */
-  void open_for_write(const tiledb::Config& cfg) {
+  void open_for_write() {
     if (exists(cached_ctx_)) {
       /** Load the current group metadata */
-      init_for_open(cfg);
+      init_for_open();
       if (!metadata_.ingestion_timestamps_.empty() &&
           index_timestamp_ < metadata_.ingestion_timestamps_.back()) {
         throw std::runtime_error(
@@ -249,7 +249,7 @@ class base_index_group {
       }
     } else {
       /** Create a new group */
-      create_default(cfg);
+      create_default();
     }
   }
 
@@ -260,8 +260,8 @@ class base_index_group {
    *
    * @todo Process the "base group" metadata here.
    */
-  void create_default(const tiledb::Config& cfg) {
-    static_cast<group_type*>(this)->create_default_impl(cfg);
+  void create_default() {
+    static_cast<group_type*>(this)->create_default_impl();
   }
 
   /** Convert an array key to a uri. */
@@ -307,8 +307,7 @@ class base_index_group {
       uint64_t dimension,
       tiledb_query_type_t rw = TILEDB_READ,
       size_t timestamp = 0,
-      const std::string& version = std::string{""},
-      const tiledb::Config& cfg = tiledb::Config{})
+      const std::string& version = std::string{""})
       : cached_ctx_(ctx)
       , group_uri_(uri)
       , index_timestamp_(timestamp)
@@ -316,11 +315,11 @@ class base_index_group {
       , opened_for_(rw) {
     switch (opened_for_) {
       case TILEDB_READ:
-        open_for_read(cfg);
+        open_for_read();
         break;
       case TILEDB_WRITE:
         set_dimension(dimension);
-        open_for_write(cfg);
+        open_for_write();
         break;
       case TILEDB_MODIFY_EXCLUSIVE:
         break;
@@ -340,9 +339,8 @@ class base_index_group {
    */
   ~base_index_group() {
     if (opened_for_ == TILEDB_WRITE) {
-      auto cfg = tiledb::Config();
       auto write_group =
-          tiledb::Group(cached_ctx_, group_uri_, TILEDB_WRITE, cfg);
+          tiledb::Group(cached_ctx_, group_uri_, TILEDB_WRITE, cached_ctx_.config());
       metadata_.store_metadata(write_group);
     }
   }
@@ -489,8 +487,7 @@ class base_index_group {
     }
     std::cout << "-------------------------------------------------------\n";
     std::cout << "Stored in " + group_uri_ + ":" << std::endl;
-    auto cfg = tiledb::Config();
-    auto read_group = tiledb::Group(cached_ctx_, group_uri_, TILEDB_READ, cfg);
+    auto read_group = tiledb::Group(cached_ctx_, group_uri_, TILEDB_READ, cached_ctx_.config());
     for (size_t i = 0; i < read_group.member_count(); ++i) {
       auto member = read_group.member(i);
       auto name = member.name();

--- a/src/include/index/index_group.h
+++ b/src/include/index/index_group.h
@@ -154,7 +154,8 @@ class base_index_group {
       throw std::runtime_error(
           "Group uri " + std::string(group_uri_) + " does not exist.");
     }
-    auto read_group = tiledb::Group(cached_ctx_, group_uri_, TILEDB_READ, cached_ctx_.config());
+    auto read_group = tiledb::Group(
+        cached_ctx_, group_uri_, TILEDB_READ, cached_ctx_.config());
 
     // Load the metadata and check the version.  We need to do this before
     // we can check the array names.
@@ -339,8 +340,8 @@ class base_index_group {
    */
   ~base_index_group() {
     if (opened_for_ == TILEDB_WRITE) {
-      auto write_group =
-          tiledb::Group(cached_ctx_, group_uri_, TILEDB_WRITE, cached_ctx_.config());
+      auto write_group = tiledb::Group(
+          cached_ctx_, group_uri_, TILEDB_WRITE, cached_ctx_.config());
       metadata_.store_metadata(write_group);
     }
   }
@@ -487,7 +488,8 @@ class base_index_group {
     }
     std::cout << "-------------------------------------------------------\n";
     std::cout << "Stored in " + group_uri_ + ":" << std::endl;
-    auto read_group = tiledb::Group(cached_ctx_, group_uri_, TILEDB_READ, cached_ctx_.config());
+    auto read_group = tiledb::Group(
+        cached_ctx_, group_uri_, TILEDB_READ, cached_ctx_.config());
     for (size_t i = 0; i < read_group.member_count(); ++i) {
       auto member = read_group.member(i);
       auto name = member.name();

--- a/src/include/index/ivf_flat_group.h
+++ b/src/include/index/ivf_flat_group.h
@@ -87,9 +87,8 @@ class ivf_flat_index_group
       const std::string& uri,
       tiledb_query_type_t rw = TILEDB_READ,
       size_t timestamp = 0,
-      const std::string& version = std::string{""},
-      const tiledb::Config& cfg = tiledb::Config{})
-      : Base(ctx, uri, index.dimension(), rw, timestamp, version, cfg) {
+      const std::string& version = std::string{""})
+      : Base(ctx, uri, index.dimension(), rw, timestamp, version) {
   }
 
  public:
@@ -145,7 +144,7 @@ class ivf_flat_index_group
     return this->array_key_to_array_name("index_array_name");
   }
 
-  void create_default_impl(const tiledb::Config& cfg) {
+  void create_default_impl() {
     if (empty(this->version_)) {
       this->version_ = current_storage_version;
     }
@@ -159,7 +158,7 @@ class ivf_flat_index_group
 
     tiledb::Group::create(cached_ctx_, group_uri_);
     auto write_group =
-        tiledb::Group(cached_ctx_, group_uri_, TILEDB_WRITE, cfg);
+        tiledb::Group(cached_ctx_, group_uri_, TILEDB_WRITE, cached_ctx_.config());
 
     this->metadata_.storage_version_ = version_;
 

--- a/src/include/index/ivf_flat_group.h
+++ b/src/include/index/ivf_flat_group.h
@@ -157,8 +157,8 @@ class ivf_flat_index_group
         string_to_filter(storage_formats[version_]["default_attr_filters"])};
 
     tiledb::Group::create(cached_ctx_, group_uri_);
-    auto write_group =
-        tiledb::Group(cached_ctx_, group_uri_, TILEDB_WRITE, cached_ctx_.config());
+    auto write_group = tiledb::Group(
+        cached_ctx_, group_uri_, TILEDB_WRITE, cached_ctx_.config());
 
     this->metadata_.storage_version_ = version_;
 

--- a/src/include/index/vamana_group.h
+++ b/src/include/index/vamana_group.h
@@ -221,8 +221,8 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
         string_to_filter(storage_formats[version_]["default_attr_filters"])};
 
     tiledb::Group::create(cached_ctx_, group_uri_);
-    auto write_group =
-        tiledb::Group(cached_ctx_, group_uri_, TILEDB_WRITE, cached_ctx_.config());
+    auto write_group = tiledb::Group(
+        cached_ctx_, group_uri_, TILEDB_WRITE, cached_ctx_.config());
 
     /**************************************************************************
      * Base group metadata setup

--- a/src/include/index/vamana_group.h
+++ b/src/include/index/vamana_group.h
@@ -110,9 +110,8 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
       const std::string& uri,
       tiledb_query_type_t rw = TILEDB_READ,
       size_t timestamp = 0,
-      const std::string& version = std::string{""},
-      const tiledb::Config& cfg = tiledb::Config{})
-      : Base(ctx, uri, index.dimension(), rw, timestamp, version, cfg) {
+      const std::string& version = std::string{""})
+      : Base(ctx, uri, index.dimension(), rw, timestamp, version) {
   }
 
  public:
@@ -209,7 +208,7 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
     return this->array_key_to_array_name("adjacency_row_index_array_name");
   }
 
-  void create_default_impl(const tiledb::Config& cfg) {
+  void create_default_impl() {
     if (empty(this->version_)) {
       this->version_ = current_storage_version;
     }
@@ -223,7 +222,7 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
 
     tiledb::Group::create(cached_ctx_, group_uri_);
     auto write_group =
-        tiledb::Group(cached_ctx_, group_uri_, TILEDB_WRITE, cfg);
+        tiledb::Group(cached_ctx_, group_uri_, TILEDB_WRITE, cached_ctx_.config());
 
     /**************************************************************************
      * Base group metadata setup


### PR DESCRIPTION
### What
In several places we create default `tiledb::Config` objects in C++. I believe this is not good for cloud ingestion b/c then we won't maintain the correct config as we open different objects. So here we update to just use the `tiledb::Config` which `tiledb::Context` has on it. But please let me know if there is more nuance here / if I'm missing something about why we did it this way.

### Testing 
Existing unit tests pass.