### PR TITLE
Update `matrix_with_ids` to hold a `unique_ptr` with an ids array instead of a `std::vector`

### DIFF
--- a/src/include/api/feature_vector_array.h
+++ b/src/include/api/feature_vector_array.h
@@ -259,7 +259,7 @@ class FeatureVectorArray {
       return _cpo::num_ids(impl_vector_array);
     }
     [[nodiscard]] const void* ids_data() const override {
-      return _cpo::ids(impl_vector_array).data();
+      return _cpo::ids(impl_vector_array);
     }
     [[nodiscard]] size_t dimension() const override {
       return _cpo::dimension(impl_vector_array);

--- a/src/include/cpos.h
+++ b/src/include/cpos.h
@@ -286,19 +286,10 @@ struct _fn {
     return t.ids();
   }
 
-  // @todo Warning: This returns a temporary object, which can cause
-  // Bad Things to happen because the caller can't count on being able
-  // to do anything with the result.  Recommend returning std::optional
-  // or defining something static (note that defining a static inside
-  // a constexpr is only in C++23.  Or maybe use a concept to
-  // remove ids() from the type-erased function altogether (that might
-  // be best).
-  //
-  // This also generates huge numbers of warnings.
   template <class T>
     requires(!_member_ids<T>)
   constexpr const auto& operator()(T&& t) const noexcept {
-    return std::vector<typename std::remove_cvref_t<T>::value_type>{};
+    return nullptr;
   }
 };
 }  // namespace _ids

--- a/src/include/detail/linalg/matrix.h
+++ b/src/include/detail/linalg/matrix.h
@@ -155,8 +155,6 @@ class Matrix : public stdx::mdspan<T, matrix_extents<I>, LayoutPolicy> {
  protected:
   size_type num_rows_{0};
   size_type num_cols_{0};
-
-  // private:
   std::unique_ptr<T[]> storage_;
 
  public:

--- a/src/include/detail/linalg/tdb_matrix.h
+++ b/src/include/detail/linalg/tdb_matrix.h
@@ -302,7 +302,8 @@ class tdbBlockedMatrix : public MatrixBase {
             MatrixBase,
             MatrixWithIds<T, typename Base::ids_type, LayoutPolicy, I>>::
             value) {
-      auto ids = std::vector<typename MatrixBase::ids_type>(load_blocksize_);
+      auto ids = std::unique_ptr<typename MatrixBase::ids_type[]>(
+          new typename MatrixBase::ids_type[load_blocksize_]);
       Base::operator=(
           Base{std::move(data_), std::move(ids), dimension, load_blocksize_});
     } else {

--- a/src/include/detail/linalg/tdb_matrix_with_ids.h
+++ b/src/include/detail/linalg/tdb_matrix_with_ids.h
@@ -200,12 +200,12 @@ class tdbBlockedMatrixWithIds
         0, (int)this->first_resident_col_, (int)this->last_resident_col_ - 1);
 
     auto layout_order = ids_schema_.cell_order();
-    this->ids().resize(elements_to_load * dimension);
+
     // Create a query
     tiledb::Query query(this->ctx_, *ids_array_);
     query.set_subarray(subarray)
         .set_layout(layout_order)
-        .set_data_buffer(attr_name, this->ids());
+        .set_data_buffer(attr_name, this->ids(), elements_to_load * dimension);
     tiledb_helpers::submit_query(tdb_func__, ids_uri_, query);
     _memory_data.insert_entry(
         tdb_func__, elements_to_load * dimension * sizeof(T));

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -620,7 +620,7 @@ class vamana_index {
     std::copy(
         training_set_ids.begin(),
         training_set_ids.end(),
-        feature_vectors_.ids().begin());
+        feature_vectors_.ids());
 
     dimension_ = ::dimension(feature_vectors_);
     num_vectors_ = ::num_vectors(feature_vectors_);
@@ -902,7 +902,7 @@ class vamana_index {
 
     write_vector(
         ctx,
-        feature_vectors_.ids(),
+        feature_vectors_.raveled_ids(),
         write_group.ids_uri(),
         0,
         false,

--- a/src/include/test/gen_graphs.h
+++ b/src/include/test/gen_graphs.h
@@ -49,7 +49,7 @@ auto random_geometric_2D(size_t N) {
   std::uniform_real_distribution<float> coord(-1.0, 1.0);
 
   auto X = ColMajorMatrixWithIds<float>(2, N);
-  std::iota(X.ids().begin(), X.ids().end(), 0);
+  std::iota(X.ids(), X.ids() + X.num_ids(), 0);
   for (size_t i = 0; i < N; ++i) {
     X(0, i) = coord(gen);
     X(1, i) = coord(gen);
@@ -87,7 +87,7 @@ auto gen_uni_grid(size_t M, size_t N) {
   edges.reserve(nedges);
 
   auto vec_array = ColMajorMatrixWithIds<float>(dim, nvectors);
-  std::iota(vec_array.ids().begin(), vec_array.ids().end(), 0);
+  std::iota(vec_array.ids(), vec_array.ids() + vec_array.num_ids(), 0);
 
   for (size_t i = 0; i < M; ++i) {
     for (size_t j = 0; j < N; ++j) {
@@ -119,7 +119,7 @@ auto gen_bi_grid(size_t M, size_t N) {
   edges.reserve(nedges);
 
   auto vec_array = ColMajorMatrixWithIds<float>(dim, nvectors);
-  std::iota(vec_array.ids().begin(), vec_array.ids().end(), 0);
+  std::iota(vec_array.ids(), vec_array.ids() + vec_array.num_ids(), 0);
 
   for (size_t i = 0; i < M; ++i) {
     for (size_t j = 0; j < N; ++j) {
@@ -209,7 +209,7 @@ auto normalize_matrix(
   auto max = *max_loc;
 
   auto to = ColMajorMatrixWithIds<T>(from.num_rows(), from.num_cols());
-  std::copy(from.ids().begin(), from.ids().end(), to.ids().begin());
+  std::copy(from.ids(), from.ids() + from.num_ids(), to.ids());
   for (size_t i = 0; i < from.num_rows(); ++i) {
     for (size_t j = 0; j < from.num_cols(); ++j) {
       auto foo = from(i, j) - min;
@@ -236,7 +236,7 @@ auto build_hypercube(size_t k_near, size_t k_far, size_t seed = 0) {
   std::uniform_int_distribution<int> heads(0, 1);
 
   ColMajorMatrixWithIds<float> nn_hypercube(3, N + 1);
-  std::iota(nn_hypercube.ids().begin(), nn_hypercube.ids().end(), 0);
+  std::iota(nn_hypercube.ids(), nn_hypercube.ids() + nn_hypercube.num_ids(), 0);
   size_t n{0};
   nn_hypercube(0, n) = 0;
   nn_hypercube(1, n) = 0;

--- a/src/include/test/test_utils.h
+++ b/src/include/test/test_utils.h
@@ -100,13 +100,13 @@ void fill_and_write_matrix(
     vfs.remove_dir(ids_uri);
   }
   std::iota(X.data(), X.data() + dimension(X) * num_vectors(X), offset);
-  std::iota(X.ids().begin(), X.ids().end(), offset);
+  std::iota(X.ids(), X.ids() + X.num_ids(), offset);
 
   // Write the vectors to their URI.
   write_matrix(ctx, X, uri);
 
   // Write the IDs to their URI.
-  write_vector(ctx, X.ids(), ids_uri);
+  write_vector(ctx, X.raveled_ids(), ids_uri);
 }
 
 void validate_metadata(

--- a/src/include/test/unit_api_feature_vector_array.cc
+++ b/src/include/test/unit_api_feature_vector_array.cc
@@ -260,7 +260,7 @@ TEST_CASE("api: MatrixWithIds constructors and destructors", "[api]") {
 
     auto a = ColMajorMatrixWithIds<DataType, IdsType>(rows, cols);
     std::iota(a.data(), a.data() + rows * cols, 0);
-    std::iota(a.ids().begin(), a.ids().end(), 0);
+    std::iota(a.ids(), a.ids() + a.num_ids(), 0);
     auto b = FeatureVectorArray(a);
 
     CHECK(b.dimension() == rows);
@@ -298,17 +298,17 @@ TEST_CASE("api: MatrixWithIds constructors and destructors", "[api]") {
 
     auto a = ColMajorMatrixWithIds<DataType, IdsType>(rows, cols);
     std::iota(a.data(), a.data() + rows * cols, 0);
-    std::iota(a.ids().begin(), a.ids().end(), 0);
+    std::iota(a.ids(), a.ids() + a.num_ids(), 0);
 
     auto a_ptr = a.data();
-    auto a_ptr_ids = a.ids().data();
+    auto a_ptr_ids = a.ids();
 
     auto b = FeatureVectorArray(std::move(a));
 
     CHECK(a_ptr == b.data());
     CHECK(a_ptr_ids == b.ids_data());
     CHECK(a.data() == nullptr);
-    CHECK(a.ids().data() == nullptr);
+    CHECK(a.ids() == nullptr);
 
     CHECK(b.dimension() == rows);
     CHECK(dimension(b) == rows);
@@ -605,7 +605,7 @@ TEST_CASE("api: temporal_policy", "[api]") {
         ctx, matrix_with_ids, feature_vectors_uri, 0, false, temporal_policy);
 
     write_vector(
-        ctx, matrix_with_ids.ids(), ids_uri, 0, false, temporal_policy);
+        ctx, matrix_with_ids.raveled_ids(), ids_uri, 0, false, temporal_policy);
   }
 
   // Read the data and validate our initial write worked.
@@ -640,7 +640,7 @@ TEST_CASE("api: temporal_policy", "[api]") {
         ctx, matrix_with_ids, feature_vectors_uri, 0, false, temporal_policy);
 
     write_vector(
-        ctx, matrix_with_ids.ids(), ids_uri, 0, false, temporal_policy);
+        ctx, matrix_with_ids.raveled_ids(), ids_uri, 0, false, temporal_policy);
   }
 
   // Read the data and validate we read at temporal_policy 100 by default.

--- a/src/include/test/unit_tdb_matrix_with_ids.cc
+++ b/src/include/test/unit_tdb_matrix_with_ids.cc
@@ -77,10 +77,10 @@ TEMPLATE_TEST_CASE(
       CHECK(X(i, j) == Y(i, j));
     }
   }
-  CHECK(size(Y.ids()) == Y.num_ids());
-  CHECK(size(X.ids()) == size(Y.ids()));
+  CHECK(size(Y.raveled_ids()) == Y.num_ids());
+  CHECK(size(X.raveled_ids()) == size(Y.raveled_ids()));
   CHECK(X.num_ids() == Y.num_ids());
-  CHECK(std::equal(X.ids().begin(), X.ids().end(), Y.ids().begin()));
+  CHECK(std::equal(X.ids(), X.ids() + X.num_ids(), Y.ids()));
   for (size_t i = 0; i < X.num_ids(); ++i) {
     CHECK(X.ids()[i] == Y.ids()[i]);
   }
@@ -96,10 +96,10 @@ TEMPLATE_TEST_CASE(
     }
   }
 
-  CHECK(size(Z.ids()) == Z.num_ids());
-  CHECK(size(X.ids()) == size(Z.ids()));
+  CHECK(size(Z.raveled_ids()) == Z.num_ids());
+  CHECK(size(X.raveled_ids()) == size(Z.raveled_ids()));
   CHECK(X.num_ids() == Z.num_ids());
-  CHECK(std::equal(X.ids().begin(), X.ids().end(), Z.ids().begin()));
+  CHECK(std::equal(X.ids(), X.ids() + X.num_ids(), Z.ids()));
   for (size_t i = 0; i < X.num_ids(); ++i) {
     CHECK(X.ids()[i] == Z.ids()[i]);
   }
@@ -136,10 +136,11 @@ TEST_CASE("tdb_matrix_with_ids: different types", "[tdb_matrix_with_ids]") {
       CHECK(X(i, j) == Y(i, j));
     }
   }
-  CHECK(size(Y.ids()) == Y.num_ids());
-  CHECK(size(X.ids()) == size(Y.ids()));
+  CHECK(Y.num_ids() == Y.num_ids());
+  CHECK(size(Y.raveled_ids()) == Y.num_ids());
+  CHECK(size(X.raveled_ids()) == size(Y.raveled_ids()));
   CHECK(X.num_ids() == Y.num_ids());
-  CHECK(std::equal(X.ids().begin(), X.ids().end(), Y.ids().begin()));
+  CHECK(std::equal(X.ids(), X.ids() + X.num_ids(), Y.ids()));
   for (size_t i = 0; i < X.num_ids(); ++i) {
     CHECK(X.ids()[i] == Y.ids()[i]);
   }
@@ -165,7 +166,7 @@ TEMPLATE_TEST_CASE(
   CHECK(X.ids()[0] == offset + 0);
   CHECK(X.ids()[1] == offset + 1);
   CHECK(X.ids()[10] == offset + 10);
-  CHECK(size(X.ids()) == Ncols);
+  CHECK(size(X.raveled_ids()) == Ncols);
 
   auto B = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
   {
@@ -178,7 +179,7 @@ TEMPLATE_TEST_CASE(
   auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
       ctx, tmp_matrix_uri, tmp_ids_uri);
   Y.load();
-  CHECK(size(Y.ids()) == size(X.ids()));
+  CHECK(size(Y.raveled_ids()) == size(X.raveled_ids()));
   CHECK(num_vectors(Y) == num_vectors(X));
   CHECK(dimension(Y) == dimension(X));
   CHECK(
@@ -205,7 +206,7 @@ TEMPLATE_TEST_CASE(
 
   auto A = ColMajorMatrixWithIds<TestType, TestType, size_t>(0, 0);
   A = std::move(Z);
-  CHECK(size(A.ids()) == size(X.ids()));
+  CHECK(size(A.raveled_ids()) == size(X.raveled_ids()));
   CHECK(num_vectors(A) == num_vectors(X));
   CHECK(dimension(A) == dimension(X));
   CHECK(
@@ -216,7 +217,7 @@ TEMPLATE_TEST_CASE(
     }
   }
 
-  CHECK(size(B.ids()) == size(X.ids()));
+  CHECK(size(B.raveled_ids()) == size(X.raveled_ids()));
   CHECK(num_vectors(B) == num_vectors(X));
   CHECK(dimension(B) == dimension(X));
   CHECK(
@@ -289,7 +290,7 @@ TEST_CASE("tdb_matrix_with_ids: empty matrix", "[tdb_matrix_with_ids]") {
     CHECK(dimension(X) == 0);
 
     CHECK(X.num_ids() == 0);
-    CHECK(X.ids().size() == 0);
+    CHECK(X.raveled_ids().size() == 0);
   }
 
   {
@@ -301,7 +302,7 @@ TEST_CASE("tdb_matrix_with_ids: empty matrix", "[tdb_matrix_with_ids]") {
     CHECK(X.num_rows() == 0);
     CHECK(dimension(X) == 0);
     CHECK(X.num_ids() == 0);
-    CHECK(X.ids().size() == 0);
+    CHECK(X.raveled_ids().size() == 0);
   }
 }
 
@@ -340,10 +341,10 @@ TEMPLATE_TEST_CASE(
     }
   }
 
-  CHECK(size(Y.ids()) == Y.num_ids());
-  CHECK(size(X.ids()) == X.num_ids());
+  CHECK(size(Y.raveled_ids()) == Y.num_ids());
+  CHECK(size(X.raveled_ids()) == X.num_ids());
   CHECK(X.num_ids() == Y.num_ids());
-  CHECK(std::equal(X.ids().begin(), X.ids().end(), Y.ids().begin()));
+  CHECK(std::equal(X.ids(), X.ids() + X.num_ids(), Y.ids()));
   for (size_t i = 0; i < X.num_ids(); ++i) {
     CHECK(X.ids()[i] == Y.ids()[i]);
   }
@@ -361,9 +362,9 @@ TEMPLATE_TEST_CASE(
     }
   }
 
-  CHECK(size(Z.ids()) == Z.num_ids());
+  CHECK(size(Z.raveled_ids()) == Z.num_ids());
   CHECK(X.num_ids() == Z.num_ids());
-  CHECK(std::equal(X.ids().begin(), X.ids().end(), Z.ids().begin()));
+  CHECK(std::equal(X.ids(), X.ids() + X.num_ids(), Z.ids()));
   for (size_t i = 0; i < X.num_ids(); ++i) {
     CHECK(X.ids()[i] == Z.ids()[i]);
   }

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -249,7 +249,7 @@ TEST_CASE("vamana: small greedy search", "[vamana]") {
   REQUIRE(ndim == 128);
 
   auto x = ColMajorMatrixWithIds<float>(ndim, npoints);
-  std::iota(x.ids().begin(), x.ids().end(), 0);
+  std::iota(x.ids(), x.ids() + x.num_ids(), 0);
 
   binary_file.read((char*)x.data(), npoints * ndim * sizeof(float));
   binary_file.close();
@@ -641,7 +641,7 @@ TEST_CASE("vamana: diskann fbin", "[vamana]") {
   REQUIRE(ndim == 128);
 
   auto x = ColMajorMatrixWithIds<float>(ndim, npoints);
-  std::iota(x.ids().begin(), x.ids().end(), 0);
+  std::iota(x.ids(), x.ids() + x.num_ids(), 0);
 
   binary_file.read((char*)x.data(), npoints * ndim);
   binary_file.close();

--- a/src/include/test/unit_vamana_metadata.cc
+++ b/src/include/test/unit_vamana_metadata.cc
@@ -83,7 +83,7 @@ TEST_CASE("vamana_metadata: load metadata from index", "[vamana_metadata]") {
     auto training_vectors =
         ColMajorMatrixWithIds<siftsmall_feature_type, siftsmall_ids_type>(
             128, 0);
-    idx.train(training_vectors, training_vectors.ids());
+    idx.train(training_vectors, training_vectors.raveled_ids());
     idx.add(training_vectors);
     idx.write_index(ctx, uri, 0);
 
@@ -114,7 +114,7 @@ TEST_CASE("vamana_metadata: load metadata from index", "[vamana_metadata]") {
         siftsmall_feature_type,
         siftsmall_ids_type>(ctx, siftsmall_inputs_uri, siftsmall_ids_uri, 222);
 
-    idx.train(training_vectors, training_vectors.ids());
+    idx.train(training_vectors, training_vectors.raveled_ids());
     idx.add(training_vectors);
     idx.write_index(ctx, uri, 2, "");
 
@@ -142,7 +142,7 @@ TEST_CASE("vamana_metadata: load metadata from index", "[vamana_metadata]") {
         siftsmall_feature_type,
         siftsmall_ids_type>(ctx, siftsmall_inputs_uri, siftsmall_ids_uri, 333);
 
-    idx.train(training_vectors, training_vectors.ids());
+    idx.train(training_vectors, training_vectors.raveled_ids());
     idx.add(training_vectors);
     idx.write_index(ctx, uri, 3);
 


### PR DESCRIPTION
### What
Fix ids() CPO / type-erased ids() member to eliminate warnings. Addresses SC-42604.

### Testing
Existing tests pass.