### PR TITLE
Update `FeatureVectorArray` to be able to read from URIs at a specified timestamp

### DIFF
--- a/src/include/api/feature_vector_array.h
+++ b/src/include/api/feature_vector_array.h
@@ -83,8 +83,13 @@ class FeatureVectorArray {
       const tiledb::Context& ctx,
       const std::string& uri,
       const std::string& ids_uri = "",
-      size_t num_vectors = 0) {
-    auto array = tiledb_helpers::open_array(tdb_func__, ctx, uri, TILEDB_READ);
+      size_t num_vectors = 0,
+      size_t timestamp = 0) {
+    auto temporal_policy =
+        timestamp == 0 ? tiledb::TemporalPolicy() :
+                         tiledb::TemporalPolicy(tiledb::TimeTravel, timestamp);
+    auto array = tiledb_helpers::open_array(
+        tdb_func__, ctx, uri, TILEDB_READ, temporal_policy);
     feature_type_ = get_array_datatype(*array);
     array->close();  // @todo create Matrix constructor that takes opened array
     feature_size_ = datatype_to_size(feature_type_);
@@ -102,7 +107,7 @@ class FeatureVectorArray {
         throw std::runtime_error("Unsupported features attribute type");
       }
       vector_array = tdb_col_major_matrix_dispatch_table.at(feature_type_)(
-          ctx, uri, num_vectors);
+          ctx, uri, num_vectors, timestamp);
     } else {
       auto ids_array =
           tiledb_helpers::open_array(tdb_func__, ctx, ids_uri, TILEDB_READ);
@@ -117,7 +122,7 @@ class FeatureVectorArray {
             "Unsupported attribute type for feature vector with ids");
       }
       vector_array = tdb_col_major_matrix_with_ids_dispatch_table.at(type)(
-          ctx, uri, ids_uri, num_vectors);
+          ctx, uri, ids_uri, num_vectors, timestamp);
     }
     (void)vector_array->load();
   }
@@ -233,15 +238,19 @@ class FeatureVectorArray {
       //     : impl_vector_array(t) {
     }
     vector_array_impl(
-        const tiledb::Context& ctx, const std::string& uri, size_t num_vectors)
-        : impl_vector_array(ctx, uri, num_vectors) {
+        const tiledb::Context& ctx,
+        const std::string& uri,
+        size_t num_vectors,
+        size_t timestamp)
+        : impl_vector_array(ctx, uri, num_vectors, timestamp) {
     }
     vector_array_impl(
         const tiledb::Context& ctx,
         const std::string& uri,
         const std::string& ids_uri,
-        size_t num_vectors)
-        : impl_vector_array(ctx, uri, ids_uri, num_vectors) {
+        size_t num_vectors,
+        size_t timestamp)
+        : impl_vector_array(ctx, uri, ids_uri, num_vectors, timestamp) {
     }
     vector_array_impl(size_t rows, size_t cols)
         : impl_vector_array(rows, cols) {
@@ -273,39 +282,23 @@ class FeatureVectorArray {
   };
 
  private:
-  using col_major_matrix_constructor_function =
-      std::function<std::unique_ptr<vector_array_base>(size_t, size_t)>;
-  using col_major_matrix_table_type =
-      std::map<tiledb_datatype_t, col_major_matrix_constructor_function>;
+  // clang-format off
+  using col_major_matrix_constructor_function = std::function<std::unique_ptr<vector_array_base>(size_t, size_t)>;
+  using col_major_matrix_table_type = std::map<tiledb_datatype_t, col_major_matrix_constructor_function>;
   static const col_major_matrix_table_type col_major_matrix_dispatch_table;
 
-  using tdb_col_major_matrix_constructor_function =
-      std::function<std::unique_ptr<vector_array_base>(
-          const tiledb::Context&, const std::string&, size_t)>;
-  using tdb_col_major_matrix_table_type =
-      std::map<tiledb_datatype_t, tdb_col_major_matrix_constructor_function>;
-  static const tdb_col_major_matrix_table_type
-      tdb_col_major_matrix_dispatch_table;
+  using tdb_col_major_matrix_constructor_function = std::function<std::unique_ptr<vector_array_base>(const tiledb::Context&, const std::string&, size_t, size_t)>;
+  using tdb_col_major_matrix_table_type = std::map<tiledb_datatype_t, tdb_col_major_matrix_constructor_function>;
+  static const tdb_col_major_matrix_table_type tdb_col_major_matrix_dispatch_table;
 
-  using col_major_matrix_with_ids_constructor_function =
-      std::function<std::unique_ptr<vector_array_base>(size_t, size_t)>;
-  using col_major_matrix_with_ids_table_type = std::map<
-      std::tuple<tiledb_datatype_t, tiledb_datatype_t>,
-      col_major_matrix_with_ids_constructor_function>;
-  static const col_major_matrix_with_ids_table_type
-      col_major_matrix_with_ids_dispatch_table;
+  using col_major_matrix_with_ids_constructor_function = std::function<std::unique_ptr<vector_array_base>(size_t, size_t)>;
+  using col_major_matrix_with_ids_table_type = std::map<std::tuple<tiledb_datatype_t, tiledb_datatype_t>, col_major_matrix_with_ids_constructor_function>;
+  static const col_major_matrix_with_ids_table_type col_major_matrix_with_ids_dispatch_table;
 
-  using tdb_col_major_matrix_with_ids_constructor_function =
-      std::function<std::unique_ptr<vector_array_base>(
-          const tiledb::Context&,
-          const std::string&,
-          const std::string&,
-          size_t)>;
-  using tdb_col_major_matrix_with_ids_table_type = std::map<
-      std::tuple<tiledb_datatype_t, tiledb_datatype_t>,
-      tdb_col_major_matrix_with_ids_constructor_function>;
-  static const tdb_col_major_matrix_with_ids_table_type
-      tdb_col_major_matrix_with_ids_dispatch_table;
+  using tdb_col_major_matrix_with_ids_constructor_function = std::function<std::unique_ptr<vector_array_base>(const tiledb::Context&, const std::string&, const std::string&, size_t, size_t)>;
+  using tdb_col_major_matrix_with_ids_table_type = std::map<std::tuple<tiledb_datatype_t, tiledb_datatype_t>, tdb_col_major_matrix_with_ids_constructor_function>;
+  static const tdb_col_major_matrix_with_ids_table_type tdb_col_major_matrix_with_ids_dispatch_table;
+  // clang-format on
 
   tiledb_datatype_t feature_type_{TILEDB_ANY};
   size_t feature_size_{0};
@@ -317,94 +310,25 @@ class FeatureVectorArray {
   std::unique_ptr</*const*/ vector_array_base> vector_array;
 };
 
-const FeatureVectorArray::col_major_matrix_table_type
-    FeatureVectorArray::col_major_matrix_dispatch_table = {
-        {TILEDB_FLOAT32,
-         [](size_t rows, size_t cols) {
-           return std::make_unique<
-               FeatureVectorArray::vector_array_impl<ColMajorMatrix<float>>>(
-               rows, cols);
-         }},
-        {TILEDB_UINT8,
-         [](size_t rows, size_t cols) {
-           return std::make_unique<
-               FeatureVectorArray::vector_array_impl<ColMajorMatrix<uint8_t>>>(
-               rows, cols);
-         }},
-        {TILEDB_INT32,
-         [](size_t rows, size_t cols) {
-           return std::make_unique<
-               FeatureVectorArray::vector_array_impl<ColMajorMatrix<int32_t>>>(
-               rows, cols);
-         }},
-        {TILEDB_UINT32,
-         [](size_t rows, size_t cols) {
-           return std::make_unique<
-               FeatureVectorArray::vector_array_impl<ColMajorMatrix<uint32_t>>>(
-               rows, cols);
-         }},
-        {TILEDB_INT64,
-         [](size_t rows, size_t cols) {
-           return std::make_unique<
-               FeatureVectorArray::vector_array_impl<ColMajorMatrix<int64_t>>>(
-               rows, cols);
-         }},
-        {TILEDB_UINT64,
-         [](size_t rows, size_t cols) {
-           return std::make_unique<
-               FeatureVectorArray::vector_array_impl<ColMajorMatrix<uint64_t>>>(
-               rows, cols);
-         }},
-};
-
-const FeatureVectorArray::tdb_col_major_matrix_table_type
-    FeatureVectorArray::tdb_col_major_matrix_dispatch_table = {
-        {TILEDB_FLOAT32,
-         [](const tiledb::Context& ctx,
-            const std::string& uri,
-            size_t num_vectors) {
-           return std::make_unique<
-               FeatureVectorArray::vector_array_impl<tdbColMajorMatrix<float>>>(
-               ctx, uri, num_vectors);
-         }},
-        {TILEDB_UINT8,
-         [](const tiledb::Context& ctx,
-            const std::string& uri,
-            size_t num_vectors) {
-           return std::make_unique<FeatureVectorArray::vector_array_impl<
-               tdbColMajorMatrix<uint8_t>>>(ctx, uri, num_vectors);
-         }},
-        {TILEDB_INT32,
-         [](const tiledb::Context& ctx,
-            const std::string& uri,
-            size_t num_vectors) {
-           return std::make_unique<FeatureVectorArray::vector_array_impl<
-               tdbColMajorMatrix<int32_t>>>(ctx, uri, num_vectors);
-         }},
-        {TILEDB_UINT32,
-         [](const tiledb::Context& ctx,
-            const std::string& uri,
-            size_t num_vectors) {
-           return std::make_unique<FeatureVectorArray::vector_array_impl<
-               tdbColMajorMatrix<uint32_t>>>(ctx, uri, num_vectors);
-         }},
-        {TILEDB_INT64,
-         [](const tiledb::Context& ctx,
-            const std::string& uri,
-            size_t num_vectors) {
-           return std::make_unique<FeatureVectorArray::vector_array_impl<
-               tdbColMajorMatrix<int64_t>>>(ctx, uri, num_vectors);
-         }},
-        {TILEDB_UINT64,
-         [](const tiledb::Context& ctx,
-            const std::string& uri,
-            size_t num_vectors) {
-           return std::make_unique<FeatureVectorArray::vector_array_impl<
-               tdbColMajorMatrix<uint64_t>>>(ctx, uri, num_vectors);
-         }},
-};
-
 // clang-format off
+const FeatureVectorArray::col_major_matrix_table_type FeatureVectorArray::col_major_matrix_dispatch_table = {
+  {TILEDB_FLOAT32, [](size_t rows, size_t cols) { return std::make_unique<FeatureVectorArray::vector_array_impl<ColMajorMatrix<float   >>>(rows, cols);}},
+  {TILEDB_UINT8,   [](size_t rows, size_t cols) { return std::make_unique<FeatureVectorArray::vector_array_impl<ColMajorMatrix<uint8_t >>>(rows, cols);}},
+  {TILEDB_INT32,   [](size_t rows, size_t cols) { return std::make_unique<FeatureVectorArray::vector_array_impl<ColMajorMatrix<int32_t >>>(rows, cols);}},
+  {TILEDB_UINT32,  [](size_t rows, size_t cols) { return std::make_unique<FeatureVectorArray::vector_array_impl<ColMajorMatrix<uint32_t>>>(rows, cols);}},
+  {TILEDB_INT64,   [](size_t rows, size_t cols) { return std::make_unique<FeatureVectorArray::vector_array_impl<ColMajorMatrix<int64_t >>>(rows, cols);}},
+  {TILEDB_UINT64,  [](size_t rows, size_t cols) { return std::make_unique<FeatureVectorArray::vector_array_impl<ColMajorMatrix<uint64_t>>>(rows, cols);}},
+};
+
+const FeatureVectorArray::tdb_col_major_matrix_table_type FeatureVectorArray::tdb_col_major_matrix_dispatch_table = {
+  {TILEDB_FLOAT32, [](const tiledb::Context& ctx, const std::string& uri, size_t num_vectors, size_t timestamp) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrix<float   >>>(ctx, uri, num_vectors, timestamp); }},
+  {TILEDB_UINT8,   [](const tiledb::Context& ctx, const std::string& uri, size_t num_vectors, size_t timestamp) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrix<uint8_t >>>(ctx, uri, num_vectors, timestamp); }},
+  {TILEDB_INT32,   [](const tiledb::Context& ctx, const std::string& uri, size_t num_vectors, size_t timestamp) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrix<int32_t >>>(ctx, uri, num_vectors, timestamp); }},
+  {TILEDB_UINT32,  [](const tiledb::Context& ctx, const std::string& uri, size_t num_vectors, size_t timestamp) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrix<uint32_t>>>(ctx, uri, num_vectors, timestamp); }},
+  {TILEDB_INT64,   [](const tiledb::Context& ctx, const std::string& uri, size_t num_vectors, size_t timestamp) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrix<int64_t >>>(ctx, uri, num_vectors, timestamp); }},
+  {TILEDB_UINT64,  [](const tiledb::Context& ctx, const std::string& uri, size_t num_vectors, size_t timestamp) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrix<uint64_t>>>(ctx, uri, num_vectors, timestamp); }},
+};
+
 const FeatureVectorArray::col_major_matrix_with_ids_table_type FeatureVectorArray::col_major_matrix_with_ids_dispatch_table = {
   {{TILEDB_FLOAT32, TILEDB_UINT32},[](size_t rows, size_t cols) { return std::make_unique<FeatureVectorArray::vector_array_impl<ColMajorMatrixWithIds<float,    uint32_t>>>(rows, cols); }},
   {{TILEDB_UINT8,   TILEDB_UINT32},[](size_t rows, size_t cols) { return std::make_unique<FeatureVectorArray::vector_array_impl<ColMajorMatrixWithIds<uint8_t,  uint32_t>>>(rows, cols); }},
@@ -422,19 +346,19 @@ const FeatureVectorArray::col_major_matrix_with_ids_table_type FeatureVectorArra
 };
 
 const FeatureVectorArray::tdb_col_major_matrix_with_ids_table_type FeatureVectorArray::tdb_col_major_matrix_with_ids_dispatch_table = {
-  {{TILEDB_FLOAT32, TILEDB_UINT32},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<float,    uint32_t>>>(ctx, uri, ids_uri, num_vectors);}},
-  {{TILEDB_UINT8,   TILEDB_UINT32},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<uint8_t,  uint32_t>>>(ctx, uri, ids_uri, num_vectors);}},
-  {{TILEDB_INT32,   TILEDB_UINT32},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<int32_t,  uint32_t>>>(ctx, uri, ids_uri, num_vectors);}},
-  {{TILEDB_UINT32,  TILEDB_UINT32},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<uint32_t, uint32_t>>>(ctx, uri, ids_uri, num_vectors);}},
-  {{TILEDB_INT64,   TILEDB_UINT32},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<int64_t,  uint32_t>>>(ctx, uri, ids_uri, num_vectors);}},
-  {{TILEDB_UINT64,  TILEDB_UINT32},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<uint64_t, uint32_t>>>(ctx, uri, ids_uri, num_vectors);}},
+  {{TILEDB_FLOAT32, TILEDB_UINT32},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors, size_t timestamp) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<float,    uint32_t>>>(ctx, uri, ids_uri, num_vectors, timestamp);}},
+  {{TILEDB_UINT8,   TILEDB_UINT32},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors, size_t timestamp) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<uint8_t,  uint32_t>>>(ctx, uri, ids_uri, num_vectors, timestamp);}},
+  {{TILEDB_INT32,   TILEDB_UINT32},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors, size_t timestamp) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<int32_t,  uint32_t>>>(ctx, uri, ids_uri, num_vectors, timestamp);}},
+  {{TILEDB_UINT32,  TILEDB_UINT32},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors, size_t timestamp) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<uint32_t, uint32_t>>>(ctx, uri, ids_uri, num_vectors, timestamp);}},
+  {{TILEDB_INT64,   TILEDB_UINT32},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors, size_t timestamp) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<int64_t,  uint32_t>>>(ctx, uri, ids_uri, num_vectors, timestamp);}},
+  {{TILEDB_UINT64,  TILEDB_UINT32},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors, size_t timestamp) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<uint64_t, uint32_t>>>(ctx, uri, ids_uri, num_vectors, timestamp);}},
 
-  {{TILEDB_FLOAT32, TILEDB_UINT64},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<float,    uint64_t>>>(ctx, uri, ids_uri, num_vectors);}},
-  {{TILEDB_UINT8,   TILEDB_UINT64},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<uint8_t,  uint64_t>>>(ctx, uri, ids_uri, num_vectors);}},
-  {{TILEDB_INT32,   TILEDB_UINT64},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<int32_t,  uint64_t>>>(ctx, uri, ids_uri, num_vectors);}},
-  {{TILEDB_UINT32,  TILEDB_UINT64},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<uint32_t, uint64_t>>>(ctx, uri, ids_uri, num_vectors);}},
-  {{TILEDB_INT64,   TILEDB_UINT64},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<int64_t,  uint64_t>>>(ctx, uri, ids_uri, num_vectors);}},
-  {{TILEDB_UINT64,  TILEDB_UINT64},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<uint64_t, uint64_t>>>(ctx, uri, ids_uri, num_vectors);}},
+  {{TILEDB_FLOAT32, TILEDB_UINT64},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors, size_t timestamp) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<float,    uint64_t>>>(ctx, uri, ids_uri, num_vectors, timestamp);}},
+  {{TILEDB_UINT8,   TILEDB_UINT64},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors, size_t timestamp) { return std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<uint8_t,  uint64_t>>>(ctx, uri, ids_uri, num_vectors, timestamp);}},
+  {{TILEDB_INT32,   TILEDB_UINT64},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors, size_t timestamp) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<int32_t,  uint64_t>>>(ctx, uri, ids_uri, num_vectors, timestamp);}},
+  {{TILEDB_UINT32,  TILEDB_UINT64},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors, size_t timestamp) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<uint32_t, uint64_t>>>(ctx, uri, ids_uri, num_vectors, timestamp);}},
+  {{TILEDB_INT64,   TILEDB_UINT64},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors, size_t timestamp) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<int64_t,  uint64_t>>>(ctx, uri, ids_uri, num_vectors, timestamp);}},
+  {{TILEDB_UINT64,  TILEDB_UINT64},[](const tiledb::Context& ctx, const std::string& uri, const std::string& ids_uri, size_t num_vectors, size_t timestamp) {return  std::make_unique<FeatureVectorArray::vector_array_impl<tdbColMajorMatrixWithIds<uint64_t, uint64_t>>>(ctx, uri, ids_uri, num_vectors, timestamp);}},
 };
 // clang-format on
 

--- a/src/include/test/unit_api_feature_vector_array.cc
+++ b/src/include/test/unit_api_feature_vector_array.cc
@@ -35,6 +35,7 @@
 #include "array_defs.h"
 #include "catch2/catch_all.hpp"
 #include "detail/ivf/qv.h"
+#include "index/index_defs.h"
 #include "query_common.h"
 #include "tdb_defs.h"
 #include "test/test_utils.h"
@@ -544,4 +545,137 @@ TEST_CASE("api: load empty matrix", "[api][index]") {
       ctx, tmp_matrix_uri, dimension, domain, dimension, tile_extent);
 
   auto X = FeatureVectorArray(ctx, tmp_matrix_uri);
+}
+
+TEST_CASE("api: read at timestamp", "[api]") {
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
+
+  std::string feature_vectors_uri =
+      (std::filesystem::temp_directory_path() / "temp_feature_vectors_uri")
+          .string();
+  std::string ids_uri =
+      (std::filesystem::temp_directory_path() / "temp_ids_uri").string();
+  if (vfs.is_dir(feature_vectors_uri)) {
+    vfs.remove_dir(feature_vectors_uri);
+  }
+  if (vfs.is_dir(ids_uri)) {
+    vfs.remove_dir(ids_uri);
+  }
+
+  auto dimension = 3;
+
+  using FeatureType = float;
+  using IdsType = uint32_t;
+
+  int32_t default_domain{std::numeric_limits<int32_t>::max() - 1};
+  int32_t default_tile_extent{100'000};
+  int32_t tile_size_bytes{64 * 1024 * 1024};
+  tiledb_filter_type_t default_compression{string_to_filter(
+      storage_formats[current_storage_version]["default_attr_filters"])};
+  int32_t tile_size{
+      (int32_t)(tile_size_bytes / sizeof(FeatureType) / dimension)};
+
+  // First we create the empty vectors matrix and the ids vector.
+  {
+    create_empty_for_matrix<FeatureType, stdx::layout_left>(
+        ctx,
+        feature_vectors_uri,
+        dimension,
+        default_domain,
+        dimension,
+        default_tile_extent,
+        default_compression);
+
+    create_empty_for_vector<IdsType>(
+        ctx, ids_uri, default_domain, tile_size, default_compression);
+  }
+
+  // Write to them at timestamp 99.
+  {
+    size_t timestamp = 99;
+    auto matrix_with_ids = ColMajorMatrixWithIds<FeatureType, IdsType>{
+        {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}, {1, 2, 3, 4}};
+
+    write_matrix(
+        ctx, matrix_with_ids, feature_vectors_uri, 0, false, timestamp);
+
+    write_vector(ctx, matrix_with_ids.ids(), ids_uri, 0, false, timestamp);
+  }
+
+  // Read the data and validate our initial write worked.
+  {
+    auto feature_vector_array =
+        FeatureVectorArray(ctx, feature_vectors_uri, ids_uri);
+    auto data = MatrixView<FeatureType, stdx::layout_left>{
+        (FeatureType*)feature_vector_array.data(),
+        extents(feature_vector_array)[0],
+        extents(feature_vector_array)[1]};
+    auto ids = std::span<IdsType>(
+        (IdsType*)feature_vector_array.ids_data(),
+        feature_vector_array.num_vectors());
+    auto expected_ids = {1, 2, 3, 4};
+    CHECK(std::equal(ids.begin(), ids.end(), expected_ids.begin()));
+    CHECK(ids.size() == 4);
+    for (size_t i = 0; i < ids.size(); ++i) {
+      for (size_t j = 0; j < dimension; ++j) {
+        CHECK(data(j, i) == i + 1);
+      }
+    }
+  }
+
+  // Write to them at timestamp 100.
+  {
+    size_t timestamp = 100;
+    auto matrix_with_ids = ColMajorMatrixWithIds<FeatureType, IdsType>{
+        {{11, 11, 11}, {22, 22, 22}, {33, 33, 33}, {44, 44, 44}},
+        {11, 22, 33, 44}};
+
+    write_matrix(
+        ctx, matrix_with_ids, feature_vectors_uri, 0, false, timestamp);
+
+    write_vector(ctx, matrix_with_ids.ids(), ids_uri, 0, false, timestamp);
+  }
+
+  // Read the data and validate we read at timestamp 100 by default.
+  {
+    auto feature_vector_array =
+        FeatureVectorArray(ctx, feature_vectors_uri, ids_uri);
+    auto data = MatrixView<FeatureType, stdx::layout_left>{
+        (FeatureType*)feature_vector_array.data(),
+        extents(feature_vector_array)[0],
+        extents(feature_vector_array)[1]};
+    auto ids = std::span<IdsType>(
+        (IdsType*)feature_vector_array.ids_data(),
+        feature_vector_array.num_vectors());
+    auto expected_ids = {11, 22, 33, 44};
+    CHECK(std::equal(ids.begin(), ids.end(), expected_ids.begin()));
+    CHECK(ids.size() == 4);
+    for (size_t i = 0; i < ids.size(); ++i) {
+      for (size_t j = 0; j < dimension; ++j) {
+        CHECK(data(j, i) == (i + 1) * 11);
+      }
+    }
+  }
+
+  // Read the data at timestamp 99 explicitly.
+  {
+    auto feature_vector_array =
+        FeatureVectorArray(ctx, feature_vectors_uri, ids_uri, 0, 99);
+    auto data = MatrixView<FeatureType, stdx::layout_left>{
+        (FeatureType*)feature_vector_array.data(),
+        extents(feature_vector_array)[0],
+        extents(feature_vector_array)[1]};
+    auto ids = std::span<IdsType>(
+        (IdsType*)feature_vector_array.ids_data(),
+        feature_vector_array.num_vectors());
+    auto expected_ids = {1, 2, 3, 4};
+    CHECK(std::equal(ids.begin(), ids.end(), expected_ids.begin()));
+    CHECK(ids.size() == 4);
+    for (size_t i = 0; i < ids.size(); ++i) {
+      for (size_t j = 0; j < dimension; ++j) {
+        CHECK(data(j, i) == i + 1);
+      }
+    }
+  }
 }


### PR DESCRIPTION
### What
Here we update `FeatureVectorArray` so that it can read from URIs at a specified timestamp. This will be used to update the type-erased Vamana index so that it can be opened at a specific timestamp.

### Testing
* Adds a new unit test which writes at timestamp 99 and 100 and then validates by default we read at timestamp 100 but we can also explicitly read at timestamp 99.