### PR TITLE
Speed up `test_ingestion.py` tests by running on less data, mix up dimensions size more between tests

### DIFF
--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -160,9 +160,9 @@ def test_ivf_flat_ingestion_u8(tmp_path):
     dataset_dir = os.path.join(tmp_path, "dataset")
     index_uri = os.path.join(tmp_path, "array")
     k = 10
-    size = 100000
+    size = 10000
     partitions = 100
-    dimensions = 128
+    dimensions = 129
     nqueries = 100
     nprobe = 20
     create_random_dataset_u8(nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir)
@@ -205,8 +205,8 @@ def test_ivf_flat_ingestion_u8(tmp_path):
 def test_ivf_flat_ingestion_f32(tmp_path):
     dataset_dir = os.path.join(tmp_path, "dataset")
     k = 10
-    size = 100000
-    dimensions = 128
+    size = 10000
+    dimensions = 127
     partitions = 100
     nqueries = 100
     nprobe = 20
@@ -730,7 +730,7 @@ def test_ingestion_with_updates(tmp_path):
     k = 10
     size = 1000
     partitions = 10
-    dimensions = 128
+    dimensions = 49
     nqueries = 100
     nprobe = 10
     data = create_random_dataset_u8(
@@ -805,9 +805,9 @@ def test_ingestion_with_batch_updates(tmp_path):
 
     dataset_dir = os.path.join(tmp_path, "dataset")
     k = 10
-    size = 100000
+    size = 10000
     partitions = 100
-    dimensions = 128
+    dimensions = 99
     nqueries = 100
     nprobe = 100
     data = create_random_dataset_u8(
@@ -833,7 +833,7 @@ def test_ingestion_with_batch_updates(tmp_path):
         update_ids = {}
         updated_ids = {}
         update_ids_offset = MAX_UINT64 - size
-        for i in range(0, 100000, 2):
+        for i in range(0, 1000, 2):
             updated_ids[i] = i + update_ids_offset
             update_ids[i + update_ids_offset] = i
         external_ids = np.zeros((len(updated_ids) * 2), dtype=np.uint64)
@@ -868,10 +868,10 @@ def test_ingestion_with_updates_and_timetravel(tmp_path):
 
     dataset_dir = os.path.join(tmp_path, "dataset")
     k = 10
-    size = 1000
-    partitions = 10
-    dimensions = 128
-    nqueries = 100
+    size = 999
+    partitions = 16
+    dimensions = 65
+    nqueries = 85
     data = create_random_dataset_u8(
         nb=size, d=dimensions, nq=nqueries, k=k, path=dataset_dir
     )
@@ -892,7 +892,7 @@ def test_ingestion_with_updates_and_timetravel(tmp_path):
 
         ingestion_timestamps, base_sizes = load_metadata(index_uri)
         assert ingestion_timestamps == [1]
-        assert base_sizes == [1000]
+        assert base_sizes == [size]
 
         if index_type == "IVF_FLAT":
             assert index.partitions == partitions
@@ -914,7 +914,7 @@ def test_ingestion_with_updates_and_timetravel(tmp_path):
 
         ingestion_timestamps, base_sizes = load_metadata(index_uri)
         assert ingestion_timestamps == [1]
-        assert base_sizes == [1000]
+        assert base_sizes == [size]
 
         index = index_class(uri=index_uri)
         _, result = index.query(queries, k=k, nprobe=partitions)
@@ -976,7 +976,7 @@ def test_ingestion_with_updates_and_timetravel(tmp_path):
 
         ingestion_timestamps, base_sizes = load_metadata(index_uri)
         assert ingestion_timestamps == [1, timestamp_end]
-        assert base_sizes == [1000, 1000]
+        assert base_sizes == [size, size]
 
         index = index_class(uri=index_uri)
         _, result = index.query(queries, k=k, nprobe=partitions)


### PR DESCRIPTION
### What
### What
Right now our Python tests are quite slow - here are the results on a CI run:
```
============================== slowest durations ===============================
600.18s call     test/test_ingestion.py::test_ivf_flat_ingestion_f32
501.77s call     test/test_object_index.py::test_object_index_ivf_flat_cloud
462.39s call     test/test_cloud.py::CloudTests::test_cloud_ivf_flat_random_sampling
446.13s call     test/test_cloud.py::CloudTests::test_cloud_ivf_flat
356.37s call     test/test_cloud.py::CloudTests::test_cloud_flat
339.90s call     test/test_cloud.py::CloudTests::test_cloud_vamana
293.70s call     test/test_ingestion.py::test_ingestion_with_batch_updates
79.84s call     test/test_ingestion.py::test_ingestion_with_updates_and_timetravel
52.43s call     test/test_object_index.py::test_object_index
52.36s call     test/test_ingestion.py::test_storage_versions
49.25s call     test/test_ingestion.py::test_ingestion_with_updates
29.53s call     test/test_ingestion.py::test_ingestion_with_additions_and_timetravel
19.67s call     test/test_ingestion.py::test_vamana_ingestion_u8
16.81s call     test/test_ingestion.py::test_ingestion_numpy_i8
16.70s call     test/test_ingestion.py::test_ingestion_multiple_workers
13.16s call     test/test_ingestion.py::test_ingestion_fvec
```
Here we speed up a few tests by lowering the size of the ingested vectors. It seems like we'll still get fine coverage with 10,000 instead of 100,000 vectors, and it speeds up the tests significantly.

Here you can see that on my local M2 Pro `test_ivf_flat_ingestion_f32` is taking 361 seconds today, but after this change we're at 12.3 seconds:
* `test_ivf_flat_ingestion_f32` with `size = 100000`:
```
361.33s call     apis/python/test/test_ingestion.py::test_ivf_flat_ingestion_f32
```
* `test_ivf_flat_ingestion_f32` with `size = 10000`:
```
12.30s call     apis/python/test/test_ingestion.py::test_ivf_flat_ingestion_f32
```

We also update the `dimensions` for several tests because right now most of them are using `dimensions = 128`, and getting a wider range is nice for test coverage.

### Testing
Tests pass.