### PR TITLE
Add clear_history() to C++, refactor group to allow static function to open a group

### DIFF
--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -131,30 +131,12 @@ class IndexVamana {
       const tiledb::Context& ctx,
       const URI& group_uri,
       TemporalPolicy temporal_policy = TemporalPolicy{TimeTravel, 0}) {
-    using metadata_element = std::tuple<std::string, void*, tiledb_datatype_t>;
-    std::vector<metadata_element> metadata{
-        {"feature_datatype", &feature_datatype_, TILEDB_UINT32},
-        {"id_datatype", &id_datatype_, TILEDB_UINT32},
-        {"adjacency_row_index_datatype",
-         &adjacency_row_index_datatype_,
-         TILEDB_UINT32}};
-
-    tiledb::Group read_group(ctx, group_uri, TILEDB_READ, ctx.config());
-
-    for (auto& [name, value, datatype] : metadata) {
-      if (!read_group.has_metadata(name, &datatype)) {
-        throw std::runtime_error("Missing metadata: " + name);
-      }
-      uint32_t count;
-      void* addr;
-      read_group.get_metadata(name, &datatype, &count, (const void**)&addr);
-      if (datatype == TILEDB_UINT32) {
-        *reinterpret_cast<uint32_t*>(value) =
-            *reinterpret_cast<uint32_t*>(addr);
-      } else {
-        throw std::runtime_error("Unsupported datatype for metadata: " + name);
-      }
-    }
+    read_types(
+        ctx,
+        group_uri,
+        &feature_datatype_,
+        &id_datatype_,
+        &adjacency_row_index_datatype_);
 
     auto type = std::tuple{
         feature_datatype_, id_datatype_, adjacency_row_index_datatype_};
@@ -252,6 +234,28 @@ class IndexVamana {
     index_->write_index(ctx, group_uri, timestamp, storage_version);
   }
 
+  static void clear_history(
+      const tiledb::Context& ctx,
+      const std::string& group_uri,
+      uint64_t timestamp) {
+    tiledb_datatype_t feature_datatype{TILEDB_ANY};
+    tiledb_datatype_t id_datatype{TILEDB_ANY};
+    tiledb_datatype_t adjacency_row_index_datatype{TILEDB_ANY};
+    read_types(
+        ctx,
+        group_uri,
+        &feature_datatype,
+        &id_datatype,
+        &adjacency_row_index_datatype);
+
+    auto type =
+        std::tuple{feature_datatype, id_datatype, adjacency_row_index_datatype};
+    if (uri_dispatch_table.find(type) == uri_dispatch_table.end()) {
+      throw std::runtime_error("Unsupported datatype combination");
+    }
+    clear_history_dispatch_table.at(type)(ctx, group_uri, timestamp);
+  }
+
   auto temporal_policy() const {
     if (!index_) {
       throw std::runtime_error(
@@ -289,6 +293,39 @@ class IndexVamana {
   }
 
  private:
+  static void read_types(
+      const tiledb::Context& ctx,
+      const std::string& group_uri,
+      tiledb_datatype_t* feature_datatype,
+      tiledb_datatype_t* id_datatype,
+      tiledb_datatype_t* adjacency_row_index_datatype) {
+    using metadata_element =
+        std::tuple<std::string, tiledb_datatype_t*, tiledb_datatype_t>;
+    std::vector<metadata_element> metadata{
+        {"feature_datatype", feature_datatype, TILEDB_UINT32},
+        {"id_datatype", id_datatype, TILEDB_UINT32},
+        {"adjacency_row_index_datatype",
+         adjacency_row_index_datatype,
+         TILEDB_UINT32}};
+
+    tiledb::Group read_group(ctx, group_uri, TILEDB_READ, ctx.config());
+
+    for (auto& [name, value, datatype] : metadata) {
+      if (!read_group.has_metadata(name, &datatype)) {
+        throw std::runtime_error("Missing metadata: " + name);
+      }
+      uint32_t count;
+      void* addr;
+      read_group.get_metadata(name, &datatype, &count, (const void**)&addr);
+      if (datatype == TILEDB_UINT32) {
+        *reinterpret_cast<uint32_t*>(value) =
+            *reinterpret_cast<uint32_t*>(addr);
+      } else {
+        throw std::runtime_error("Unsupported datatype for metadata: " + name);
+      }
+    }
+  }
+
   /**
    * Non-type parameterized base class (for type erasure).
    */
@@ -310,6 +347,11 @@ class IndexVamana {
         const std::string& group_uri,
         std::optional<size_t> timestamp,
         const std::string& storage_version) = 0;
+
+    //    static virtual void write_index(
+    //        const tiledb::Context& ctx,
+    //        const std::string& group_uri,
+    //        uint64_t timestamp) = 0;
 
     [[nodiscard]] virtual size_t dimension() const = 0;
     [[nodiscard]] virtual TemporalPolicy temporal_policy() const = 0;
@@ -434,6 +476,13 @@ class IndexVamana {
       impl_index_.write_index(ctx, group_uri, timestamp, storage_version);
     }
 
+    //    static void clear_history(
+    //        const tiledb::Context& ctx,
+    //        const std::string& group_uri,
+    //        uint64_t timestamp) override {
+    //      impl_index_::clear_history(ctx, group_uri, timestamp);
+    //    }
+
     size_t dimension() const override {
       return ::dimension(impl_index_);
     }
@@ -457,6 +506,10 @@ class IndexVamana {
   using uri_constructor_function = std::function<std::unique_ptr<index_base>(const tiledb::Context&, const std::string&, TemporalPolicy)>;
   using uri_table_type = std::map<std::tuple<tiledb_datatype_t, tiledb_datatype_t, tiledb_datatype_t>, uri_constructor_function>;
   static const uri_table_type uri_dispatch_table;
+
+  using clear_history_constructor_function = std::function<void(const tiledb::Context&, const std::string&, int)>;
+  using clear_history_table_type = std::map<std::tuple<tiledb_datatype_t, tiledb_datatype_t, tiledb_datatype_t>, clear_history_constructor_function>;
+  static const clear_history_table_type clear_history_dispatch_table;
   // clang-format on
 
   size_t dimension_ = 0;
@@ -498,6 +551,21 @@ const IndexVamana::uri_table_type IndexVamana::uri_dispatch_table = {
   {{TILEDB_INT8,    TILEDB_UINT64, TILEDB_UINT64}, [](const tiledb::Context& ctx, const std::string& uri, TemporalPolicy temporal_policy) { return std::make_unique<index_impl<vamana_index<int8_t,  uint64_t, uint64_t>>>(ctx, uri, temporal_policy); }},
   {{TILEDB_UINT8,   TILEDB_UINT64, TILEDB_UINT64}, [](const tiledb::Context& ctx, const std::string& uri, TemporalPolicy temporal_policy) { return std::make_unique<index_impl<vamana_index<uint8_t, uint64_t, uint64_t>>>(ctx, uri, temporal_policy); }},
   {{TILEDB_FLOAT32, TILEDB_UINT64, TILEDB_UINT64}, [](const tiledb::Context& ctx, const std::string& uri, TemporalPolicy temporal_policy) { return std::make_unique<index_impl<vamana_index<float,   uint64_t, uint64_t>>>(ctx, uri, temporal_policy); }},
+};
+
+const IndexVamana::clear_history_table_type IndexVamana::clear_history_dispatch_table = {
+  {{TILEDB_INT8,    TILEDB_UINT32, TILEDB_UINT32}, [](const tiledb::Context& ctx, const std::string& uri, uint64_t timestamp) { return vamana_index<int8_t,  uint32_t, uint32_t>::clear_history(ctx, uri, timestamp); }},
+  {{TILEDB_UINT8,   TILEDB_UINT32, TILEDB_UINT32}, [](const tiledb::Context& ctx, const std::string& uri, uint64_t timestamp) { return vamana_index<uint8_t, uint32_t, uint32_t>::clear_history(ctx, uri, timestamp); }},
+  {{TILEDB_FLOAT32, TILEDB_UINT32, TILEDB_UINT32}, [](const tiledb::Context& ctx, const std::string& uri, uint64_t timestamp) { return vamana_index<float,   uint32_t, uint32_t>::clear_history(ctx, uri, timestamp); }},
+  {{TILEDB_INT8,    TILEDB_UINT32, TILEDB_UINT64}, [](const tiledb::Context& ctx, const std::string& uri, uint64_t timestamp) { return vamana_index<int8_t,  uint32_t, uint64_t>::clear_history(ctx, uri, timestamp); }},
+  {{TILEDB_UINT8,   TILEDB_UINT32, TILEDB_UINT64}, [](const tiledb::Context& ctx, const std::string& uri, uint64_t timestamp) { return vamana_index<uint8_t, uint32_t, uint64_t>::clear_history(ctx, uri, timestamp); }},
+  {{TILEDB_FLOAT32, TILEDB_UINT32, TILEDB_UINT64}, [](const tiledb::Context& ctx, const std::string& uri, uint64_t timestamp) { return vamana_index<float,   uint32_t, uint64_t>::clear_history(ctx, uri, timestamp); }},
+  {{TILEDB_INT8,    TILEDB_UINT64, TILEDB_UINT32}, [](const tiledb::Context& ctx, const std::string& uri, uint64_t timestamp) { return vamana_index<int8_t,  uint64_t, uint32_t>::clear_history(ctx, uri, timestamp); }},
+  {{TILEDB_UINT8,   TILEDB_UINT64, TILEDB_UINT32}, [](const tiledb::Context& ctx, const std::string& uri, uint64_t timestamp) { return vamana_index<uint8_t, uint64_t, uint32_t>::clear_history(ctx, uri, timestamp); }},
+  {{TILEDB_FLOAT32, TILEDB_UINT64, TILEDB_UINT32}, [](const tiledb::Context& ctx, const std::string& uri, uint64_t timestamp) { return vamana_index<float,   uint64_t, uint32_t>::clear_history(ctx, uri, timestamp); }},
+  {{TILEDB_INT8,    TILEDB_UINT64, TILEDB_UINT64}, [](const tiledb::Context& ctx, const std::string& uri, uint64_t timestamp) { return vamana_index<int8_t,  uint64_t, uint64_t>::clear_history(ctx, uri, timestamp); }},
+  {{TILEDB_UINT8,   TILEDB_UINT64, TILEDB_UINT64}, [](const tiledb::Context& ctx, const std::string& uri, uint64_t timestamp) { return vamana_index<uint8_t, uint64_t, uint64_t>::clear_history(ctx, uri, timestamp); }},
+  {{TILEDB_FLOAT32, TILEDB_UINT64, TILEDB_UINT64}, [](const tiledb::Context& ctx, const std::string& uri, uint64_t timestamp) { return vamana_index<float,   uint64_t, uint64_t>::clear_history(ctx, uri, timestamp); }},
 };
 // clang-format on
 

--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -348,11 +348,6 @@ class IndexVamana {
         std::optional<size_t> timestamp,
         const std::string& storage_version) = 0;
 
-    //    static virtual void write_index(
-    //        const tiledb::Context& ctx,
-    //        const std::string& group_uri,
-    //        uint64_t timestamp) = 0;
-
     [[nodiscard]] virtual size_t dimension() const = 0;
     [[nodiscard]] virtual TemporalPolicy temporal_policy() const = 0;
   };
@@ -475,13 +470,6 @@ class IndexVamana {
         const std::string& storage_version) override {
       impl_index_.write_index(ctx, group_uri, timestamp, storage_version);
     }
-
-    //    static void clear_history(
-    //        const tiledb::Context& ctx,
-    //        const std::string& group_uri,
-    //        uint64_t timestamp) override {
-    //      impl_index_::clear_history(ctx, group_uri, timestamp);
-    //    }
 
     size_t dimension() const override {
       return ::dimension(impl_index_);

--- a/src/include/index/index_group.h
+++ b/src/include/index/index_group.h
@@ -236,6 +236,10 @@ class base_index_group {
    * @todo Process the "base group" metadata here.
    */
   void create_default() {
+    if (get_dimension() == 0) {
+      throw std::runtime_error(
+          "Dimension must be set when creating a new group.");
+    }
     static_cast<group_type*>(this)->create_default_impl();
   }
 
@@ -304,9 +308,6 @@ class base_index_group {
         open_for_read();
         break;
       case TILEDB_WRITE:
-        if (dimension == 0) {
-          throw std::runtime_error("Dimension must be set for write mode.");
-        }
         set_dimension(dimension);
         open_for_write();
         break;
@@ -321,11 +322,19 @@ class base_index_group {
     }
   }
 
+  /**
+   * @brief Clears all history that is <= timestamp.
+   */
   void clear_history(uint64_t timestamp) {
     if (opened_for_ != TILEDB_WRITE) {
       throw std::runtime_error("Cannot clear history in read mode.");
     }
-    metadata_.clear_history(timestamp);
+    if (!exists()) {
+      throw std::runtime_error(
+          "Cannot clear history because group does not exist.");
+    }
+
+    // TODO(paris): Implement the clear.
   }
 
   /**

--- a/src/include/index/ivf_flat_group.h
+++ b/src/include/index/ivf_flat_group.h
@@ -157,24 +157,14 @@ class ivf_flat_index_group : public base_index_group<index_type> {
 
     metadata_.feature_type_str_ =
         type_to_string_v<typename index_type::feature_type>;
-    std::cout
-        << "[ivf_flat_group@create_default_impl] metadata_.feature_type_str_: "
-        << metadata_.feature_type_str_ << std::endl;
     metadata_.id_type_str_ = type_to_string_v<typename index_type::id_type>;
-    std::cout << "[ivf_flat_group@create_default_impl] metadata_.id_type_str_: "
-              << metadata_.id_type_str_ << std::endl;
     metadata_.indices_type_str_ =
         type_to_string_v<typename index_type::indices_type>;
-    std::cout
-        << "[ivf_flat_group@create_default_impl] metadata_.indices_type_str_: "
-        << metadata_.indices_type_str_ << std::endl;
 
     metadata_.ingestion_timestamps_ = {0};
     metadata_.base_sizes_ = {0};
     metadata_.partition_history_ = {0};
     metadata_.temp_size_ = 0;
-    std::cout << "[ivf_flat_group@create_default_impl] this->get_dimension(): "
-              << this->get_dimension() << std::endl;
     metadata_.dimension_ = this->get_dimension();
 
     create_empty_for_matrix<

--- a/src/include/index/ivf_flat_index.h
+++ b/src/include/index/ivf_flat_index.h
@@ -234,11 +234,7 @@ class ivf_flat_index {
      * in at this same timestamp.
      */
     dimension_ = group_->get_dimension();
-    std::cout << "[ivf_flat_index@ctor 2] dimension_: " << dimension_
-              << std::endl;
     num_partitions_ = group_->get_num_partitions();
-    std::cout << "[ivf_flat_index@ctor 2] num_partitions_: " << num_partitions_
-              << std::endl;
     // Read all rows from column 0 -> `num_partitions_`. Set no upper_bound.
     centroids_ =
         std::move(tdbPreLoadMatrix<centroid_feature_type, stdx::layout_left>(
@@ -771,6 +767,7 @@ class ivf_flat_index {
     write_group.append_ingestion_timestamp(temporal_policy_.timestamp_end());
     write_group.append_base_size(::num_vectors(*partitioned_vectors_));
     write_group.append_num_partitions(num_partitions_);
+
     write_matrix(
         ctx,
         centroids_,

--- a/src/include/index/vamana_group.h
+++ b/src/include/index/vamana_group.h
@@ -55,8 +55,8 @@
  *      - Example: [[distance between 0 and 1, distance between 0 and 2], etc.]
  *   -  adjacency_row_index: Each entry in the row index indicates where the
  * neighbhors for that index start. 0 because that's where neighbors for vertex
- * 0 start, then 2 b/c that's where niehbhors for vertex 1 start, then 4 b/c
- * that's whre niehbhors for vertex 2 start, then 6 b/c that's the end.
+ * 0 start, then 2 b/c that's where neighbors for vertex 1 start, then 4 b/c
+ * that's whre neighbors for vertex 2 start, then 6 b/c that's the end.
  *      - Example: [0, 2, 4, 6]
  */
 [[maybe_unused]] static StorageFormat vamana_storage_formats = {
@@ -70,18 +70,9 @@
          // {"medoids_array_name", "medoids"},
      }}};
 
-template <class Index>
-class vamana_index_group;
-
-template <class Index>
-struct metadata_type_selector<vamana_index_group<Index>> {
-  using type = vamana_index_metadata;
-};
-
-template <class Index>
-class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
-  using Base = base_index_group<vamana_index_group>;
-  // using Base::Base;
+template <class index_type>
+class vamana_index_group : public base_index_group<index_type> {
+  using Base = base_index_group<index_type>;
 
   using Base::array_key_to_array_name_;
   using Base::array_name_to_uri_;
@@ -92,26 +83,20 @@ class vamana_index_group : public base_index_group<vamana_index_group<Index>> {
   using Base::valid_array_names_;
   using Base::version_;
 
-  using index_type = Index;
-  // std::reference_wrapper<const index_type> index_;
-  // index_type index_;
-
   // @todo Make this controllable
   static const int32_t default_domain{std::numeric_limits<int32_t>::max() - 1};
   static const int32_t default_tile_extent{100'000};
   static const int32_t tile_size_bytes{64 * 1024 * 1024};
 
  public:
-  using index_group_metadata_type = vamana_index_metadata;
-
   vamana_index_group(
-      const index_type& index,
       const tiledb::Context& ctx,
       const std::string& uri,
       tiledb_query_type_t rw = TILEDB_READ,
       TemporalPolicy temporal_policy = TemporalPolicy{TimeTravel, 0},
-      const std::string& version = std::string{""})
-      : Base(ctx, uri, index.dimension(), rw, temporal_policy, version) {
+      const std::string& version = std::string{""},
+      uint64_t dimension = 0)
+      : Base(ctx, uri, rw, temporal_policy, version, dimension) {
   }
 
  public:

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -961,10 +961,9 @@ class vamana_index {
       const tiledb::Context& ctx,
       const std::string& group_uri,
       uint64_t timestamp) {
-    // todo: get dimension
-    //    auto write_group =
-    //        vamana_index_group<vamana_index>(ctx, group_uri, 0, TILEDB_WRITE);
-    //    write_group.clear_history(timestamp);
+    auto write_group =
+        vamana_index_group<vamana_index>(ctx, group_uri, TILEDB_WRITE);
+    write_group.clear_history(timestamp);
   }
 
   const vamana_index_group<vamana_index>& group() const {

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -413,6 +413,9 @@ class vamana_index {
   using adjacency_row_index_type = IndexType;
   using score_type = float;
 
+  using group_type = vamana_index_group<vamana_index>;
+  using metadata_type = vamana_index_metadata;
+
  private:
   /****************************************************************************
    * Index group information
@@ -502,12 +505,12 @@ class vamana_index {
       TemporalPolicy temporal_policy = TemporalPolicy{TimeTravel, 0})
       : temporal_policy_{temporal_policy}
       , group_{std::make_unique<vamana_index_group<vamana_index>>(
-            *this, ctx, uri, TILEDB_READ, temporal_policy_)} {
+            ctx, uri, TILEDB_READ, temporal_policy_)} {
     if (temporal_policy_.timestamp_end() == 0) {
       temporal_policy_ = {
           TimeTravel, group_->get_previous_ingestion_timestamp()};
       group_ = {std::make_unique<vamana_index_group<vamana_index>>(
-          *this, ctx, uri, TILEDB_READ, temporal_policy_)};
+          ctx, uri, TILEDB_READ, temporal_policy_)};
     }
 
     // @todo Make this table-driven
@@ -856,8 +859,13 @@ class vamana_index {
     // metadata: dimension, ntotal, L, R, B, alpha_min, alpha_max, medoid
     // Save as a group: metadata, feature_vectors, graph edges, offsets
 
-    auto write_group = vamana_index_group(
-        *this, ctx, group_uri, TILEDB_WRITE, temporal_policy_, storage_version);
+    auto write_group = vamana_index_group<vamana_index>(
+        ctx,
+        group_uri,
+        TILEDB_WRITE,
+        temporal_policy_,
+        storage_version,
+        dimension_);
 
     // @todo Make this table-driven
     write_group.set_dimension(dimension_);
@@ -947,6 +955,16 @@ class vamana_index {
         temporal_policy_);
 
     return true;
+  }
+
+  static void clear_history(
+      const tiledb::Context& ctx,
+      const std::string& group_uri,
+      uint64_t timestamp) {
+    // todo: get dimension
+    //    auto write_group =
+    //        vamana_index_group<vamana_index>(ctx, group_uri, 0, TILEDB_WRITE);
+    //    write_group.clear_history(timestamp);
   }
 
   const vamana_index_group<vamana_index>& group() const {

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -962,7 +962,7 @@ class vamana_index {
       const std::string& group_uri,
       uint64_t timestamp) {
     auto write_group =
-        vamana_index_group<vamana_index>(ctx, group_uri, TILEDB_WRITE);
+        vamana_index_group<vamana_index>(ctx, group_uri, TILEDB_WRITE, {});
     write_group.clear_history(timestamp);
   }
 

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -793,4 +793,7 @@ TEST_CASE(
         all_ingestion_timestamps.end(),
         std::vector<uint64_t>{99, 100}.begin()));
   }
+
+  // Clear history.
+  { IndexVamana::clear_history(ctx, index_uri, 99); }
 }

--- a/src/include/test/unit_ivf_flat_group.cc
+++ b/src/include/test/unit_ivf_flat_group.cc
@@ -44,9 +44,6 @@ TEST_CASE("ivf_flat_group: test test", "[ivf_flat_group]") {
   REQUIRE(true);
 }
 
-// This test is for debugging and checks whether a particular group can be
-// opened
-#if 0
 TEST_CASE("ivf_flat_group: read a tiledb::Group", "[ivf_flat_group]") {
   tiledb::Context ctx;
   tiledb::Config cfg;
@@ -60,10 +57,9 @@ TEST_CASE("ivf_flat_group: read a tiledb::Group", "[ivf_flat_group]") {
     if (!name || empty(*name)) {
       throw std::runtime_error("Name is empty.");
     }
-    std::cout << i <<  ": " << *name << " " << member.uri() << std::endl;
+    std::cout << i << ": " << *name << " " << member.uri() << std::endl;
   }
 }
-#endif
 
 TEST_CASE("ivf_flat_group: create tiledb::Group", "[ivf_flat_group]") {
   tiledb::Context ctx;
@@ -87,9 +83,8 @@ struct dummy_index {
   using indices_type = int;
   using centroid_feature_type = float;
 
-  auto dimension() const {
-    return 10;
-  }
+  using group_type = ivf_flat_index_group<dummy_index>;
+  using metadata_type = ivf_flat_index_metadata;
 };
 
 TEST_CASE(
@@ -98,7 +93,7 @@ TEST_CASE(
   tiledb::Context ctx;
 
   CHECK_THROWS_WITH(
-      ivf_flat_index_group(dummy_index{}, ctx, "I dont exist"),
+      ivf_flat_index_group<dummy_index>(ctx, "I dont exist"),
       "Group uri I dont exist does not exist.");
 }
 
@@ -114,7 +109,8 @@ TEST_CASE("ivf_flat_group: write constructor - create", "[ivf_flat_group]") {
   }
 
   ivf_flat_index_group x =
-      ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+  CHECK(x.get_dimension() == 10);
 }
 
 TEST_CASE(
@@ -131,10 +127,12 @@ TEST_CASE(
   }
 
   ivf_flat_index_group x =
-      ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+  CHECK(x.get_dimension() == 10);
 
   ivf_flat_index_group y =
-      ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+  CHECK(x.get_dimension() == 10);
 }
 
 TEST_CASE(
@@ -151,10 +149,11 @@ TEST_CASE(
   }
 
   ivf_flat_index_group x =
-      ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+  CHECK(x.get_dimension() == 10);
 
   ivf_flat_index_group y =
-      ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
 }
 
 TEST_CASE(
@@ -172,13 +171,15 @@ TEST_CASE(
   }
 
   ivf_flat_index_group x =
-      ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+  CHECK(x.get_dimension() == 10);
 
   ivf_flat_index_group y =
-      ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+  CHECK(x.get_dimension() == 10);
 
   ivf_flat_index_group z =
-      ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
 }
 
 TEST_CASE(
@@ -203,28 +204,35 @@ TEST_CASE(
   size_t offset = 0;
 
   ivf_flat_index_group x =
-      ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+  CHECK(x.get_dimension() == 10);
 
   SECTION("Just set") {
     SECTION("After create") {
     }
 
     SECTION("After create and read") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and write") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = ivf_flat_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     SECTION("After create and write and read") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = ivf_flat_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
+      x = ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and read and write") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
+      x = ivf_flat_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     x.set_ingestion_timestamp(expected_ingestion);
@@ -239,21 +247,27 @@ TEST_CASE(
     }
 
     SECTION("After create and read") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and write") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = ivf_flat_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     SECTION("After create and write and read") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = ivf_flat_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
+      x = ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and read and write") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
+      x = ivf_flat_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     x.append_ingestion_timestamp(expected_ingestion);
@@ -268,21 +282,27 @@ TEST_CASE(
     }
 
     SECTION("After create and read") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and write") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = ivf_flat_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     SECTION("After create and write and read") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = ivf_flat_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
+      x = ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and read and write") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
+      x = ivf_flat_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     x.set_ingestion_timestamp(expected_ingestion);
@@ -311,21 +331,27 @@ TEST_CASE(
     }
 
     SECTION("After create and read") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and write") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = ivf_flat_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     SECTION("After create and write and read") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = ivf_flat_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
+      x = ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and read and write") {
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
-      x = ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
+      x = ivf_flat_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     x.set_ingestion_timestamp(expected_ingestion);
@@ -372,26 +398,22 @@ TEST_CASE("ivf_flat_group: storage version", "[ivf_flat_group]") {
   auto offset = 2345;
 
   ivf_flat_index_group x =
-      ivf_flat_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      ivf_flat_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+  CHECK(x.get_dimension() == 10);
 
   SECTION("0.3") {
-    x = ivf_flat_index_group(
-        dummy_index{},
-        ctx,
-        tmp_uri,
-        TILEDB_WRITE,
-        TemporalPolicy{TimeTravel, 0},
-        "0.3");
+    x = ivf_flat_index_group<dummy_index>(
+        ctx, tmp_uri, TILEDB_WRITE, TemporalPolicy{TimeTravel, 0}, "0.3", 10);
   }
 
   SECTION("current_storage_version") {
-    x = ivf_flat_index_group(
-        dummy_index{},
+    x = ivf_flat_index_group<dummy_index>(
         ctx,
         tmp_uri,
         TILEDB_WRITE,
         TemporalPolicy{TimeTravel, 0},
-        current_storage_version);
+        current_storage_version,
+        10);
   }
 
   x.set_ingestion_timestamp(expected_ingestion + offset);
@@ -419,13 +441,10 @@ TEST_CASE("ivf_flat_group: invalid storage version", "[ivf_flat_group]") {
   if (vfs.is_dir(tmp_uri)) {
     vfs.remove_dir(tmp_uri);
   }
-  CHECK_THROWS(ivf_flat_index_group(
-      dummy_index{},
-      ctx,
-      tmp_uri,
-      TILEDB_WRITE,
-      TemporalPolicy{TimeTravel, 0},
-      "invalid"));
+  CHECK_THROWS(
+      ivf_flat_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, TemporalPolicy{TimeTravel, 0}, "invalid"),
+      10);
 }
 
 TEST_CASE("ivf_flat_group: mismatched storage version", "[ivf_flat_group]") {
@@ -438,21 +457,16 @@ TEST_CASE("ivf_flat_group: mismatched storage version", "[ivf_flat_group]") {
     vfs.remove_dir(tmp_uri);
   }
 
-  ivf_flat_index_group x = ivf_flat_index_group(
-      dummy_index{},
-      ctx,
-      tmp_uri,
-      TILEDB_WRITE,
-      TemporalPolicy{TimeTravel, 0},
-      "0.3");
+  ivf_flat_index_group x = ivf_flat_index_group<dummy_index>(
+      ctx, tmp_uri, TILEDB_WRITE, TemporalPolicy{TimeTravel, 0}, "0.3", 10);
 
   CHECK_THROWS_WITH(
-      ivf_flat_index_group(
-          dummy_index{},
+      ivf_flat_index_group<dummy_index>(
           ctx,
           tmp_uri,
           TILEDB_WRITE,
           TemporalPolicy{TimeTravel, 0},
-          "different_version"),
+          "different_version",
+          10),
       "Version mismatch. Requested different_version but found 0.3");
 }

--- a/src/include/test/unit_ivf_flat_group.cc
+++ b/src/include/test/unit_ivf_flat_group.cc
@@ -44,6 +44,9 @@ TEST_CASE("ivf_flat_group: test test", "[ivf_flat_group]") {
   REQUIRE(true);
 }
 
+// This test is for debugging and checks whether a particular group can be
+// opened
+#if 0
 TEST_CASE("ivf_flat_group: read a tiledb::Group", "[ivf_flat_group]") {
   tiledb::Context ctx;
   tiledb::Config cfg;
@@ -57,9 +60,10 @@ TEST_CASE("ivf_flat_group: read a tiledb::Group", "[ivf_flat_group]") {
     if (!name || empty(*name)) {
       throw std::runtime_error("Name is empty.");
     }
-    std::cout << i << ": " << *name << " " << member.uri() << std::endl;
+    std::cout << i <<  ": " << *name << " " << member.uri() << std::endl;
   }
 }
+#endif
 
 TEST_CASE("ivf_flat_group: create tiledb::Group", "[ivf_flat_group]") {
   tiledb::Context ctx;

--- a/src/include/test/unit_vamana_group.cc
+++ b/src/include/test/unit_vamana_group.cc
@@ -43,16 +43,15 @@ struct dummy_index {
   using adjacency_row_index_type = int;
   using score_type = float;
 
+  using group_type = vamana_index_group<dummy_index>;
+  using metadata_type = vamana_index_metadata;
+
   constexpr static tiledb_datatype_t feature_datatype = TILEDB_FLOAT32;
   constexpr static tiledb_datatype_t id_datatype = TILEDB_UINT64;
   constexpr static tiledb_datatype_t adjacency_row_index_datatype =
       TILEDB_UINT64;
   constexpr static tiledb_datatype_t adjacency_scores_datatype = TILEDB_FLOAT32;
   constexpr static tiledb_datatype_t adjacency_ids_datatype = TILEDB_UINT64;
-
-  auto dimension() const {
-    return 10;
-  }
 };
 
 TEST_CASE(
@@ -60,7 +59,7 @@ TEST_CASE(
   tiledb::Context ctx;
 
   CHECK_THROWS_WITH(
-      vamana_index_group(dummy_index{}, ctx, "I dont exist"),
+      vamana_index_group<dummy_index>(ctx, "I dont exist"),
       "Group uri I dont exist does not exist.");
 }
 
@@ -76,7 +75,8 @@ TEST_CASE("vamana_group: write constructor - create", "[vamana_group]") {
   }
 
   vamana_index_group x =
-      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+  CHECK(x.get_dimension() == 10);
 }
 
 TEST_CASE(
@@ -92,10 +92,12 @@ TEST_CASE(
   }
 
   vamana_index_group x =
-      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+  CHECK(x.get_dimension() == 10);
 
   vamana_index_group y =
-      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+  CHECK(x.get_dimension() == 10);
 }
 
 TEST_CASE(
@@ -112,7 +114,8 @@ TEST_CASE(
 
   {
     vamana_index_group x =
-        vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+        vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+    CHECK(x.get_dimension() == 10);
     x.append_num_edges(0);
     x.append_base_size(0);
     x.append_ingestion_timestamp(0);
@@ -120,12 +123,12 @@ TEST_CASE(
     // We throw b/c the vamana_index_group hasn't actually been written (the
     // write happens in the destructor).
     CHECK_THROWS_WITH(
-        vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ),
+        vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ),
         "No ingestion timestamps found.");
   }
 
   vamana_index_group y =
-      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
 }
 
 TEST_CASE(
@@ -143,18 +146,19 @@ TEST_CASE(
 
   {
     vamana_index_group x =
-        vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+        vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+    CHECK(x.get_dimension() == 10);
     // We throw b/c the vamana_index_group hasn't actually been written (the
     // write happens in the destructor).
     CHECK_THROWS_WITH(
-        vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ),
+        vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ),
         "No ingestion timestamps found.");
   }
 
   // If we don't append to the group, even if it's been written there will be no
   // timestamps.
   CHECK_THROWS_WITH(
-      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ),
+      vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ),
       "No ingestion timestamps found.");
 }
 
@@ -181,35 +185,43 @@ TEST_CASE(
 
   {
     vamana_index_group x =
-        vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+        vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+    CHECK(x.get_dimension() == 10);
     x.append_num_edges(0);
     x.append_base_size(0);
     x.append_ingestion_timestamp(0);
   }
 
   vamana_index_group x =
-      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+  CHECK(x.get_dimension() == 10);
 
   SECTION("Just set") {
     SECTION("After create") {
     }
 
     SECTION("After create and read") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and write") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = vamana_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     SECTION("After create and write and read") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = vamana_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
+      x = vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and read and write") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
+      x = vamana_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     x.set_ingestion_timestamp(expected_ingestion);
@@ -224,21 +236,27 @@ TEST_CASE(
     }
 
     SECTION("After create and read") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and write") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = vamana_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     SECTION("After create and write and read") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = vamana_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
+      x = vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and read and write") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
+      x = vamana_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     x.append_ingestion_timestamp(expected_ingestion);
@@ -253,21 +271,27 @@ TEST_CASE(
     }
 
     SECTION("After create and read") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and write") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = vamana_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     SECTION("After create and write and read") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = vamana_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
+      x = vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and read and write") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
+      x = vamana_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     x.set_ingestion_timestamp(expected_ingestion);
@@ -294,21 +318,27 @@ TEST_CASE(
     }
 
     SECTION("After create and read") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and write") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = vamana_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     SECTION("After create and write and read") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
+      x = vamana_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
+      x = vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
     }
 
     SECTION("After create and read and write") {
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_READ);
-      x = vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      x = vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
+      x = vamana_index_group<dummy_index>(
+          ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+      CHECK(x.get_dimension() == 10);
     }
 
     x.set_ingestion_timestamp(expected_ingestion);
@@ -355,24 +385,19 @@ TEST_CASE("vamana_group: storage version", "[vamana_group]") {
   auto offset = 2345;
 
   vamana_index_group x =
-      vamana_index_group(dummy_index{}, ctx, tmp_uri, TILEDB_WRITE);
+      vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_WRITE, {}, "", 10);
+  CHECK(x.get_dimension() == 10);
 
   SECTION("0.3") {
-    x = vamana_index_group(
-        dummy_index{},
-        ctx,
-        tmp_uri,
-        TILEDB_WRITE,
-        TemporalPolicy{TimeTravel, 0},
-        "0.3");
+    x = vamana_index_group<dummy_index>(
+        ctx, tmp_uri, TILEDB_WRITE, TemporalPolicy{TimeTravel, 0}, "0.3", 10);
     x.append_num_edges(0);
     x.append_base_size(0);
     x.append_ingestion_timestamp(0);
   }
 
   SECTION("current_storage_version") {
-    x = vamana_index_group(
-        dummy_index{},
+    x = vamana_index_group<dummy_index>(
         ctx,
         tmp_uri,
         TILEDB_WRITE,
@@ -408,13 +433,13 @@ TEST_CASE("vamana_group: invalid storage version", "[vamana_group]") {
   if (vfs.is_dir(tmp_uri)) {
     vfs.remove_dir(tmp_uri);
   }
-  CHECK_THROWS(vamana_index_group(
-      dummy_index{},
+  CHECK_THROWS(vamana_index_group<dummy_index>(
       ctx,
       tmp_uri,
       TILEDB_WRITE,
       TemporalPolicy{TimeTravel, 0},
-      "invalid"));
+      "invalid",
+      10));
 }
 
 TEST_CASE("vamana_group: mismatched storage version", "[vamana_group]") {
@@ -427,21 +452,16 @@ TEST_CASE("vamana_group: mismatched storage version", "[vamana_group]") {
     vfs.remove_dir(tmp_uri);
   }
 
-  vamana_index_group x = vamana_index_group(
-      dummy_index{},
-      ctx,
-      tmp_uri,
-      TILEDB_WRITE,
-      TemporalPolicy{TimeTravel, 0},
-      "0.3");
+  vamana_index_group x = vamana_index_group<dummy_index>(
+      ctx, tmp_uri, TILEDB_WRITE, TemporalPolicy{TimeTravel, 0}, "0.3", 10);
 
   CHECK_THROWS_WITH(
-      vamana_index_group(
-          dummy_index{},
+      vamana_index_group<dummy_index>(
           ctx,
           tmp_uri,
           TILEDB_WRITE,
           TemporalPolicy{TimeTravel, 0},
-          "different_version"),
+          "different_version",
+          10),
       "Version mismatch. Requested different_version but found 0.3");
 }

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -1289,4 +1289,7 @@ TEST_CASE("vamana: vamana_index write and read", "[vamana]") {
   CHECK(idx.compare_feature_vectors(idx2));
   CHECK(idx.compare_adj_scores(idx2));
   CHECK(idx.compare_adj_ids(idx2));
+
+  vamana_index<siftsmall_feature_type, siftsmall_ids_type>::clear_history(
+      ctx, vamana_index_uri, five_minutes_from_now);
 }


### PR DESCRIPTION
### What
Here we add C++ support for the `clear_history()` API. In order to do this we refactor `index_group.h` to allow the `clear_history()` static function to open a group. We need this because previously we would have to pass in a group object to `index_group`, now we just pass in the type. This change also has the added benefit of deleting a good amount of code and simplifying things.

### TODO
We don't actually implement the `clear_history()` logic, but we set it up to be called. I'll implement this in a follow-up right after this: #372 

### Testing
* Existing tests pass.
* Can call `clear_history()` from C++.