### PR TITLE
Support Vamana in the ObjectIndex

### DIFF
--- a/apis/python/src/tiledb/vector_search/__init__.py
+++ b/apis/python/src/tiledb/vector_search/__init__.py
@@ -19,6 +19,7 @@ from .module import query_vq_nth
 from .module import validate_top_k
 from .storage_formats import STORAGE_VERSION
 from .storage_formats import storage_formats
+from .vamana_index import VamanaIndex
 
 try:
     from tiledb.vector_search.version import version as __version__

--- a/apis/python/src/tiledb/vector_search/object_api/object_index.py
+++ b/apis/python/src/tiledb/vector_search/object_api/object_index.py
@@ -11,8 +11,10 @@ import tiledb.vector_search.object_api as object_api
 from tiledb.cloud.dag import Mode
 from tiledb.vector_search import FlatIndex
 from tiledb.vector_search import IVFFlatIndex
+from tiledb.vector_search import VamanaIndex
 from tiledb.vector_search import flat_index
 from tiledb.vector_search import ivf_flat_index
+from tiledb.vector_search import vamana_index
 from tiledb.vector_search.embeddings import ObjectEmbedding
 from tiledb.vector_search.object_readers import ObjectReader
 from tiledb.vector_search.storage_formats import STORAGE_VERSION
@@ -53,6 +55,12 @@ class ObjectIndex:
                 self.index = IVFFlatIndex(
                     uri=uri, config=config, timestamp=timestamp, **kwargs
                 )
+            elif self.index_type == "VAMANA":
+                self.index = VamanaIndex(
+                    uri=uri, config=config, timestamp=timestamp, **kwargs
+                )
+            else:
+                raise ValueError(f"Unsupported index type {self.index_type}")
 
             self.object_reader_source_code = self.index.group.meta[
                 "object_reader_source_code"
@@ -428,6 +436,16 @@ def create(
                 config=config,
                 storage_version=storage_version,
             )
+        elif index_type == "VAMANA":
+            index = vamana_index.create(
+                uri=uri,
+                dimensions=dimensions,
+                vector_type=vector_type,
+                config=config,
+                storage_version=storage_version,
+            )
+        else:
+            raise ValueError(f"Unsupported index type {index_type}")
 
         group = tiledb.Group(uri, "w")
         group.meta["object_reader_source_code"] = get_source_code(object_reader)

--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -92,7 +92,8 @@ class VamanaIndex(index.Index):
 
         assert queries.dtype == np.float32
         if opt_l < k:
-            raise ValueError(f"opt_l ({opt_l}) should be >= k ({k})")
+            warnings.warn(f"opt_l ({opt_l}) should be >= k ({k}), setting to k")
+            opt_l = k
 
         if queries.ndim == 1:
             queries = np.array([queries])

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -279,10 +279,6 @@ def test_vamana_index(tmp_path):
         and ingestion_timestamps[0] < timestamp_5_minutes_from_now
     )
 
-    # Check that we throw if we query with an invalid opt_l.
-    with pytest.raises(ValueError):
-        index.query(queries, k=3, opt_l=2)
-
     # Test that we can query with multiple query vectors.
     for i in range(5):
         query_and_check_distances(


### PR DESCRIPTION
### What
Add Vamana support to the `ObjectIndex`. 

We also update so that if `opt_l < k`, we'll just set `opt_l = k`. This is to set a sane default and prevent crashes that can happen when a user just tries to query.

### Testing
Updates the `ObjectIndex` test to run on Vamana and Flat.