### PR TITLE
Expose `build_config()` in Python

### DIFF
--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -42,6 +42,7 @@
 #include "api/ivf_flat_index.h"
 #include "api/vamana_index.h"
 #include "detail/time/temporal_policy.h"
+#include "stats.h"
 
 namespace py = pybind11;
 
@@ -440,4 +441,8 @@ void init_type_erased_module(py::module_& m) {
       .def("id_type_string", &IndexIVFFlat::id_type_string)
       .def("px_type_string", &IndexIVFFlat::px_type_string)
       .def("dimensions", &IndexIVFFlat::dimensions);
+
+  m.def("build_config", []() {
+    std::cout << build_config().dump() << std::endl;
+  });
 }

--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -442,7 +442,5 @@ void init_type_erased_module(py::module_& m) {
       .def("px_type_string", &IndexIVFFlat::px_type_string)
       .def("dimensions", &IndexIVFFlat::dimensions);
 
-  m.def("build_config", []() {
-    std::cout << build_config().dump() << std::endl;
-  });
+  m.def("build_config_string", []() { return build_config().dump(); });
 }

--- a/src/include/stats.h
+++ b/src/include/stats.h
@@ -223,37 +223,28 @@ static auto dump_logs = [](std::string filename,
 };
 
 static auto build_config() {
-  std::string uuid_;
-  std::string date_;
-  std::size_t uuid_size_ = 24;
-
-  auto seed = std::random_device();
-  auto gen = std::mt19937(seed());
-  auto dis = std::uniform_int_distribution<int8_t>(97, 122);
-  uuid_.resize(uuid_size_);
-  std::generate(uuid_.begin(), uuid_.end(), [&] { return dis(gen); });
-
   // This is failing today, but could perhaps be added back in the future.
   // char host_[16];
   // if (int e = gethostname(host_, sizeof(host_))) {
   //   std::cerr << "truncated host name\n";
   //   strncpy(host_, "ghost", 15);
   // }
+
+  std::string date;
   {
     std::stringstream ss;
     std::time_t currentTime = std::time(nullptr);
     std::string dateString = std::ctime(&currentTime);
     dateString.erase(dateString.find('\n'));
     ss << dateString;
-    date_ = ss.str();
+    date = ss.str();
   }
 
   auto&& [major, minor, patch] = tiledb::version();
 
   json config = {
-      {"uuid", uuid_},
       {"Build_date", CURRENT_DATETIME},
-      {"Run_date", date_},
+      {"Run_date", date},
       {"cmake_source_dir", CMAKE_SOURCE_DIR},
       {"Build", BUILD_TYPE},
       {"Compiler",

--- a/src/include/stats.h
+++ b/src/include/stats.h
@@ -230,23 +230,12 @@ static auto build_config() {
   //   strncpy(host_, "ghost", 15);
   // }
 
-  std::string date;
-  {
-    std::stringstream ss;
-    std::time_t currentTime = std::time(nullptr);
-    std::string dateString = std::ctime(&currentTime);
-    dateString.erase(dateString.find('\n'));
-    ss << dateString;
-    date = ss.str();
-  }
-
   auto&& [major, minor, patch] = tiledb::version();
 
   json config = {
-      {"Build_date", CURRENT_DATETIME},
-      {"Run_date", date},
-      {"cmake_source_dir", CMAKE_SOURCE_DIR},
-      {"Build", BUILD_TYPE},
+      {"CURRENT_DATETIME", CURRENT_DATETIME},
+      {"CMAKE_SOURCE_DIR", CMAKE_SOURCE_DIR},
+      {"BUILD_TYPE", BUILD_TYPE},
       {"Compiler",
        {{"CXX_COMPILER", IVF_HACK_CXX_COMPILER},
         {"CXX_COMPILER_ID", CXX_COMPILER_ID},

--- a/src/include/stats.h
+++ b/src/include/stats.h
@@ -222,10 +222,8 @@ static auto dump_logs = [](std::string filename,
   }
 };
 
-#ifdef JSON_LOGGING
-static auto config_log(const std::string& program_name) {
+static auto build_config() {
   std::string uuid_;
-  char host_[16];
   std::string date_;
   std::size_t uuid_size_ = 24;
 
@@ -235,10 +233,12 @@ static auto config_log(const std::string& program_name) {
   uuid_.resize(uuid_size_);
   std::generate(uuid_.begin(), uuid_.end(), [&] { return dis(gen); });
 
-  if (int e = gethostname(host_, sizeof(host_))) {
-    std::cerr << "truncated host name\n";
-    strncpy(host_, "ghost", 15);
-  }
+  // This is failing today, but could perhaps be added back in the future.
+  // char host_[16];
+  // if (int e = gethostname(host_, sizeof(host_))) {
+  //   std::cerr << "truncated host name\n";
+  //   strncpy(host_, "ghost", 15);
+  // }
   {
     std::stringstream ss;
     std::time_t currentTime = std::time(nullptr);
@@ -252,8 +252,6 @@ static auto config_log(const std::string& program_name) {
 
   json config = {
       {"uuid", uuid_},
-      {"host", host_},
-      {"Program", program_name},
       {"Build_date", CURRENT_DATETIME},
       {"Run_date", date_},
       {"cmake_source_dir", CMAKE_SOURCE_DIR},
@@ -296,6 +294,5 @@ auto args_log(const Args& args) {
   }
   return arg_log;
 }
-#endif  // JSON_LOGGING
 
 #endif  // TDB_STATS_H

--- a/src/include/test/unit_stats.cc
+++ b/src/include/test/unit_stats.cc
@@ -27,17 +27,16 @@
  *
  * @section DESCRIPTION
  *
- * WIP.
  */
 
 #include <catch2/catch_all.hpp>
-#include <chrono>
-#include <iostream>
-#include <thread>
 
-#include "utils/logging.h"
-#include "utils/timer.h"
+#include "stats.h"
 
 TEST_CASE("stats: test test", "[stats]") {
   REQUIRE(true);
+}
+
+TEST_CASE("stats: test build_config", "[stats]") {
+  build_config();
 }


### PR DESCRIPTION
### What
When investigating an issue with Vamana cloud I wanted to print out information about the tiledb library version used in an UDF. You can do this to print out the tiledb Python library version:
```
>>> def testme():
...     import tiledb.vector_search
...     return tiledb.vector_search.version.version
...
>>> tiledb.cloud.udf.exec(testme, image_name="3.9-vectorsearch")
'0.4.0'
```
But I also noticed this function which was hidden behind a conditional directive. Here we start building it again, add a C++ test for it, and expose it in Python. This seems nice for potential future issues like this, though do let me know if you have concerns about exposing this to users.

### Result
This is what it prints out:
```
{"Build":"Release","Build_date":"2024-05-16 16:39:04","Compiler":{"CMAKE_CXX_FLAGS":"-Wall -Wno-unused-variable ","CMAKE_CXX_FLAGS_DEBUG":"-g","CMAKE_CXX_FLAGS_RELEASE":"-O3 -DNDEBUG","CMAKE_CXX_FLAGS_RELWITHDEBINFO":"-O2 -g -DNDEBUG","CXX_COMPILER":"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++","CXX_COMPILER_ID":"AppleClang","CXX_VERSION":"15.0.0.15000309"},"GIT_REPO":{"GIT_BRANCH":"main","GIT_COMMIT_DATE":"2024-05-16","GIT_COMMIT_HASH":"9effb8bc","GIT_COMMIT_TIME":"10:26:42","GIT_REPO_NAME":"TileDB-Vector-Search-4","GIT_REPO_URL":""},"Run_date":"Thu May 16 16:41:20 2024","cmake_source_dir":"/Users/parismorgan/repo/TileDB-Vector-Search-4/src","tiledb_version":{"major":2,"minor":23,"patch":0},"uuid":"fdntoharwtynnkithnxcrdcy"}
```