### PR TITLE
Test pytest parallelism

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -30,14 +30,14 @@ jobs:
         run: |
           pip install .[test]
           cd apis/python
-          pytest -n auto --durations=0
+          pytest -n logical --durations=0
           # TODO: fix editable on linux
           #pip uninstall -y tiledb.vector_search
           #pip install -e .
           #pytest
           pip install -r test/ipynb/requirements.txt
           export TILEDB_REST_TOKEN=$TILEDB_CLOUD_HELPER_VAR
-          pytest --nbmake test/ipynb
+          pytest -n logical --durations=0 --nbmake test/ipynb
         env:
           TILEDB_CLOUD_HELPER_VAR: ${{ secrets.TILEDB_CLOUD_HELPER_VAR }}
         shell: bash -el {0}


### PR DESCRIPTION
### What
Speeds up PyTest by using `logical`, which lets us use 4 workers, versus 2 when we use `auto`:
```
created: 4/4 workers
4 workers [69 items]
```
Let me know if you have other ideas around testing this though! Happy to do something else if you have other ideas.