### PR TITLE
Fix CLion UI issue with long test names, cleanup C++ unit tests

### DIFF
--- a/src/include/test/time_l2.cc
+++ b/src/include/test/time_l2.cc
@@ -220,8 +220,6 @@ float l22_just_swap(const V& u, const U& v) {
   return l22(v, u);
 }
 
-bool global_debug = false;
-
 using typelist = std::tuple<
     std::tuple<float, float>,
     std::tuple<uint8_t, float>,

--- a/src/include/test/unit_adj_list.cc
+++ b/src/include/test/unit_adj_list.cc
@@ -33,12 +33,8 @@
 #include "detail/graph/adj_list.h"
 #include "test/utils/tiny_graphs.h"
 
-TEST_CASE("adj_list: test test", "[adj_list]") {
-  REQUIRE(true);
-}
-
 TEMPLATE_TEST_CASE(
-    "adj_list: index_adj_list initializer_list",
+    "index_adj_list initializer_list",
     "[adj_list]",
     int,
     unsigned,
@@ -57,7 +53,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "adj_list: pseudo copy constructor",
+    "pseudo copy constructor",
     "[adj_list]",
     (std::tuple<float, int>),
     (std::tuple<float, size_t>),

--- a/src/include/test/unit_algorithm.cc
+++ b/src/include/test/unit_algorithm.cc
@@ -32,11 +32,7 @@
 #include <catch2/catch_all.hpp>
 #include "algorithm.h"
 
-TEST_CASE("algorithm: test test", "[algorithm]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("algorithm: for_each", "[algorithm]") {
+TEST_CASE("for_each", "[algorithm]") {
   size_t length = GENERATE(
       0,
       1,

--- a/src/include/test/unit_api_feature_vector.cc
+++ b/src/include/test/unit_api_feature_vector.cc
@@ -35,10 +35,6 @@
 #include "test/utils/test_utils.h"
 #include "utils/utils.h"
 
-TEST_CASE("api_feature_vector: test test", "[api_feature_vector]") {
-  REQUIRE(true);
-}
-
 // ----------------------------------------------------------------------------
 // FeatureVector tests
 // ----------------------------------------------------------------------------

--- a/src/include/test/unit_api_feature_vector_array.cc
+++ b/src/include/test/unit_api_feature_vector_array.cc
@@ -44,15 +44,11 @@
 #include <tiledb/group_experimental.h>
 #include <tiledb/tiledb>
 
-TEST_CASE("api_feature_vector_array: test test", "[api_feature_vector_array]") {
-  REQUIRE(true);
-}
-
 // ----------------------------------------------------------------------------
 // FeatureVectorArray tests
 // ----------------------------------------------------------------------------
 
-TEST_CASE("api: feature vector array open", "[api]") {
+TEST_CASE("feature vector array open", "[api]") {
   tiledb::Context ctx;
 
   auto a = FeatureVectorArray(ctx, sift_inputs_uri);
@@ -84,7 +80,7 @@ auto ack() {
   _ack(MatrixView<float>{});
 }
 
-TEST_CASE("api: Matrix constructors and destructors", "[api]") {
+TEST_CASE("Matrix constructors and destructors", "[api]") {
   auto a = ColMajorMatrix<int>(3, 7);
   auto b = FeatureVectorArray(a);
 
@@ -93,7 +89,7 @@ TEST_CASE("api: Matrix constructors and destructors", "[api]") {
 }
 
 TEMPLATE_TEST_CASE(
-    "api: FeatureVectorArray feature_type",
+    "FeatureVectorArray feature_type",
     "[api]",
     int,
     int8_t,
@@ -127,7 +123,7 @@ TEMPLATE_TEST_CASE(
   CHECK(g.feature_size() == sizeof(TestType));
 }
 
-TEST_CASE("api: tdbMatrix constructors and destructors", "[api]") {
+TEST_CASE("tdbMatrix constructors and destructors", "[api]") {
   tiledb::Context ctx;
   auto c = ColMajorMatrix<int>(3, 7);
 
@@ -146,7 +142,7 @@ TEST_CASE("api: tdbMatrix constructors and destructors", "[api]") {
 }
 
 #if 0  // This fails with 2.16.0
-TEST_CASE("api: Arrays going out of scope", "[api]") {
+TEST_CASE("Arrays going out of scope", "[api]") {
   auto ctx = tiledb::Context{};
   auto foo = tiledb::Array(ctx, "/tmp/a", TILEDB_READ);
   auto bar = std::move(foo);
@@ -154,7 +150,7 @@ TEST_CASE("api: Arrays going out of scope", "[api]") {
 #endif
 
 TEMPLATE_TEST_CASE(
-    "api: tdb FeatureVectorArray feature_type",
+    "tdb FeatureVectorArray feature_type",
     "[api]",
     int,
     int8_t,
@@ -199,7 +195,7 @@ TEMPLATE_TEST_CASE(
   }
 }
 
-TEST_CASE("api: query checks", "[api][index]") {
+TEST_CASE("query checks", "[api][index]") {
   tiledb::Context ctx;
   size_t k_nn = 10;
   size_t nthreads = 8;
@@ -236,7 +232,7 @@ TEST_CASE("api: query checks", "[api][index]") {
 // FeatureVectorArray with IDs tests
 // ----------------------------------------------------------------------------
 
-TEST_CASE("api: feature vector array with IDs open", "[api]") {
+TEST_CASE("feature vector array with IDs open", "[api]") {
   tiledb::Context ctx;
 
   auto a = FeatureVectorArray(ctx, sift_inputs_uri, sift_ids_uri);
@@ -250,7 +246,7 @@ TEST_CASE("api: feature vector array with IDs open", "[api]") {
   CHECK(num_vectors(b) == num_bigann1M_vectors);
 }
 
-TEST_CASE("api: MatrixWithIds constructors and destructors", "[api]") {
+TEST_CASE("MatrixWithIds constructors and destructors", "[api]") {
   auto rows = 3;
   auto cols = 7;
 
@@ -340,7 +336,7 @@ TEST_CASE("api: MatrixWithIds constructors and destructors", "[api]") {
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(
-    "api: FeatureVectorArray with IDs feature_type",
+    "FeatureVectorArray with IDs",
     "[api]",
     (ColMajorMatrixWithIds),
     ((int, uint32_t),
@@ -393,7 +389,7 @@ TEMPLATE_PRODUCT_TEST_CASE(
   CHECK(g.ids_size() == sizeof(IdsType));
 }
 
-TEST_CASE("api: tdbMatrixWithIds constructors and destructors", "[api]") {
+TEST_CASE("tdbMatrixWithIds constructors and destructors", "[api]") {
   tiledb::Context ctx;
 
   int offset = 13;
@@ -420,7 +416,7 @@ TEST_CASE("api: tdbMatrixWithIds constructors and destructors", "[api]") {
 }
 
 TEMPLATE_TEST_CASE(
-    "api: tdb FeatureVectorArray with IDs feature_type",
+    "tdb FeatureVectorArray with IDs feature_type",
     "[api]",
     uint32_t,
     uint64_t) {
@@ -489,7 +485,7 @@ TEMPLATE_TEST_CASE(
   }
 }
 
-TEST_CASE("api: query checks with IDs", "[api][index]") {
+TEST_CASE("query checks with IDs", "[api][index]") {
   tiledb::Context ctx;
   size_t k_nn = 10;
   size_t nthreads = 8;
@@ -532,7 +528,7 @@ TEST_CASE("api: query checks with IDs", "[api][index]") {
   }
 }
 
-TEST_CASE("api: load empty matrix", "[api][index]") {
+TEST_CASE("load empty matrix", "[api][index]") {
   tiledb::Context ctx;
   std::string tmp_matrix_uri =
       (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
@@ -551,7 +547,7 @@ TEST_CASE("api: load empty matrix", "[api][index]") {
   auto X = FeatureVectorArray(ctx, tmp_matrix_uri);
 }
 
-TEST_CASE("api: temporal_policy", "[api]") {
+TEST_CASE("temporal_policy", "[api]") {
   tiledb::Context ctx;
   tiledb::VFS vfs(ctx);
 

--- a/src/include/test/unit_api_flat_l2_index.cc
+++ b/src/include/test/unit_api_flat_l2_index.cc
@@ -33,10 +33,6 @@
 #include "catch2/catch_all.hpp"
 #include "test/utils/query_common.h"
 
-TEST_CASE("api_flat_l2_index: test test", "[api_flat_l2_index]") {
-  REQUIRE(true);
-}
-
 // ----------------------------------------------------------------------------
 // Index tests
 // ----------------------------------------------------------------------------

--- a/src/include/test/unit_api_ivf_flat_index.cc
+++ b/src/include/test/unit_api_ivf_flat_index.cc
@@ -33,11 +33,7 @@
 #include "catch2/catch_all.hpp"
 #include "test/utils/query_common.h"
 
-TEST_CASE("api_ivf_flat_index: test test", "[api_ivf_flat_index]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("api_ivf_flat_index: init constructor", "[api_ivf_flat_index]") {
+TEST_CASE("init constructor", "[api_ivf_flat_index]") {
   SECTION("default") {
     auto a = IndexIVFFlat();
     CHECK(a.feature_type() == TILEDB_ANY);
@@ -130,7 +126,7 @@ TEST_CASE("api_ivf_flat_index: init constructor", "[api_ivf_flat_index]") {
   }
 }
 
-TEST_CASE("api_ivf_flat_index: infer feature type", "[api_ivf_flat_index]") {
+TEST_CASE("infer feature type", "[api_ivf_flat_index]") {
   auto a = IndexIVFFlat(std::make_optional<IndexOptions>(
       {{"id_type", "uint32"}, {"px_type", "uint32"}}));
   auto ctx = tiledb::Context{};
@@ -141,7 +137,7 @@ TEST_CASE("api_ivf_flat_index: infer feature type", "[api_ivf_flat_index]") {
   CHECK(a.px_type() == TILEDB_UINT32);
 }
 
-TEST_CASE("api_ivf_flat_index: infer dimension", "[api_ivf_flat_index]") {
+TEST_CASE("infer dimension", "[api_ivf_flat_index]") {
   auto a = IndexIVFFlat(std::make_optional<IndexOptions>(
       {{"id_type", "uint32"}, {"px_type", "uint32"}}));
   auto ctx = tiledb::Context{};
@@ -154,9 +150,7 @@ TEST_CASE("api_ivf_flat_index: infer dimension", "[api_ivf_flat_index]") {
   CHECK(dimensions(a) == 128);
 }
 
-TEST_CASE(
-    "api_ivf_flat_index: api_ivf_flat_index write and read",
-    "[api_ivf_flat_index]") {
+TEST_CASE("api_ivf_flat_index write and read", "[api_ivf_flat_index]") {
   auto ctx = tiledb::Context{};
   std::string api_ivf_flat_index_uri =
       (std::filesystem::temp_directory_path() / "api_ivf_flat_index").string();
@@ -182,9 +176,7 @@ TEST_CASE(
   CHECK(a.px_type() == b.px_type());
 }
 
-TEST_CASE(
-    "api_ivf_flat_index: build index and query in place infinite",
-    "[api_ivf_flat_index]") {
+TEST_CASE("build index and query in place infinite", "[api_ivf_flat_index]") {
   auto ctx = tiledb::Context{};
   size_t k_nn = 10;
   size_t nprobe = GENERATE(8, 32);
@@ -220,9 +212,7 @@ TEST_CASE(
 #endif
 }
 
-TEST_CASE(
-    "api_ivf_flat_index: read index and query infinite and finite",
-    "[api_ivf_flat_index]") {
+TEST_CASE("read index and query infinite and finite", "[api_ivf_flat_index]") {
   auto ctx = tiledb::Context{};
   size_t k_nn = 10;
   size_t nprobe = GENERATE(8, 32);

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -33,11 +33,7 @@
 #include "catch2/catch_all.hpp"
 #include "test/utils/query_common.h"
 
-TEST_CASE("api_vamana_index: test test", "[api_vamana_index]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("api_vamana_index: init constructor", "[api_vamana_index]") {
+TEST_CASE("init constructor", "[api_vamana_index]") {
   SECTION("default") {
     auto a = IndexVamana();
     CHECK(a.feature_type() == TILEDB_ANY);
@@ -173,9 +169,7 @@ TEST_CASE("api_vamana_index: init constructor", "[api_vamana_index]") {
   }
 }
 
-TEST_CASE(
-    "api_vamana_index: create empty index and then train and query",
-    "[api_vamana_index]") {
+TEST_CASE("create empty index and then train and query", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   using feature_type_type = uint8_t;
   using id_type_type = uint32_t;
@@ -245,7 +239,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "api_vamana_index: create empty index and then train and query with "
+    "create empty index and then train and query with "
     "external IDs",
     "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
@@ -318,7 +312,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "api_vamana_index: create empty index and then train and query with sift",
+    "create empty index and then train and query with sift",
     "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   size_t k_nn = 10;
@@ -377,7 +371,7 @@ TEST_CASE(
   }
 }
 
-TEST_CASE("api_vamana_index: infer feature type", "[api_vamana_index]") {
+TEST_CASE("infer feature type", "[api_vamana_index]") {
   auto a = IndexVamana(std::make_optional<IndexOptions>(
       {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
   auto ctx = tiledb::Context{};
@@ -388,7 +382,7 @@ TEST_CASE("api_vamana_index: infer feature type", "[api_vamana_index]") {
   CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
 }
 
-TEST_CASE("api_vamana_index: infer dimension", "[api_vamana_index]") {
+TEST_CASE("infer dimension", "[api_vamana_index]") {
   auto a = IndexVamana(std::make_optional<IndexOptions>(
       {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
   auto ctx = tiledb::Context{};
@@ -401,8 +395,7 @@ TEST_CASE("api_vamana_index: infer dimension", "[api_vamana_index]") {
   CHECK(dimensions(a) == 128);
 }
 
-TEST_CASE(
-    "api_vamana_index: api_vamana_index write and read", "[api_vamana_index]") {
+TEST_CASE("api_vamana_index write and read", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   std::string api_vamana_index_uri =
       (std::filesystem::temp_directory_path() / "api_vamana_index").string();
@@ -428,7 +421,7 @@ TEST_CASE(
   CHECK(a.adjacency_row_index_type() == b.adjacency_row_index_type());
 }
 
-TEST_CASE("api_vamana_index: build index and query", "[api_vamana_index]") {
+TEST_CASE("build index and query", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   size_t k_nn = 10;
   size_t nprobe = GENERATE(8, 32);
@@ -449,7 +442,7 @@ TEST_CASE("api_vamana_index: build index and query", "[api_vamana_index]") {
   CHECK(recall == 1.0);
 }
 
-TEST_CASE("api_vamana_index: read index and query", "[api_vamana_index]") {
+TEST_CASE("read index and query", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   size_t k_nn = 10;
 
@@ -483,7 +476,7 @@ TEST_CASE("api_vamana_index: read index and query", "[api_vamana_index]") {
   CHECK(recall == 1.0);
 }
 
-TEST_CASE("api_vamana_index: storage_version", "[api_vamana_index]") {
+TEST_CASE("storage_version", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   using feature_type_type = uint8_t;
   using id_type_type = uint32_t;
@@ -540,9 +533,7 @@ TEST_CASE("api_vamana_index: storage_version", "[api_vamana_index]") {
   }
 }
 
-TEST_CASE(
-    "api_vamana_index: write and load index with timestamps",
-    "[api_vamana_index]") {
+TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   using feature_type_type = uint8_t;
   using id_type_type = uint32_t;

--- a/src/include/test/unit_array_defs.cc
+++ b/src/include/test/unit_array_defs.cc
@@ -39,10 +39,6 @@
 #include "detail/flat/qv.h"
 #include "detail/linalg/tdb_matrix.h"
 
-TEST_CASE("array_defs: test test", "[array_defs]") {
-  REQUIRE(true);
-}
-
 std::vector<std::string> test_array_roots{
     sift_root,
     siftsmall_root,
@@ -56,7 +52,7 @@ std::vector<std::string> test_file_roots{
     siftsmall_files_root,
 };
 
-TEST_CASE("array_defs: test array root uris", "[array_defs]") {
+TEST_CASE("test array root uris", "[array_defs]") {
   for (auto& uri : {siftsmall_root, bigann10k_root}) {
     REQUIRE(std::filesystem::is_directory(uri));
   }
@@ -125,7 +121,7 @@ std::vector<std::string> siftsmall_files{
     siftsmall_groundtruth_file,
 };
 
-TEST_CASE("array_defs: test array uris", "[array_defs]") {
+TEST_CASE("test array uris", "[array_defs]") {
   bool debug = false;
 
   for (auto& test :
@@ -158,7 +154,7 @@ TEST_CASE("array_defs: test array uris", "[array_defs]") {
   }
 }
 
-TEST_CASE("array_defs: compare siftsmall arrays and files", "[array_defs]") {
+TEST_CASE("compare siftsmall arrays and files", "[array_defs]") {
   tiledb::Context ctx;
 
   auto array_inputs = tdbColMajorPreLoadMatrix<siftsmall_feature_type>(

--- a/src/include/test/unit_backwards_compatibility.cc
+++ b/src/include/test/unit_backwards_compatibility.cc
@@ -45,13 +45,7 @@
 #include "test/utils/array_defs.h"
 #include "utils/print_types.h"
 
-TEST_CASE("backwards_compatibility: test test", "[backwards_compatibility]") {
-  REQUIRE(true);
-}
-
-TEST_CASE(
-    "backwards_compatibility: test_query_old_indices",
-    "[backwards_compatibility]") {
+TEST_CASE("test_query_old_indices", "[backwards_compatibility]") {
   tiledb::Context ctx;
   tiledb::Config cfg;
 

--- a/src/include/test/unit_concepts.cc
+++ b/src/include/test/unit_concepts.cc
@@ -48,10 +48,6 @@
 #include <string>
 #include <vector>
 
-TEST_CASE("concepts: test test", "[concepts]") {
-  REQUIRE(true);
-}
-
 template <class V, class U>
 inline auto sum_of_squares(V const& a, U const& b) {
   float sum{0.0};
@@ -73,7 +69,7 @@ inline auto sum_of_squares(V const& a, U const& b) {
   return sum;
 }
 
-TEST_CASE("concepts: std::unsigned_integral", "[concepts]") {
+TEST_CASE("std::unsigned_integral", "[concepts]") {
   std::vector<unsigned> v(1);
   CHECK(std::unsigned_integral<unsigned>);
   CHECK(std::same_as<decltype(v[0]), unsigned&>);
@@ -82,7 +78,7 @@ TEST_CASE("concepts: std::unsigned_integral", "[concepts]") {
 }
 
 TEMPLATE_TEST_CASE(
-    "concepts: std::unsigned_integral sum",
+    "std::unsigned_integral sum",
     "[concepts]",
     int,
     unsigned,
@@ -102,7 +98,7 @@ TEMPLATE_TEST_CASE(
   CHECK(sum2 == 27.0);
 }
 
-TEST_CASE("concepts: random_access_range", "[concepts]") {
+TEST_CASE("random_access_range", "[concepts]") {
   CHECK(!std::ranges::random_access_range<int>);
 
   CHECK(std::ranges::random_access_range<std::vector<int>>);
@@ -117,7 +113,7 @@ TEST_CASE("concepts: random_access_range", "[concepts]") {
   CHECK(std::ranges::random_access_range<Vector<int>>);
 }
 
-TEST_CASE("concepts: sized_range", "[concepts]") {
+TEST_CASE("sized_range", "[concepts]") {
   CHECK(!std::ranges::sized_range<int>);
 
   CHECK(std::ranges::sized_range<std::vector<int>>);
@@ -132,7 +128,7 @@ TEST_CASE("concepts: sized_range", "[concepts]") {
   CHECK(std::ranges::sized_range<Vector<int>>);
 }
 
-TEST_CASE("concepts: contiguous range", "[concepts]") {
+TEST_CASE("contiguous range", "[concepts]") {
   CHECK(!std::ranges::contiguous_range<int>);
   CHECK(std::ranges::contiguous_range<std::vector<int>>);
   CHECK(std::ranges::contiguous_range<std::vector<double>>);
@@ -144,7 +140,7 @@ TEST_CASE("concepts: contiguous range", "[concepts]") {
   CHECK(std::ranges::contiguous_range<Vector<int>>);
 }
 
-TEST_CASE("concepts: range_of_ranges", "[concepts]") {
+TEST_CASE("range_of_ranges", "[concepts]") {
   CHECK(!range_of_ranges<int>);
   CHECK(!range_of_ranges<std::vector<int>>);
   CHECK(!range_of_ranges<std::vector<double>>);
@@ -164,7 +160,7 @@ TEST_CASE("concepts: range_of_ranges", "[concepts]") {
   CHECK(!range_of_ranges<Vector<int>>);
 }
 
-TEST_CASE("concepts: inner_range", "[concepts]") {
+TEST_CASE("inner_range", "[concepts]") {
   CHECK(std::is_same_v<
         inner_range_t<std::vector<std::vector<int>>>,
         std::vector<int>>);
@@ -173,25 +169,25 @@ TEST_CASE("concepts: inner_range", "[concepts]") {
         typename std::vector<std::vector<int>>::value_type>);
 }
 
-TEST_CASE("concepts: inner_iterator_t", "[concepts]") {
+TEST_CASE("inner_iterator_t", "[concepts]") {
   CHECK(std::is_same_v<
         inner_iterator_t<std::vector<std::vector<int>>>,
         std::vector<int>::iterator>);
 }
 
-TEST_CASE("concepts: inner_const_iterator_t", "[concepts]") {
+TEST_CASE("inner_const_iterator_t", "[concepts]") {
   CHECK(std::is_same_v<
         inner_const_iterator_t<std::vector<std::vector<int>>>,
         std::vector<int>::const_iterator>);
 }
 
-TEST_CASE("concepts: inner_value_t", "[concepts]") {
+TEST_CASE("inner_value_t", "[concepts]") {
   CHECK(std::is_same_v<
         inner_value_t<std::vector<std::vector<int>>>,
         std::vector<int>::value_type>);
 }
 
-TEST_CASE("concepts: inner_reference_t", "[concepts]") {
+TEST_CASE("inner_reference_t", "[concepts]") {
   CHECK(std::is_same_v<
         inner_reference_t<std::vector<std::vector<int>>>,
         std::vector<int>::reference>);
@@ -208,7 +204,7 @@ struct bar {
   }
 };
 
-TEST_CASE("concepts: invocable", "[concepts]") {
+TEST_CASE("invocable", "[concepts]") {
   foo(bar{});
   std::invoke(bar{}, 1);
   std::invoke(Vector<int>{}, 1);
@@ -222,7 +218,7 @@ TEST_CASE("concepts: invocable", "[concepts]") {
   CHECK(std::is_invocable_r_v<int, Vector<int>, int>);
 }
 
-TEST_CASE("concepts: subscriptable_range", "[concepts]") {
+TEST_CASE("subscriptable_range", "[concepts]") {
   using sv = std::vector<int>;
   using svi = std::ranges::iterator_t<sv>;
   using svri = std::iter_reference_t<svi>;
@@ -245,7 +241,7 @@ TEST_CASE("concepts: subscriptable_range", "[concepts]") {
   CHECK(subscriptable_range<Vector<int>>);
 }
 
-TEST_CASE("concepts: callable_range", "[concepts]") {
+TEST_CASE("callable_range", "[concepts]") {
   CHECK(!callable_range<int>);
   CHECK(!callable_range<std::vector<int>>);
   CHECK(!callable_range<std::vector<double>>);
@@ -261,7 +257,7 @@ TEST_CASE("concepts: callable_range", "[concepts]") {
   CHECK(callable<int, bar, int>);
 }
 
-TEST_CASE("concepts: Vector", "[concepts]") {
+TEST_CASE("Vector", "[concepts]") {
   CHECK(!range_of_ranges<Vector<int>>);
   CHECK(std::ranges::random_access_range<Vector<int>>);
   CHECK(std::ranges::sized_range<Vector<int>>);
@@ -271,7 +267,7 @@ TEST_CASE("concepts: Vector", "[concepts]") {
   CHECK(std::ranges::sized_range<Vector<int>>);
 }
 
-TEST_CASE("concepts: dimensionable", "[concepts]") {
+TEST_CASE("dimensionable", "[concepts]") {
   CHECK(!dimensionable<int>);
   CHECK(dimensionable<std::vector<int>>);
   CHECK(dimensionable<std::vector<double>>);
@@ -291,7 +287,7 @@ struct dummy_vectorable {
   }
 };
 
-TEST_CASE("concepts: vectorable", "[concepts]") {
+TEST_CASE("vectorable", "[concepts]") {
   CHECK(!vectorable<int>);
   CHECK(vectorable<std::vector<int>>);
   CHECK(vectorable<std::vector<double>>);
@@ -307,7 +303,7 @@ TEST_CASE("concepts: vectorable", "[concepts]") {
   CHECK(vectorable<dummy_vectorable>);
 }
 
-TEST_CASE("concepts: partitionable", "[concepts]") {
+TEST_CASE("partitionable", "[concepts]") {
   CHECK(!partitionable<int>);
   CHECK(!partitionable<std::vector<int>>);
   CHECK(!partitionable<std::vector<double>>);
@@ -350,7 +346,7 @@ void bar() {
   foo(dummy_feature_vector<int>{});
 }
 
-TEST_CASE("concepts: feature_vector", "[concepts]") {
+TEST_CASE("feature_vector", "[concepts]") {
   CHECK(!feature_vector<int>);
   CHECK(feature_vector<std::vector<int>>);
   CHECK(feature_vector<std::vector<double>>);
@@ -364,7 +360,7 @@ TEST_CASE("concepts: feature_vector", "[concepts]") {
   CHECK(feature_vector<dummy_feature_vector<int>>);
 }
 
-TEST_CASE("concepts: query_vector", "[concepts]") {
+TEST_CASE("query_vector", "[concepts]") {
   CHECK(!query_vector<int>);
   CHECK(query_vector<std::vector<int>>);
   CHECK(query_vector<std::vector<double>>);
@@ -379,7 +375,7 @@ TEST_CASE("concepts: query_vector", "[concepts]") {
   CHECK(query_vector<dummy_feature_vector<int>>);
 }
 
-TEST_CASE("concepts: feature_vector_array", "[concepts]") {
+TEST_CASE("feature_vector_array", "[concepts]") {
   CHECK(!feature_vector_array<int>);
   CHECK(!feature_vector_array<std::vector<int>>);
   CHECK(!feature_vector_array<std::vector<double>>);
@@ -387,17 +383,16 @@ TEST_CASE("concepts: feature_vector_array", "[concepts]") {
 }
 
 // Placeholders
-TEST_CASE("concepts: contiguous_feature_vector_range", "[concepts]") {
+TEST_CASE("contiguous_feature_vector_range", "[concepts]") {
 }
 
-TEST_CASE("concepts: partitioned_feature_vector_range", "[concepts]") {
+TEST_CASE("partitioned_feature_vector_range", "[concepts]") {
 }
 
-TEST_CASE(
-    "concepts: contiguous_partitioned_feature_vector_range", "[concepts]") {
+TEST_CASE("contiguous_partitioned_feature_vector_range", "[concepts]") {
 }
 
-TEST_CASE("concepts: distance_function", "[concepts]") {
+TEST_CASE("distance_function", "[concepts]") {
   CHECK(!distance_function<
         int,
         dummy_feature_vector_with_size<float>,
@@ -444,7 +439,7 @@ TEST_CASE("concepts: distance_function", "[concepts]") {
         dummy_feature_vector_with_size<float>>);
 }
 
-TEST_CASE("concepts: sub_distance_function", "[concepts]") {
+TEST_CASE("sub_distance_function", "[concepts]") {
   CHECK(!sub_distance_function<
         int,
         dummy_feature_vector_with_size<float>,
@@ -487,7 +482,7 @@ TEST_CASE("concepts: sub_distance_function", "[concepts]") {
         dummy_feature_vector_with_size<float>>);
 }
 
-TEST_CASE("concepts: cached_sub_distance_function", "[concepts]") {
+TEST_CASE("cached_sub_distance_function", "[concepts]") {
   CHECK(!cached_sub_distance_function<
         int,
         dummy_feature_vector_with_size<float>,

--- a/src/include/test/unit_concepts_vs.cc
+++ b/src/include/test/unit_concepts_vs.cc
@@ -42,10 +42,6 @@
 #include "detail/linalg/tdb_partitioned_matrix.h"
 #include "detail/linalg/vector.h"
 
-TEST_CASE("concepts_vs: test test", "[concepts_vs]") {
-  REQUIRE(true);
-}
-
 // Concepts:
 // 1. subscriptable_range
 // 2. callable
@@ -60,7 +56,7 @@ TEST_CASE("concepts_vs: test test", "[concepts_vs]") {
 // 11. contiguous_partitioned_feature_vector_array
 // 12. matrix_with_ids
 
-TEST_CASE("concepts_vs: Vector", "[concepts_vs]") {
+TEST_CASE("Vector", "[concepts_vs]") {
   CHECK(subscriptable_range<Vector<int>>);
   CHECK(subscriptable_range<Vector<double>>);
   CHECK(subscriptable_range<Vector<bool>>);
@@ -133,7 +129,7 @@ auto test_contiguous_feature_vector_array(const Matrix<int>& d) {
   return _contiguous_feature_vector_array(d);
 }
 
-TEST_CASE("concepts_vs: Matrix", "[concepts_vs]") {
+TEST_CASE("Matrix", "[concepts_vs]") {
   CHECK(!subscriptable_range<Matrix<int>>);
   CHECK(!subscriptable_range<Matrix<double>>);
   CHECK(!subscriptable_range<Matrix<bool>>);
@@ -179,7 +175,7 @@ TEST_CASE("concepts_vs: Matrix", "[concepts_vs]") {
   CHECK(!contiguous_partitioned_feature_vector_array<Matrix<bool>>);
 }
 
-TEST_CASE("concepts_vs: MatrixWithIds", "[concepts_vs]") {
+TEST_CASE("MatrixWithIds", "[concepts_vs]") {
   CHECK(!subscriptable_range<MatrixWithIds<int>>);
   CHECK(!subscriptable_range<MatrixWithIds<double>>);
   CHECK(!subscriptable_range<MatrixWithIds<bool>>);
@@ -225,7 +221,7 @@ TEST_CASE("concepts_vs: MatrixWithIds", "[concepts_vs]") {
   CHECK(!contiguous_partitioned_feature_vector_array<MatrixWithIds<bool>>);
 }
 
-TEST_CASE("concepts_vs: tdbMatrixWithIds", "[concepts_vs]") {
+TEST_CASE("tdbMatrixWithIds", "[concepts_vs]") {
   CHECK(!subscriptable_range<tdbMatrixWithIds<int>>);
   CHECK(!subscriptable_range<tdbMatrixWithIds<double>>);
   CHECK(!subscriptable_range<tdbMatrixWithIds<bool>>);
@@ -271,10 +267,10 @@ TEST_CASE("concepts_vs: tdbMatrixWithIds", "[concepts_vs]") {
   CHECK(!contiguous_partitioned_feature_vector_array<tdbMatrixWithIds<bool>>);
 }
 
-TEST_CASE("concepts_vs: tdbMatrix", "[concepts_vs]") {
+TEST_CASE("tdbMatrix", "[concepts_vs]") {
   REQUIRE(true);
 }
 
-TEST_CASE("concepts_vs: tdbPartitionedMatrix", "[concepts_vs]") {
+TEST_CASE("tdbPartitionedMatrix", "[concepts_vs]") {
   REQUIRE(true);
 }

--- a/src/include/test/unit_cpos.cc
+++ b/src/include/test/unit_cpos.cc
@@ -37,14 +37,10 @@
 #include "mdspan/mdspan.hpp"
 #include "utils/print_types.h"
 
-TEST_CASE("cpos: test test", "[cpos]") {
-  REQUIRE(true);
-}
-
 template <class I = size_t>
 using matrix_extents = stdx::dextents<I, 2>;
 
-TEMPLATE_TEST_CASE("cpos: test num_rows", "[cpos]", float, uint8_t) {
+TEMPLATE_TEST_CASE("test num_rows", "[cpos]", float, uint8_t) {
   std::vector<TestType> v0(200);
   std::vector<TestType> v1(200);
 

--- a/src/include/test/unit_execution_policy.cc
+++ b/src/include/test/unit_execution_policy.cc
@@ -38,7 +38,7 @@
 #include <span>
 #include "../execution_policy.h"
 
-TEST_CASE("execution_policy: construct", "[execution_policy]") {
+TEST_CASE("construct", "[execution_policy]") {
   std::execution::sequenced_policy p;
 
   std::vector<int> v(10);
@@ -48,9 +48,5 @@ TEST_CASE("execution_policy: construct", "[execution_policy]") {
   stdx::fill(q, v.begin(), v.end(), 0);
 }
 #else
-
-TEST_CASE("execution_policy: test test", "[execution_policy]") {
-  REQUIRE(true);
-}
 
 #endif

--- a/src/include/test/unit_fixed_min_heap.cc
+++ b/src/include/test/unit_fixed_min_heap.cc
@@ -40,11 +40,7 @@
 
 bool debug = false;
 
-TEST_CASE("fixed_min_heap: test test", "[fixed_min_heap]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("fixed_min_heap: std::heap", "[fixed_min_heap]") {
+TEST_CASE("std::heap", "[fixed_min_heap]") {
   std::vector<int> v{3, 1, 4, 1, 5, 9};
 
   if (debug) {
@@ -93,7 +89,7 @@ TEST_CASE("fixed_min_heap: std::heap", "[fixed_min_heap]") {
   }
 }
 
-TEST_CASE("fixed_min_heap: std::set", "[fixed_min_heap]") {
+TEST_CASE("std::set", "[fixed_min_heap]") {
   std::set<int> a;
 
   SECTION("insert in ascending order") {
@@ -112,7 +108,7 @@ TEST_CASE("fixed_min_heap: std::set", "[fixed_min_heap]") {
   CHECK(*rbegin(a) == 9);
 }
 
-TEST_CASE("fixed_min_heap: std::set with pairs", "[fixed_min_heap]") {
+TEST_CASE("std::set with pairs", "[fixed_min_heap]") {
   using element = std::tuple<float, int>;
   std::set<element> a;
 
@@ -139,7 +135,7 @@ TEST_CASE("fixed_min_heap: std::set with pairs", "[fixed_min_heap]") {
   // CHECK(*rbegin(a) == element{9, 1});
 }
 
-TEST_CASE("fixed_min_heap: initializer constructor", "[fixed_min_heap]") {
+TEST_CASE("initializer constructor", "[fixed_min_heap]") {
   fixed_min_pair_heap<float, int> a(
       5,
       {
@@ -237,7 +233,7 @@ TEST_CASE("fixed_min_heap: initializer constructor", "[fixed_min_heap]") {
   }
 }
 
-TEST_CASE("fixed_min_heap: fixed_min_pair_heap", "[fixed_min_heap]") {
+TEST_CASE("fixed_min_pair_heap", "[fixed_min_heap]") {
   fixed_min_pair_heap<float, int> a(5);
 
   SECTION("insert in ascending order") {
@@ -268,8 +264,7 @@ TEST_CASE("fixed_min_heap: fixed_min_pair_heap", "[fixed_min_heap]") {
   CHECK(a.size() == 5);
 }
 
-TEST_CASE(
-    "fixed_min_heap: fixed_min_heap with a 5500 vector", "[fixed_min_heap]") {
+TEST_CASE("fixed_min_heap with a 5500 vector", "[fixed_min_heap]") {
   using element = std::tuple<float, int>;
   fixed_min_pair_heap<float, int> a(7);
   std::vector<element> v(5500);
@@ -302,12 +297,7 @@ TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "fixed_min_heap: first_less",
-    "[fixed_min_heap]",
-    float,
-    double,
-    int,
-    unsigned) {
+    "first_less", "[fixed_min_heap]", float, double, int, unsigned) {
   first_less<std::tuple<TestType, size_t>> a;
   auto v = std::vector<std::tuple<TestType, size_t>>{
       {0, 0},
@@ -409,7 +399,7 @@ TEST_CASE("threshold_heap: new threshold", "[threshold_heap]") {
 }
 
 TEST_CASE(
-    "fixed_min_heap: fixed_max_heap with a large vector and compare function",
+    "fixed_max_heap with a large vector and compare function",
     "[fixed_min_heap]") {
   using element = std::tuple<float, int>;
 
@@ -447,8 +437,7 @@ TEST_CASE(
   CHECK(a2 == v3);
 }
 
-TEST_CASE(
-    "fixed_min_heap: fixed_max_heap with a large vector", "[fixed_min_heap]") {
+TEST_CASE("fixed_max_heap with a large vector", "[fixed_min_heap]") {
   using element = std::tuple<float, int>;
 
   fixed_min_pair_heap<float, int, std::greater<float>> a(
@@ -488,7 +477,7 @@ TEST_CASE(
 // This seems to duplicate above
 #if 0
 TEST_CASE(
-    "fixed_min_heap: fixed_max_heap with a large vector", "[fixed_min_heap]") {
+    "fixed_max_heap with a large vector", "[fixed_min_heap]") {
   using element = std::tuple<float, int>;
 
   fixed_min_pair_heap<float, int, std::greater<float>> a(

--- a/src/include/test/unit_flat_l2_index.cc
+++ b/src/include/test/unit_flat_l2_index.cc
@@ -34,11 +34,7 @@
 #include "index/flat_l2_index.h"
 #include "test/utils/array_defs.h"
 
-TEST_CASE("index: test test", "[index]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("index: uri constructor", "[index]") {
+TEST_CASE("uri constructor", "[index]") {
   tiledb::Context ctx;
   auto index = flat_l2_index<float>(ctx, sift_inputs_uri);
 }

--- a/src/include/test/unit_flat_pq_index.cc
+++ b/src/include/test/unit_flat_pq_index.cc
@@ -39,12 +39,7 @@
 #include "test/utils/gen_graphs.h"
 #include "test/utils/query_common.h"
 
-TEST_CASE("flat_pq_index: test test", "[flat_pq_index]") {
-  REQUIRE(true);
-}
-
-TEST_CASE(
-    "flat_pq_index: flat qv_partition with sub distance", "[flat_pq_index]") {
+TEST_CASE("flat qv_partition with sub distance", "[flat_pq_index]") {
   {
     auto sub_sift_base =
         ColMajorMatrix<sift_feature_type>(2, num_vectors(sift_base));
@@ -96,7 +91,7 @@ TEST_CASE(
   }
 }
 
-TEST_CASE("flat_pq_index: flat qv_partition hypercube", "[flat_pq_index]") {
+TEST_CASE("flat qv_partition hypercube", "[flat_pq_index]") {
   const bool debug = false;
 
   size_t k_near = 8;
@@ -311,14 +306,12 @@ TEST_CASE("normalize matrix", "[flat_pq_index]") {
   }
 }
 
-TEMPLATE_TEST_CASE(
-    "flat_pq_index: create flat_pq_index", "[flat_pq_index]", float, uint8_t) {
+TEMPLATE_TEST_CASE("create flat_pq_index", "[flat_pq_index]", float, uint8_t) {
   auto pq_idx = flat_pq_index<TestType, uint32_t, uint32_t>(128, 16, 8);
   REQUIRE(true);
 }
 
-TEMPLATE_TEST_CASE(
-    "flat_pq_index: train flat_pq_index", "[flat_pq_index]", float, uint8_t) {
+TEMPLATE_TEST_CASE("train flat_pq_index", "[flat_pq_index]", float, uint8_t) {
   size_t k_near = 32;
   size_t k_far = 32;
 
@@ -330,8 +323,7 @@ TEMPLATE_TEST_CASE(
   REQUIRE(true);
 }
 
-TEMPLATE_TEST_CASE(
-    "flat_pq_index: add flat_pq_index", "[flat_pq_index]", float, uint8_t) {
+TEMPLATE_TEST_CASE("add flat_pq_index", "[flat_pq_index]", float, uint8_t) {
   size_t k_near = 32;
   size_t k_far = 32;
 
@@ -345,7 +337,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "flat_pq_index: verify flat_pq_index encoding with hypercube",
+    "verify flat_pq_index encoding with hypercube",
     "[flat_pq_index]",
     float,
     uint8_t) {
@@ -363,7 +355,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "flat_pq_index: verify flat_pq_index encoding with stacked hypercube",
+    "verify flat_pq_index encoding with stacked hypercube",
     "[flat_pq_index]",
     float,
     uint8_t) {
@@ -434,8 +426,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEST_CASE(
-    "flat_pq_index: verify pq_encoding and pq_distances with siftsmall",
-    "[flat_pq_index]") {
+    "verify pq_encoding and pq_distances with siftsmall", "[flat_pq_index]") {
   tiledb::Context ctx;
   auto training_set = tdbColMajorMatrix<siftsmall_feature_type>(
       ctx, siftsmall_inputs_uri, 2500);
@@ -469,10 +460,7 @@ TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "flat_pq_index: query stacked hypercube",
-    "[flat_pq_index]",
-    float,
-    uint8_t) {
+    "query stacked hypercube", "[flat_pq_index]", float, uint8_t) {
   size_t k_dist = GENERATE(/*0,*/ 32);
   size_t k_near = k_dist;
   size_t k_far = k_dist;
@@ -691,7 +679,7 @@ TEMPLATE_TEST_CASE(
 #endif
 }
 
-TEST_CASE("flat_pq_index: query siftsmall", "[flat_pq_index]") {
+TEST_CASE("query siftsmall", "[flat_pq_index]") {
   const bool debug = false;
 
   auto k_nn = 10;
@@ -754,7 +742,7 @@ TEST_CASE("flat_pq_index: query siftsmall", "[flat_pq_index]") {
   }
 }
 
-TEST_CASE("flat_pq_index: query 1M", "[flat_pq_index]") {
+TEST_CASE("query 1M", "[flat_pq_index]") {
   const bool debug = false;
 
   auto num_vectors = num_bigann1M_vectors;
@@ -821,7 +809,7 @@ TEST_CASE("flat_pq_index: query 1M", "[flat_pq_index]") {
   }
 }
 
-TEST_CASE("flat_pq_index: flat_pq_index write and read", "[flat_pq_index]") {
+TEST_CASE("flat_pq_index write and read", "[flat_pq_index]") {
   const bool debug = false;
 
   size_t dimensions_{128};

--- a/src/include/test/unit_flat_qv.cc
+++ b/src/include/test/unit_flat_qv.cc
@@ -35,12 +35,6 @@
 #include "test/utils/array_defs.h"
 #include "test/utils/query_common.h"
 
-bool global_debug = false;
-
-TEST_CASE("qv test test", "[flat qv]") {
-  REQUIRE(true);
-}
-
 TEST_CASE("flat qv simple case", "[flat qv]") {
   auto db = ColMajorMatrix<float>{
       {

--- a/src/include/test/unit_flat_vq.cc
+++ b/src/include/test/unit_flat_vq.cc
@@ -33,10 +33,6 @@
 #include "detail/flat/vq.h"
 #include "test/utils/query_common.h"
 
-TEST_CASE("flat vq: test test", "[flat vq]") {
-  REQUIRE(true);
-}
-
 // @todo: test with tdbMatrix
 TEST_CASE("flat vq all or nothing", "[flat vq]") {
   auto ids = std::vector<size_t>(sift_base.num_cols());

--- a/src/include/test/unit_gemm.cc
+++ b/src/include/test/unit_gemm.cc
@@ -56,7 +56,7 @@
               )
 */
 
-TEST_CASE("gemm: test test", "[gemm]") {
+TEST_CASE("test cblas_sgemm", "[gemm]") {
   float a{0};
   cblas_sgemm(
       CblasRowMajor,
@@ -75,7 +75,7 @@ TEST_CASE("gemm: test test", "[gemm]") {
       1);
 }
 
-TEST_CASE("gemm: row major test", "[sgemm]") {
+TEST_CASE("row major test", "[sgemm]") {
   std::vector<float> A{1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
   std::vector<float> B{7.0, 8.0, 9.0, 10.0, 11.0, 12.0};
 

--- a/src/include/test/unit_gen_graphs.cc
+++ b/src/include/test/unit_gen_graphs.cc
@@ -36,18 +36,14 @@
 #include "test/utils/gen_graphs.h"
 #include "utils/print_types.h"
 
-TEST_CASE("gen_graphs: test test", "[gen_graphs]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("gen_graphs: unigrid", "[gen_graphs]") {
+TEST_CASE("unigrid", "[gen_graphs]") {
   auto&& [vecs, edges] = gen_uni_grid(5, 7);
 
   dump_coordinates("coords.txt", vecs);
   dump_edgelist("edges.txt", edges);
 }
 
-TEST_CASE("gen_graphs: bigrid", "[gen_graphs]") {
+TEST_CASE("bigrid", "[gen_graphs]") {
   auto&& [vecs, edges] = gen_bi_grid(5, 7);
 
   dump_coordinates("coords.txt", vecs);

--- a/src/include/test/unit_index_defs.cc
+++ b/src/include/test/unit_index_defs.cc
@@ -36,11 +36,7 @@
 #include "index/index_defs.h"
 #include "tdb_defs.h"
 
-TEST_CASE("index_defs: test test", "[index_defs]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("index_defs: tiledb_to_type", "[index_defs]") {
+TEST_CASE("tiledb_to_type", "[index_defs]") {
   CHECK(std::is_same_v<tiledb_to_type_t<TILEDB_FLOAT32>, float>);
   CHECK(std::is_same_v<tiledb_to_type_t<TILEDB_UINT64>, uint64_t>);
   CHECK(std::is_same_v<tiledb_to_type_t<TILEDB_UINT32>, uint32_t>);
@@ -50,7 +46,7 @@ TEST_CASE("index_defs: tiledb_to_type", "[index_defs]") {
   CHECK(std::is_same_v<tiledb_to_type_t<TILEDB_UINT8>, uint8_t>);
 }
 
-TEST_CASE("index_defs: type_to_tiledb", "[index_defs]") {
+TEST_CASE("type_to_tiledb", "[index_defs]") {
   CHECK(type_to_tiledb_t<float> == TILEDB_FLOAT32);
   CHECK(type_to_tiledb_t<uint64_t> == TILEDB_UINT64);
   CHECK(type_to_tiledb_t<uint32_t> == TILEDB_UINT32);
@@ -60,7 +56,7 @@ TEST_CASE("index_defs: type_to_tiledb", "[index_defs]") {
   CHECK(type_to_tiledb_t<uint8_t> == TILEDB_UINT8);
 }
 
-TEST_CASE("index_defs: string_to_datatype", "[index_defs]") {
+TEST_CASE("string_to_datatype", "[index_defs]") {
   CHECK(string_to_datatype("float32") == TILEDB_FLOAT32);
   CHECK(string_to_datatype("int8") == TILEDB_INT8);
   CHECK(string_to_datatype("uint8") == TILEDB_UINT8);
@@ -70,7 +66,7 @@ TEST_CASE("index_defs: string_to_datatype", "[index_defs]") {
   CHECK(string_to_datatype("uint64") == TILEDB_UINT64);
 }
 
-TEST_CASE("index_defs: datatype_to_string", "[index_defs]") {
+TEST_CASE("datatype_to_string", "[index_defs]") {
   CHECK(datatype_to_string(TILEDB_FLOAT32) == "float32");
   CHECK(datatype_to_string(TILEDB_INT8) == "int8");
   CHECK(datatype_to_string(TILEDB_UINT8) == "uint8");

--- a/src/include/test/unit_inner_product_distance.cc
+++ b/src/include/test/unit_inner_product_distance.cc
@@ -32,8 +32,7 @@
 #include <catch2/catch_all.hpp>
 #include "detail/scoring/inner_product.h"
 
-TEST_CASE(
-    "inner_product_distance: simple vectors", "[inner_product_distance]") {
+TEST_CASE("simple vectors", "[inner_product_distance]") {
   auto u = std::vector<uint8_t>{1, 2, 3, 4};
   auto v = std::vector<uint8_t>{5, 6, 7, 8};
   auto x = std::vector<float>{1, 2, 3, 4};

--- a/src/include/test/unit_ivf_flat_group.cc
+++ b/src/include/test/unit_ivf_flat_group.cc
@@ -40,14 +40,10 @@
 #include "index/ivf_flat_group.h"
 #include "test/utils/array_defs.h"
 
-TEST_CASE("ivf_flat_group: test test", "[ivf_flat_group]") {
-  REQUIRE(true);
-}
-
 // This test is for debugging and checks whether a particular group can be
 // opened
 #if 0
-TEST_CASE("ivf_flat_group: read a tiledb::Group", "[ivf_flat_group]") {
+TEST_CASE("read a tiledb::Group", "[ivf_flat_group]") {
   tiledb::Context ctx;
   tiledb::Config cfg;
   std::string tmp_uri = siftsmall_group_uri;
@@ -65,7 +61,7 @@ TEST_CASE("ivf_flat_group: read a tiledb::Group", "[ivf_flat_group]") {
 }
 #endif
 
-TEST_CASE("ivf_flat_group: create tiledb::Group", "[ivf_flat_group]") {
+TEST_CASE("create tiledb::Group", "[ivf_flat_group]") {
   tiledb::Context ctx;
   tiledb::Config cfg;
   std::string tmp_uri =
@@ -91,9 +87,7 @@ struct dummy_index {
   using metadata_type = ivf_flat_index_metadata;
 };
 
-TEST_CASE(
-    "ivf_flat_group: read constructor for non-existent group",
-    "[ivf_flat_group]") {
+TEST_CASE("read constructor for non-existent group", "[ivf_flat_group]") {
   tiledb::Context ctx;
 
   CHECK_THROWS_WITH(
@@ -101,7 +95,7 @@ TEST_CASE(
       "Group uri I dont exist does not exist.");
 }
 
-TEST_CASE("ivf_flat_group: write constructor - create", "[ivf_flat_group]") {
+TEST_CASE("write constructor - create", "[ivf_flat_group]") {
   std::string tmp_uri = (std::filesystem::temp_directory_path() /
                          "ivf_flat_group_test_write_constructor")
                             .string();
@@ -117,8 +111,7 @@ TEST_CASE("ivf_flat_group: write constructor - create", "[ivf_flat_group]") {
   CHECK(x.get_dimensions() == 10);
 }
 
-TEST_CASE(
-    "ivf_flat_group: write constructor - create and open", "[ivf_flat_group]") {
+TEST_CASE("write constructor - create and open", "[ivf_flat_group]") {
   bool debug = false;
   std::string tmp_uri = (std::filesystem::temp_directory_path() /
                          "ivf_flat_group_test_write_constructor")
@@ -139,8 +132,7 @@ TEST_CASE(
   CHECK(x.get_dimensions() == 10);
 }
 
-TEST_CASE(
-    "ivf_flat_group: write constructor - create and read", "[ivf_flat_group]") {
+TEST_CASE("write constructor - create and read", "[ivf_flat_group]") {
   bool debug = false;
   std::string tmp_uri = (std::filesystem::temp_directory_path() /
                          "ivf_flat_group_test_write_constructor")
@@ -159,9 +151,7 @@ TEST_CASE(
   ivf_flat_group y = ivf_flat_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
 }
 
-TEST_CASE(
-    "ivf_flat_group: write constructor - create, write, and read",
-    "[ivf_flat_group]") {
+TEST_CASE("write constructor - create, write, and read", "[ivf_flat_group]") {
   bool debug = false;
   std::string tmp_uri = (std::filesystem::temp_directory_path() /
                          "ivf_flat_group_test_write_constructor")
@@ -185,8 +175,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "ivf_flat_group: group metadata - bases, ingestions, partitions",
-    "[ivf_flat_group]") {
+    "group metadata - bases, ingestions, partitions", "[ivf_flat_group]") {
   std::string tmp_uri = (std::filesystem::temp_directory_path() /
                          "ivf_flat_group_test_write_constructor")
                             .string();
@@ -370,7 +359,7 @@ TEST_CASE(
   CHECK(x.get_dimensions() == expected_dimension + offset);
 }
 
-TEST_CASE("ivf_flat_group: storage version", "[ivf_flat_group]") {
+TEST_CASE("storage version", "[ivf_flat_group]") {
   std::string tmp_uri =
       (std::filesystem::temp_directory_path() / "ivf_flat_group").string();
 
@@ -422,7 +411,7 @@ TEST_CASE("ivf_flat_group: storage version", "[ivf_flat_group]") {
   CHECK(x.get_dimensions() == expected_dimension + offset);
 }
 
-TEST_CASE("ivf_flat_group: invalid storage version", "[ivf_flat_group]") {
+TEST_CASE("invalid storage version", "[ivf_flat_group]") {
   std::string tmp_uri =
       (std::filesystem::temp_directory_path() / "ivf_flat_group").string();
 
@@ -437,7 +426,7 @@ TEST_CASE("ivf_flat_group: invalid storage version", "[ivf_flat_group]") {
       10);
 }
 
-TEST_CASE("ivf_flat_group: mismatched storage version", "[ivf_flat_group]") {
+TEST_CASE("mismatched storage version", "[ivf_flat_group]") {
   std::string tmp_uri =
       (std::filesystem::temp_directory_path() / "ivf_flat_group").string();
 
@@ -461,7 +450,7 @@ TEST_CASE("ivf_flat_group: mismatched storage version", "[ivf_flat_group]") {
       "Version mismatch. Requested different_version but found 0.3");
 }
 
-TEST_CASE("ivf_flat_group: clear history", "[ivf_flat_group]") {
+TEST_CASE("clear history", "[ivf_flat_group]") {
   std::string tmp_uri =
       (std::filesystem::temp_directory_path() / "ivf_flat_group").string();
 

--- a/src/include/test/unit_ivf_flat_index.cc
+++ b/src/include/test/unit_ivf_flat_index.cc
@@ -41,10 +41,6 @@
 #include "test/utils/gen_graphs.h"
 #include "test/utils/query_common.h"
 
-TEST_CASE("ivf_index: test test", "[ivf_index]") {
-  REQUIRE(true);
-}
-
 // kmeans and kmeans indexing still WIP
 
 void debug_centroids(auto& index) {
@@ -58,7 +54,7 @@ void debug_centroids(auto& index) {
   std::cout << std::endl;
 }
 
-TEST_CASE("ivf_index: test kmeans initializations", "[ivf_index][init]") {
+TEST_CASE("test kmeans initializations", "[ivf_index][init]") {
   const bool debug = false;
 
   std::vector<float> data = {8, 6, 7, 5, 3, 3, 7, 2, 1, 4, 1, 3, 0, 5, 1, 2,
@@ -115,7 +111,7 @@ TEST_CASE("ivf_index: test kmeans initializations", "[ivf_index][init]") {
   CHECK(outer_counts == index.get_centroids().num_cols());
 }
 
-TEST_CASE("ivf_index: test kmeans", "[ivf_index][kmeans]") {
+TEST_CASE("test kmeans", "[ivf_index][kmeans]") {
   const bool debug = false;
 
   std::vector<float> data = {8, 6, 7, 5, 3, 3, 7, 2, 1, 4, 1, 3, 0, 5, 1, 2,
@@ -147,7 +143,7 @@ TEST_CASE("ivf_index: test kmeans", "[ivf_index][kmeans]") {
  * More significant testing of kmeans (more significant comparisons against
  * sklearn) are done in python
  */
-TEST_CASE("ivf_index: debug w/ sk", "[ivf_index]") {
+TEST_CASE("debug w/ sk", "[ivf_index]") {
   const bool debug = false;
 
   ColMajorMatrix<float> training_data{
@@ -240,7 +236,7 @@ TEST_CASE("ivf_index: debug w/ sk", "[ivf_index]") {
   }
 }
 
-TEST_CASE("ivf_index: ivf_index write and read", "[ivf_index]") {
+TEST_CASE("ivf_index write and read", "[ivf_index]") {
   size_t dimension = 128;
   size_t nlist = 100;
   size_t nprobe = 10;
@@ -275,10 +271,7 @@ TEST_CASE("ivf_index: ivf_index write and read", "[ivf_index]") {
 }
 
 TEMPLATE_TEST_CASE(
-    "flativf_index: query stacked hypercube",
-    "[flativf_index]",
-    float,
-    uint8_t) {
+    "flatquery stacked hypercube", "[flativf_index]", float, uint8_t) {
   size_t k_dist = GENERATE(0, 32);
   size_t k_near = k_dist;
   size_t k_far = k_dist;
@@ -373,8 +366,7 @@ TEMPLATE_TEST_CASE(
 
 // Note:  In-place only makes sense for infinite ram case
 // @todo Use a fixed seed for initializing kmeans
-TEST_CASE(
-    "ivf_index: Build index and query in place, infinite", "[ivf_index]") {
+TEST_CASE("Build index and query in place, infinite", "[ivf_index]") {
   tiledb::Context ctx;
   size_t nlist = GENERATE(1, 100);
   using s = siftsmall_test_init_defaults;
@@ -618,7 +610,7 @@ TEST_CASE("Read from externally written index", "[ivf_index]") {
 
 // Decided to not support this for now -- see instead unit_compat.cc
 #if 0
-TEST_CASE("ivf_index: matrix+vector constructor, infinite", "[ivf_index]") {
+TEST_CASE("matrix+vector constructor, infinite", "[ivf_index]") {
   size_t nprobe = 16;
   size_t k_nn = 10;
   size_t nthreads = 8;
@@ -683,7 +675,7 @@ TEST_CASE("ivf_index: matrix+vector constructor, infinite", "[ivf_index]") {
   }
 }
 
-TEST_CASE("ivf_index: matrix+vector constructor, finite", "[ivf_index]") {
+TEST_CASE("matrix+vector constructor, finite", "[ivf_index]") {
   size_t nprobe = 16;
   size_t k_nn = 10;
   size_t nthreads = 8;

--- a/src/include/test/unit_ivf_flat_metadata.cc
+++ b/src/include/test/unit_ivf_flat_metadata.cc
@@ -40,17 +40,12 @@
 #include "test/utils/array_defs.h"
 #include "test/utils/test_utils.h"
 
-TEST_CASE("ivf_flat_metadata: test test", "[ivf_flat_metadata]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("ivf_flat_metadata: default constructor", "[ivf_flat_metadata]") {
+TEST_CASE("default constructor", "[ivf_flat_metadata]") {
   auto x = ivf_flat_index_metadata();
   ivf_flat_index_metadata y;
 }
 
-TEST_CASE(
-    "ivf_flat_metadata: load metadata from index", "[ivf_flat_metadata]") {
+TEST_CASE("load metadata from index", "[ivf_flat_metadata]") {
   tiledb::Context ctx;
   tiledb::Config cfg;
 

--- a/src/include/test/unit_ivf_pq_group.cc
+++ b/src/include/test/unit_ivf_pq_group.cc
@@ -33,11 +33,7 @@
 
 #include "index/ivf_pq_group.h"
 
-TEST_CASE("ivf_pqt_group: test test", "[ivf_pq_group]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("ivf_pq_group: create tiledb::Group", "[ivf_pq_group]") {
+TEST_CASE("create tiledb::Group", "[ivf_pq_group]") {
   tiledb::Context ctx;
   tiledb::Config cfg;
   std::string tmp_uri =
@@ -68,8 +64,7 @@ struct dummy_pq_index {
   using metadata_type = ivf_pq_metadata;
 };
 
-TEST_CASE(
-    "ivf_pq_group: write constructor - create and open", "[ivf_pq_group]") {
+TEST_CASE("write constructor - create and open", "[ivf_pq_group]") {
   std::string tmp_uri = (std::filesystem::temp_directory_path() /
                          "ivf_pq_group_test_write_constructor")
                             .string();

--- a/src/include/test/unit_ivf_pq_index.cc
+++ b/src/include/test/unit_ivf_pq_index.cc
@@ -37,10 +37,6 @@
 #include "test/utils/gen_graphs.h"
 #include "test/utils/query_common.h"
 
-TEST_CASE("ivf_pq_index: test test", "[ivf_pq_index]") {
-  REQUIRE(true);
-}
-
 struct dummy_pq_index {
   using feature_type = float;
   using flat_vector_feature_type = feature_type;
@@ -79,7 +75,7 @@ void debug_flat_ivf_centroids(auto& index) {
   std::cout << std::endl;
 }
 
-TEST_CASE("ivf_pq_index: default construct two", "[ivf_pq_index]") {
+TEST_CASE("default construct two", "[ivf_pq_index]") {
   ivf_pq_index<float, uint32_t, uint32_t> x;
   ivf_pq_index<float, uint32_t, uint32_t> y;
   CHECK(x.compare_cached_metadata(y));
@@ -454,9 +450,7 @@ TEMPLATE_TEST_CASE(
 }
 #endif
 
-TEST_CASE(
-    "ivf_pq_index: Build index and query in place, infinite",
-    "[ivf_pq_index]") {
+TEST_CASE("Build index and query in place, infinite", "[ivf_pq_index]") {
   tiledb::Context ctx;
   // size_t nlist = GENERATE(1, 100);
   size_t nlist = 20;

--- a/src/include/test/unit_ivf_pq_metadata.cc
+++ b/src/include/test/unit_ivf_pq_metadata.cc
@@ -33,11 +33,7 @@
 #include <tiledb/tiledb>
 #include "index/ivf_pq_metadata.h"
 
-TEST_CASE("ivf_pq_metadata: test test", "[ivf_pq_metadata]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("ivf_pq_metadata: default constructor", "[ivf_pq_metadata]") {
+TEST_CASE("default constructor", "[ivf_pq_metadata]") {
   auto x = ivf_pq_metadata();
   ivf_pq_metadata y;
 }

--- a/src/include/test/unit_ivf_qv.cc
+++ b/src/include/test/unit_ivf_qv.cc
@@ -38,11 +38,7 @@
 #include "test/utils/array_defs.h"
 #include "test/utils/query_common.h"
 
-TEST_CASE("qv: test test", "[qv]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("ivf qv: infinite all or none", "[ivf qv]") {
+TEST_CASE("infinite all or none", "[ivf qv]") {
   // vq_query_infinite_ram
   // vq_query_infinite_ram_2
 
@@ -137,7 +133,7 @@ TEST_CASE("ivf qv: infinite all or none", "[ivf qv]") {
   }
 }
 
-TEST_CASE("ivf qv: finite all or none", "[ivf qv]") {
+TEST_CASE("finite all or none", "[ivf qv]") {
   // vq_query_infinite_ram
   // vq_query_infinite_ram_2
 

--- a/src/include/test/unit_ivf_vq.cc
+++ b/src/include/test/unit_ivf_vq.cc
@@ -39,18 +39,14 @@
 #include "test/utils/query_common.h"
 #include "utils/utils.h"
 
-TEST_CASE("vq: test test", "[ivf vq]") {
-  REQUIRE(true);
-}
-
 // vq_apply_query
-TEST_CASE("ivf vq: vq apply query", "[ivf vq]") {
+TEST_CASE("vq apply query", "[ivf vq]") {
   //  vq_apply_query(query, shuffled_db, new_indices, active_queries, ids,
   //  active_partitions, k_nn, first_part, last_part);
   REQUIRE(true);
 }
 
-TEST_CASE("ivf vq: infinite all or none", "[ivf vq]") {
+TEST_CASE("infinite all or none", "[ivf vq]") {
   // vq_query_infinite_ram
   // vq_query_infinite_ram_2
 
@@ -123,7 +119,7 @@ TEST_CASE("ivf vq: infinite all or none", "[ivf vq]") {
   }
 }
 
-TEST_CASE("ivf vq: finite all or none", "[ivf vq]") {
+TEST_CASE("finite all or none", "[ivf vq]") {
   // vq_query_infinite_ram
   // vq_query_infinite_ram_2
 

--- a/src/include/test/unit_l2_distance.cc
+++ b/src/include/test/unit_l2_distance.cc
@@ -34,10 +34,7 @@
 #include "detail/linalg/matrix.h"
 #include "detail/scoring/l2_distance.h"
 
-TEST_CASE("l2_distance: null test", "[l2_distance]") {
-}
-
-TEST_CASE("l2_distance: naive_sum_of_squares", "[l2_distance]") {
+TEST_CASE("naive_sum_of_squares", "[l2_distance]") {
   // size_t n = GENERATE(1, 3, 127, 1021, 1024);
 
   size_t n = GENERATE(127);

--- a/src/include/test/unit_linalg.cc
+++ b/src/include/test/unit_linalg.cc
@@ -40,11 +40,7 @@
 using TestTypes =
     std::tuple<float, uint8_t, double, int, char, size_t, uint32_t>;
 
-TEST_CASE("linalg: test test", "[linalg]") {
-  REQUIRE(true);
-}
-
-TEMPLATE_LIST_TEST_CASE("linalg: test mdspan", "[linalg][mdspan]", TestTypes) {
+TEMPLATE_LIST_TEST_CASE("test mdspan", "[linalg][mdspan]", TestTypes) {
   size_t M = GENERATE(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
   size_t N = GENERATE(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
   TestType* t = nullptr;
@@ -53,11 +49,11 @@ TEMPLATE_LIST_TEST_CASE("linalg: test mdspan", "[linalg][mdspan]", TestTypes) {
   CHECK(m.rank() == 2);
 }
 
-TEMPLATE_LIST_TEST_CASE("linalg: test span", "[linalg][span]", TestTypes) {
+TEMPLATE_LIST_TEST_CASE("test span", "[linalg][span]", TestTypes) {
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "linalg: test Vector constructor", "[linalg][vector][create]", TestTypes) {
+    "test Vector constructor", "[linalg][vector][create]", TestTypes) {
   auto a = Vector<TestType>(7);
   auto v = a.data();
   std::iota(v, v + 7, 1);
@@ -91,7 +87,7 @@ TEMPLATE_LIST_TEST_CASE(
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "linalg: test Matrix constructor, default oriented",
+    "test Matrix constructor, default oriented",
     "[linalg][matrix][create][default]",
     TestTypes) {
   auto a = Matrix<TestType>(3, 2);
@@ -127,7 +123,7 @@ TEMPLATE_LIST_TEST_CASE(
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "linalg: test Matrix constructor, row oriented",
+    "test Matrix constructor, row oriented",
     "[linalg][matrix][create][row]",
     TestTypes) {
   auto a = Matrix<TestType, Kokkos::layout_right>(3, 2);
@@ -163,7 +159,7 @@ TEMPLATE_LIST_TEST_CASE(
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "linalg: test Matrix constructor, column oriented",
+    "test Matrix constructor, column oriented",
     "[linalg][matrixx][create][column]",
     TestTypes) {
   auto a = Matrix<TestType, Kokkos::layout_left>(3, 2);
@@ -209,7 +205,7 @@ TEMPLATE_LIST_TEST_CASE(
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "linalg: test Matrix initializer_list constructor, row oriented",
+    "test Matrix initializer_list constructor, row oriented",
     "[linalg][matrix][create][row]",
     TestTypes) {
   auto a = Matrix<TestType, Kokkos::layout_right>{{1, 2}, {3, 4}, {5, 6}};
@@ -245,7 +241,7 @@ TEMPLATE_LIST_TEST_CASE(
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "linalg: test Matrix initializer list constructor, column oriented",
+    "test Matrix initializer list constructor, column oriented",
     "[linalg][matrixx][create][column]",
     TestTypes) {
   auto a = Matrix<TestType, Kokkos::layout_left>{{1, 2, 3}, {4, 5, 6}};
@@ -300,7 +296,7 @@ auto make_matrix(size_t num_rows, size_t num_cols) {
 };
 
 TEST_CASE(
-    "linalg: test Matrix copy constructor, row oriented",
+    "test Matrix copy constructor, row oriented",
     "[linalg][matrix][copy-create][row]") {
   auto&& [a, v] = make_matrix<float>(3, 2);
   CHECK(a.data() == v);
@@ -316,8 +312,7 @@ TEST_CASE(
 
 #ifdef TDB_ROW_MATRIX
 TEST_CASE(
-    "linalg: test tdbMatrix constructor, row",
-    "[linalg][tdbmatrix][create][row]") {
+    "test tdbMatrix constructor, row", "[linalg][tdbmatrix][create][row]") {
   // d1, d2, val_1
   //  data = np.array([
   //    [8, 6, 7, 5, 3, 1, 4, 1],
@@ -422,13 +417,13 @@ TEST_CASE(
 }
 #endif
 
-TEST_CASE("linalg: print cwd", "[linalg][cwd]") {
+TEST_CASE("print cwd", "[linalg][cwd]") {
   std::filesystem::path currentPath = std::filesystem::current_path();
   std::cout << "Current Working Directory: " << currentPath << std::endl;
 }
 
 TEST_CASE(
-    "linalg: test tdbMatrix constructor, column",
+    "test tdbMatrix constructor, column",
     "[linalg][tdbmatrix][create][column]") {
   std::vector<float> data = {
       8, 6, 7, 5, 3, 1, 4, 1, 3, 0, 9, 9, 5, 9, 2, 7,
@@ -526,7 +521,7 @@ TEST_CASE(
 
 #ifdef TILEDB_ROW_MATRIX
 TEST_CASE(
-    "linalg: test partitioned tdbMatrix constructor, row",
+    "test partitioned tdbMatrix constructor, row",
     "[linalg][partitioned][tdbmatrix][create][row]") {
   size_t part = GENERATE(0, 1, 2, 3, 4);
 
@@ -591,7 +586,7 @@ TEST_CASE(
 #endif
 
 TEST_CASE(
-    "linalg: test partitioned tdbMatrix constructor, column",
+    "test partitioned tdbMatrix constructor, column",
     "[linalg][partitioned][tdbmatrix][create][column]") {
   REQUIRE(local_array_exists("array_dense_1"));
   size_t part = GENERATE(0, 1, 2, 3, 4);
@@ -652,8 +647,7 @@ TEST_CASE(
 }
 
 #ifdef TILEDB_ROW_MATRIX
-TEST_CASE(
-    "linalg: test advance, row major", "[linalg][tdbmatrix][advance][row]") {
+TEST_CASE("test advance, row major", "[linalg][tdbmatrix][advance][row]") {
   tiledb::Context ctx;
   auto a = tdbMatrix<float, Kokkos::layout_right>(ctx, "array_dense_1", 2);
   a.load();
@@ -701,8 +695,7 @@ TEST_CASE(
 }
 #endif
 
-TEST_CASE(
-    "linalg: test advance, column", "[linalg][tdbmatrix][advance][column]") {
+TEST_CASE("test advance, column", "[linalg][tdbmatrix][advance][column]") {
   REQUIRE(local_array_exists("array_dense_1"));
   tiledb::Context ctx;
   auto a = tdbMatrix<float, Kokkos::layout_left>(ctx, "array_dense_2", 2);
@@ -751,9 +744,7 @@ TEST_CASE(
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "linalg: test write/read std::vector",
-    "[linalg][read-write][vector]",
-    TestTypes) {
+    "test write/read std::vector", "[linalg][read-write][vector]", TestTypes) {
   auto length = GENERATE(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
   tiledb::Context ctx;
 
@@ -775,7 +766,7 @@ TEMPLATE_LIST_TEST_CASE(
 using LayoutTypes = std::tuple<Kokkos::layout_right, Kokkos::layout_left>;
 
 TEMPLATE_LIST_TEST_CASE(
-    "linalg: test write/read Matrix",
+    "test write/read Matrix",
     "[linalg][tdbmatrix][read-write][matrix]",
     TestTypes) {
   size_t M = GENERATE(1, 2, 13, 1440, 1441);

--- a/src/include/test/unit_logging.cc
+++ b/src/include/test/unit_logging.cc
@@ -42,11 +42,7 @@ using namespace std::literals::chrono_literals;
 
 auto duration = 500ms;
 
-TEST_CASE("logging: test test", "[logging]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("logging: test", "[logging]") {
+TEST_CASE("test", "[logging]") {
   log_timer a("test");
 
   std::this_thread::sleep_for(500ms);
@@ -64,7 +60,7 @@ TEST_CASE("logging: test", "[logging]") {
   CHECK((f <= 1040 && f >= 1000));
 }
 
-TEST_CASE("logging: noisy test", "[logging]") {
+TEST_CASE("noisy test", "[logging]") {
   log_timer a("noisy_test", true);
 
   std::this_thread::sleep_for(500ms);
@@ -82,7 +78,7 @@ TEST_CASE("logging: noisy test", "[logging]") {
   CHECK((f <= 1040 && f >= 1000));
 }
 
-TEST_CASE("logging: interval test", "[logging]") {
+TEST_CASE("interval test", "[logging]") {
   log_timer a("interval_test", true);
 
   std::this_thread::sleep_for(500ms);
@@ -125,18 +121,18 @@ TEST_CASE("logging: interval test", "[logging]") {
   CHECK((f <= 1040 && f >= 1000));
 }
 
-TEST_CASE("logging: scoped_timer start test", "[logging]") {
+TEST_CASE("scoped_timer start test", "[logging]") {
   scoped_timer a("life_test");
   std::this_thread::sleep_for(300ms);
 }
 
-TEST_CASE("logging: scoped_timer stop test", "[logging]") {
+TEST_CASE("scoped_timer stop test", "[logging]") {
   std::this_thread::sleep_for(500ms);
   auto f = _timing_data.get_entries_summed("life_test");
   CHECK((f <= 320 && f >= 300));
 }
 
-TEST_CASE("logging: ordering", "[logging]") {
+TEST_CASE("ordering", "[logging]") {
   auto g = log_timer{"g"};
   auto f = log_timer{"f"};
   auto i = log_timer{"i"};
@@ -180,6 +176,6 @@ TEST_CASE("logging: ordering", "[logging]") {
   CHECK((f_t > 499 && f_t < 560));
 }
 
-TEST_CASE("logging: memory", "[logging]") {
+TEST_CASE("memory", "[logging]") {
   _memory_data.insert_entry(tdb_func__, 8675309);
 }

--- a/src/include/test/unit_matrix.cc
+++ b/src/include/test/unit_matrix.cc
@@ -38,21 +38,17 @@
 
 using TestTypes = std::tuple<float, double, int, char, size_t, uint32_t>;
 
-TEST_CASE("matrix: test test", "[matrix]") {
-  REQUIRE(true);
-}
-
 /*
  * Many tests remain in linalg.cc from before the refactor.
  */
-TEST_CASE("matrix: initializer list", "[matrix]") {
+TEST_CASE("initializer list", "[matrix]") {
   auto A = Matrix<float>{{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
   auto a = std::vector<float>{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8};
   CHECK(
       std::equal(A.data(), A.data() + A.num_rows() * A.num_cols(), a.begin()));
 }
 
-TEST_CASE("matrix: copy", "[matrix]") {
+TEST_CASE("copy", "[matrix]") {
   auto A = Matrix<float>{{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
   auto a = std::vector<float>{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8};
   auto aptr = A.data();
@@ -67,7 +63,7 @@ TEST_CASE("matrix: copy", "[matrix]") {
   CHECK(A.data() == nullptr);
 }
 
-TEST_CASE("matrix: assign", "[matrix]") {
+TEST_CASE("assign", "[matrix]") {
   auto A = Matrix<float>{{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
   auto a = std::vector<float>{8, 6, 7, 5, 3, 0, 9, 5, 0, 2, 7, 3};
 
@@ -86,7 +82,7 @@ TEST_CASE("matrix: assign", "[matrix]") {
   CHECK(A.data() == nullptr);
 }
 
-TEST_CASE("matrix: vector of matrix", "[matrix]") {
+TEST_CASE("vector of matrix", "[matrix]") {
   std::vector<Matrix<float>> v;
 
   auto A = Matrix<float>{{8, 6, 7}, {5, 3, 0}, {9, 5, 0}};
@@ -139,7 +135,7 @@ TEST_CASE("matrix: vector of matrix", "[matrix]") {
   }
 }
 
-TEMPLATE_TEST_CASE("matrix: view", "[matrix]", char, float, int32_t, int64_t) {
+TEMPLATE_TEST_CASE("view", "[matrix]", char, float, int32_t, int64_t) {
   size_t major = 7;
   size_t minor = 13;
   auto v = std::vector<TestType>(major * minor);

--- a/src/include/test/unit_matrix_with_ids.cc
+++ b/src/include/test/unit_matrix_with_ids.cc
@@ -38,17 +38,8 @@
 #include "detail/linalg/matrix_with_ids.h"
 #include "mdspan/mdspan.hpp"
 
-TEST_CASE("matrix_with_ids: test test", "[matrix_with_ids]") {
-  REQUIRE(true);
-}
-
 TEMPLATE_TEST_CASE(
-    "matrix_with_ids: template arguments",
-    "[matrix_with_ids]",
-    char,
-    float,
-    int32_t,
-    int64_t) {
+    "template arguments", "[matrix_with_ids]", char, float, int32_t, int64_t) {
   auto vectors = std::unique_ptr<float[]>(new float[100]);
   auto ids = std::unique_ptr<TestType[]>(new TestType[100]);
   auto matrix = MatrixWithIds<float, TestType>{
@@ -57,7 +48,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "matrix_with_ids: move constructor",
+    "move constructor",
     "[matrix_with_ids]",
     stdx::layout_right,
     stdx::layout_left) {
@@ -80,12 +71,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "matrix_with_ids: size constructor",
-    "[matrix_with_ids]",
-    char,
-    float,
-    int32_t,
-    int64_t) {
+    "size constructor", "[matrix_with_ids]", char, float, int32_t, int64_t) {
   auto row_matrix =
       MatrixWithIds<TestType, TestType, stdx::layout_right, size_t>{2, 5};
   CHECK(row_matrix.num_rows() == 2);
@@ -106,7 +92,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "matrix_with_ids: initializer list",
+    "initializer list",
     "[matrix_with_ids]",
     stdx::layout_right,
     stdx::layout_left) {
@@ -134,10 +120,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "matrix_with_ids: copy",
-    "[matrix_with_ids]",
-    stdx::layout_right,
-    stdx::layout_left) {
+    "copy", "[matrix_with_ids]", stdx::layout_right, stdx::layout_left) {
   auto A = MatrixWithIds<float, float, TestType>{
       {{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}}, {1, 2, 3, 4}};
 
@@ -167,10 +150,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "matrix_with_ids: assign",
-    "[matrix_with_ids]",
-    stdx::layout_right,
-    stdx::layout_left) {
+    "assign", "[matrix_with_ids]", stdx::layout_right, stdx::layout_left) {
   auto A = MatrixWithIds<float, float, TestType>{
       {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}, {0, 1, 2, 3}};
   auto a = std::vector<float>{8, 6, 7, 5, 3, 0, 9, 5, 0, 2, 7, 3};
@@ -195,7 +175,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "matrix_with_ids: assign to matrix",
+    "assign to matrix",
     "[matrix_with_ids]",
     stdx::layout_right,
     stdx::layout_left) {
@@ -217,7 +197,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "matrix_with_ids: vector of matrix",
+    "vector of matrix",
     "[matrix_with_ids]",
     stdx::layout_right,
     stdx::layout_left) {
@@ -286,13 +266,7 @@ TEMPLATE_TEST_CASE(
   }
 }
 
-TEMPLATE_TEST_CASE(
-    "matrix_with_ids: view",
-    "[matrix_with_ids]",
-    char,
-    float,
-    int32_t,
-    int64_t) {
+TEMPLATE_TEST_CASE("view", "[matrix_with_ids]", char, float, int32_t, int64_t) {
   size_t major = 7;
   size_t minor = 13;
   auto v = std::vector<TestType>(major * minor);

--- a/src/include/test/unit_mdspan.cc
+++ b/src/include/test/unit_mdspan.cc
@@ -37,11 +37,7 @@ namespace stdx {
 using namespace Kokkos;
 }  // namespace stdx
 
-TEST_CASE("mdspan: test test", "[mdspan]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("mdspan: basic construction", "[mdspan]") {
+TEST_CASE("basic construction", "[mdspan]") {
   // using a = stdx::mdspan<int, stdx::extents<>>;
   // using a = Kokkos::mdspan<int, Kokkos::extents<size_t,
   // stdx::dynamic_extent>>;
@@ -80,7 +76,7 @@ TEST_CASE("mdspan: basic construction", "[mdspan]") {
   }
 }
 
-TEST_CASE("mdspan: rectangular", "[mdspan]") {
+TEST_CASE("rectangular", "[mdspan]") {
   std::vector<int> v(187);
   std::iota(v.begin(), v.end(), 17);
 

--- a/src/include/test/unit_memory.cc
+++ b/src/include/test/unit_memory.cc
@@ -6,18 +6,14 @@
 #include <memory>
 #include <vector>
 
-TEST_CASE("memory: test test", "[memory]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("memory: move unique_ptr scalar", "[memory]") {
+TEST_CASE("move unique_ptr scalar", "[memory]") {
   auto p = std::make_unique<int>(42);
   auto q = std::move(p);
   REQUIRE(*q == 42);
   REQUIRE(p == nullptr);
 }
 
-TEST_CASE("memory: move unique_ptr array", "[memory]") {
+TEST_CASE("move unique_ptr array", "[memory]") {
   // This will default initialize the array
   std::unique_ptr<double[]> storage_{new double[42]};
 

--- a/src/include/test/unit_nn-descent.cc
+++ b/src/include/test/unit_nn-descent.cc
@@ -43,17 +43,8 @@
 
 bool debug = false;
 
-TEST_CASE("nn-descent: test test", "[nn-descent]") {
-  REQUIRE(true);
-}
-
 TEMPLATE_TEST_CASE(
-    "nn-descent: accuracy",
-    "[nn-descent]",
-    uint32_t,
-    int32_t,
-    uint64_t,
-    int64_t) {
+    "accuracy", "[nn-descent]", uint32_t, int32_t, uint64_t, int64_t) {
   size_t k_nn = 10;
 
   using feature_type = float;
@@ -102,12 +93,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "nn-descent: connectivity",
-    "[nn-descent]",
-    int32_t,
-    uint32_t,
-    int64_t,
-    uint64_t) {
+    "connectivity", "[nn-descent]", int32_t, uint32_t, int64_t, uint64_t) {
   size_t k_nn = 10;
 
   using feature_type = float;
@@ -123,7 +109,7 @@ TEMPLATE_TEST_CASE(
   bfs(g, TestType{0});
 }
 
-TEST_CASE("nn-descent: nn_descent_1", "[nn-descent]") {
+TEST_CASE("nn_descent_1", "[nn-descent]") {
   using feature_type = float;
   using id_type = uint32_t;
 
@@ -190,7 +176,7 @@ TEST_CASE("nn-descent: nn_descent_1", "[nn-descent]") {
   }
 }
 
-TEST_CASE("nn-descent: nn_descent_1 vs ivf", "[nn-descent]") {
+TEST_CASE("nn_descent_1 vs ivf", "[nn-descent]") {
   using feature_type = float;
   using id_type = uint64_t;
 

--- a/src/include/test/unit_nn-graph.cc
+++ b/src/include/test/unit_nn-graph.cc
@@ -33,13 +33,7 @@
 #include "detail/graph/nn-graph.h"
 #include "test/utils/query_common.h"
 
-bool global_debug = false;
-
-TEST_CASE("nn-graph: test test", "[nn-graph]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("nn-graph: init_random_graph", "[nn-graph]") {
+TEST_CASE("init_random_graph", "[nn-graph]") {
   using feature_type = float;
   using id_type = uint32_t;
 
@@ -57,7 +51,7 @@ TEST_CASE("nn-graph: init_random_graph", "[nn-graph]") {
   CHECK(total_degree == g.num_vertices() * k_nn);
 }
 
-TEST_CASE("nn-graph: reverse random graph", "[nn-graph]") {
+TEST_CASE("reverse random graph", "[nn-graph]") {
   using feature_type = float;
   using id_type = uint32_t;
 

--- a/src/include/test/unit_partition.cc
+++ b/src/include/test/unit_partition.cc
@@ -34,11 +34,7 @@
 #include "test/utils/array_defs.h"
 #include "test/utils/query_common.h"
 
-TEST_CASE("partition: test test", "[partition]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("partition: top_centroids", "[partition]") {
+TEST_CASE("top_centroids", "[partition]") {
   auto parts = ColMajorMatrix<float>{
       {
           1,
@@ -81,7 +77,7 @@ TEST_CASE("partition: top_centroids", "[partition]") {
   CHECK(top_centroids(0, 4) == 1);
 }
 
-TEST_CASE("partition: partition_ivf_index", "[partition]") {
+TEST_CASE("partition_ivf_index", "[partition]") {
   // auto partition_ivf_index(
   //      auto&& centroids, auto&& query, size_t nprobe, size_t nthreads)
 

--- a/src/include/test/unit_partitioned_matrix.cc
+++ b/src/include/test/unit_partitioned_matrix.cc
@@ -36,10 +36,6 @@
 #include "detail/linalg/partitioned_matrix.h"
 #include "mdspan/mdspan.hpp"
 
-TEST_CASE("partitioned_matrix: test test", "[partitioned_matrix]") {
-  REQUIRE(true);
-}
-
 TEST_CASE("partitioned_matrix: sizes constructor", "[partitioned_matrix]") {
   using feature_type = int;
   using id_type = int;

--- a/src/include/test/unit_scoring.cc
+++ b/src/include/test/unit_scoring.cc
@@ -42,7 +42,7 @@
 
 #if defined(TILEDB_VS_ENABLE_BLAS) && 0
 
-TEST_CASE("scoring: vector test", "[scoring]") {
+TEST_CASE("vector test", "[scoring]") {
   std::vector<std::vector<float>> a{
       {1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}};
   std::vector<float> b{0, 0, 0, 0};
@@ -92,9 +92,7 @@ using scoring_typelist = std::tuple<
     std::tuple<float, size_t, int>>;
 // get_top_k (heap) from scores array
 TEMPLATE_LIST_TEST_CASE(
-    "scoring: get_top_k_from_scores vector",
-    "[scoring][get_top_k]",
-    scoring_typelist) {
+    "get_top_k_from_scores vector", "[scoring][get_top_k]", scoring_typelist) {
   using score_type = std::tuple_element_t<0, TestType>;
   using index_type = std::tuple_element_t<1, TestType>;
   // using groundtruth_type = std::tuple_element_t<2, TestType>;
@@ -112,9 +110,7 @@ TEMPLATE_LIST_TEST_CASE(
 
 // get_top_k (heap) from scores matrix, parallel
 TEMPLATE_LIST_TEST_CASE(
-    "scoring: get_top_k_from_scores matrix",
-    "[scoring][get_top_k]",
-    scoring_typelist) {
+    "get_top_k_from_scores matrix", "[scoring][get_top_k]", scoring_typelist) {
   using score_type = std::tuple_element_t<0, TestType>;
   using index_type = std::tuple_element_t<1, TestType>;
   using groundtruth_type = std::tuple_element_t<2, TestType>;
@@ -168,8 +164,7 @@ TEMPLATE_LIST_TEST_CASE(
 }
 
 // consolidate scores
-TEMPLATE_LIST_TEST_CASE(
-    "scoring: consolidate scores", "[scoring]", scoring_typelist) {
+TEMPLATE_LIST_TEST_CASE("consolidate scores", "[scoring]", scoring_typelist) {
   using score_type = std::tuple_element_t<0, TestType>;
   using index_type = std::tuple_element_t<1, TestType>;
   // using groundtruth_type = std::tuple_element_t<2, TestType>;
@@ -293,9 +288,7 @@ TEMPLATE_LIST_TEST_CASE(
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "scoring: get_top_k_from_heap one min_heap",
-    "[scoring]",
-    scoring_typelist) {
+    "get_top_k_from_heap one min_heap", "[scoring]", scoring_typelist) {
   using score_type = std::tuple_element_t<0, TestType>;
   using index_type = std::tuple_element_t<1, TestType>;
   using groundtruth_type = std::tuple_element_t<2, TestType>;
@@ -374,7 +367,7 @@ TEMPLATE_LIST_TEST_CASE(
   }
 }
 
-TEMPLATE_LIST_TEST_CASE("scoring: get_top_k", "[scoring]", scoring_typelist) {
+TEMPLATE_LIST_TEST_CASE("get_top_k", "[scoring]", scoring_typelist) {
   using score_type = std::tuple_element_t<0, TestType>;
   using index_type = std::tuple_element_t<1, TestType>;
   using groundtruth_type = std::tuple_element_t<2, TestType>;
@@ -524,9 +517,7 @@ TEMPLATE_LIST_TEST_CASE("scoring: get_top_k", "[scoring]", scoring_typelist) {
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "scoring: get_top_k_from_heap vector of min_heap",
-    "[scoring]",
-    scoring_typelist) {
+    "get_top_k_from_heap vector of min_heap", "[scoring]", scoring_typelist) {
   using score_type = std::tuple_element_t<0, TestType>;
   using index_type = std::tuple_element_t<1, TestType>;
   using groundtruth_type = std::tuple_element_t<2, TestType>;
@@ -629,8 +620,7 @@ TEMPLATE_LIST_TEST_CASE(
 }
 
 // test pad with sentinel
-TEMPLATE_LIST_TEST_CASE(
-    "scoring: pad_with_sentinels", "[scoring]", scoring_typelist) {
+TEMPLATE_LIST_TEST_CASE("pad_with_sentinels", "[scoring]", scoring_typelist) {
   using score_type = std::tuple_element_t<0, TestType>;
   using index_type = std::tuple_element_t<1, TestType>;
   using groundtruth_type = std::tuple_element_t<2, TestType>;
@@ -729,7 +719,7 @@ inline float sum_of_squares_avx2(const V& a, const W& b) {
   return sum;
 }
 
-TEST_CASE("scoring: avx2", "[scoring]") {
+TEST_CASE("avx2", "[scoring]") {
   ColMajorMatrix<float> rand_a{
       {0, 1, 2, 3, 4, 5, 6, 7, 3, 1, 4},
       {8, 9, 10, 11, 12, 13, 14, 15, 1, 5, 9},

--- a/src/include/test/unit_stats.cc
+++ b/src/include/test/unit_stats.cc
@@ -33,10 +33,6 @@
 
 #include "stats.h"
 
-TEST_CASE("stats: test test", "[stats]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("stats: test build_config", "[stats]") {
+TEST_CASE("test build_config", "[stats]") {
   build_config();
 }

--- a/src/include/test/unit_stl.cc
+++ b/src/include/test/unit_stl.cc
@@ -3,7 +3,7 @@
 #include <catch2/catch_all.hpp>
 #include <set>
 
-TEST_CASE("stl: basic set", "[set]") {
+TEST_CASE("basic set", "[set]") {
   std::set<int> s_a{1, 2, 3, 4, 5};
   CHECK(s_a.size() == 5);
   CHECK(*(s_a.begin()) == 1);
@@ -13,7 +13,7 @@ TEST_CASE("stl: basic set", "[set]") {
   CHECK(*(s_d.begin()) == 1);
 }
 
-TEST_CASE("stl: scalar set with less comparator", "[set]") {
+TEST_CASE("scalar set with less comparator", "[set]") {
   using set_type = std::set<size_t, std::less<size_t>>;
 
   set_type s_a{1, 2, 3, 4, 5};
@@ -25,7 +25,7 @@ TEST_CASE("stl: scalar set with less comparator", "[set]") {
   CHECK(*(s_d.begin()) == 1);
 }
 
-TEST_CASE("stl: scalar set with greater comparator", "[set]") {
+TEST_CASE("scalar set with greater comparator", "[set]") {
   using set_type = std::set<size_t, std::greater<size_t>>;
 
   set_type s_a{1, 2, 3, 4, 5};

--- a/src/include/test/unit_tdb_io.cc
+++ b/src/include/test/unit_tdb_io.cc
@@ -40,14 +40,10 @@
 #include "test/utils/array_defs.h"
 #include "test/utils/query_common.h"
 
-TEST_CASE("tdb_io: test test", "[tdb_io]") {
-  REQUIRE(true);
-}
-
 // This may not work any longer as we are putting array sizes into the group
 // metadata rather than assuming it is the same as the array dimensions.
 #if 0
-TEST_CASE("tdb_io: read vector", "[tdb_io]") {
+TEST_CASE("read vector", "[tdb_io]") {
   tiledb::Context ctx;
 
   // Nice hallucination
@@ -57,7 +53,7 @@ TEST_CASE("tdb_io: read vector", "[tdb_io]") {
 }
 #endif
 
-TEMPLATE_TEST_CASE("tdb_io: read / write vector", "[tdb_io]", float, uint8_t) {
+TEMPLATE_TEST_CASE("read / write vector", "[tdb_io]", float, uint8_t) {
   tiledb::Context ctx;
   std::string tmp_std_vector_uri =
       (std::filesystem::temp_directory_path() / "tmp_std_vector").string();
@@ -89,7 +85,7 @@ TEMPLATE_TEST_CASE("tdb_io: read / write vector", "[tdb_io]", float, uint8_t) {
   CHECK(y == v);
 }
 
-TEST_CASE("tdb_io: read matrix", "[tdb_io]") {
+TEST_CASE("read matrix", "[tdb_io]") {
   tiledb::Context ctx;
 
   auto X = tdbColMajorMatrix<uint8_t>(ctx, bigann1M_inputs_uri);
@@ -97,7 +93,7 @@ TEST_CASE("tdb_io: read matrix", "[tdb_io]") {
   CHECK(dimensions(X) == bigann1M_dimension);
 }
 
-TEST_CASE("tdb_io: load_file", "[tdb_io]") {
+TEST_CASE("load_file", "[tdb_io]") {
   tiledb::Context ctx;
 
   SECTION("inputs") {
@@ -119,7 +115,7 @@ TEST_CASE("tdb_io: load_file", "[tdb_io]") {
   }
 }
 
-TEMPLATE_TEST_CASE("tdb_io: write matrix", "[tdb_io]", float, uint8_t) {
+TEMPLATE_TEST_CASE("write matrix", "[tdb_io]", float, uint8_t) {
   tiledb::Context ctx;
   std::string tmp_matrix_uri =
       (std::filesystem::temp_directory_path() / "tmp_matrix").string();
@@ -151,7 +147,7 @@ TEMPLATE_TEST_CASE("tdb_io: write matrix", "[tdb_io]", float, uint8_t) {
   }
 }
 
-TEST_CASE("tdb_io: write empty matrix", "[tdb_io]") {
+TEST_CASE("write empty matrix", "[tdb_io]") {
   tiledb::Context ctx;
   std::string tmp_matrix_uri =
       (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
@@ -183,7 +179,7 @@ TEST_CASE("tdb_io: write empty matrix", "[tdb_io]") {
   CHECK(empty_preload_matrix.num_rows() == 0);
 }
 
-TEST_CASE("tdb_io: write empty vector", "[tdb_io]") {
+TEST_CASE("write empty vector", "[tdb_io]") {
   tiledb::Context ctx;
   std::string tmp_vector_uri =
       (std::filesystem::temp_directory_path() / "tmp_vector").string();
@@ -211,7 +207,7 @@ TEST_CASE("tdb_io: write empty vector", "[tdb_io]") {
   CHECK(filled_vector.size() == domain);
 }
 
-TEST_CASE("tdb_io: create group", "[tdb_io]") {
+TEST_CASE("create group", "[tdb_io]") {
   size_t N = 10'000;
 
   tiledb::Context ctx;

--- a/src/include/test/unit_tdb_matrix.cc
+++ b/src/include/test/unit_tdb_matrix.cc
@@ -41,11 +41,7 @@
 
 using TestTypes = std::tuple<float, double, int, char, size_t, uint32_t>;
 
-TEST_CASE("tdb_matrix: test test", "[tdb_matrix]") {
-  REQUIRE(true);
-}
-
-TEMPLATE_TEST_CASE("tdb_matrix: constructors", "[tdb_matrix]", float, uint8_t) {
+TEMPLATE_TEST_CASE("constructors", "[tdb_matrix]", float, uint8_t) {
   tiledb::Context ctx;
   std::string tmp_matrix_uri =
       (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
@@ -82,8 +78,7 @@ TEMPLATE_TEST_CASE("tdb_matrix: constructors", "[tdb_matrix]", float, uint8_t) {
   }
 }
 
-TEMPLATE_TEST_CASE(
-    "tdb_matrix: assign to matrix", "[tdb_matrix]", float, uint8_t) {
+TEMPLATE_TEST_CASE("assign to matrix", "[tdb_matrix]", float, uint8_t) {
   tiledb::Context ctx;
   std::string tmp_matrix_uri =
       (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
@@ -164,7 +159,7 @@ TEMPLATE_TEST_CASE(
   }
 }
 
-TEMPLATE_TEST_CASE("tdb_matrix: preload", "[tdb_matrix]", float, uint8_t) {
+TEMPLATE_TEST_CASE("preload", "[tdb_matrix]", float, uint8_t) {
   tiledb::Context ctx;
   std::string tmp_matrix_uri =
       (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
@@ -207,7 +202,7 @@ TEMPLATE_TEST_CASE("tdb_matrix: preload", "[tdb_matrix]", float, uint8_t) {
   }
 }
 
-TEST_CASE("tdb_matrix: MatrixBase template parameter", "[tdb_matrix]") {
+TEST_CASE("MatrixBase template parameter", "[tdb_matrix]") {
   // Load data.
   tiledb::Context ctx;
   int offset = 13;
@@ -272,7 +267,7 @@ TEST_CASE("tdb_matrix: MatrixBase template parameter", "[tdb_matrix]") {
   }
 }
 
-TEST_CASE("tdb_matrix: empty matrix", "[tdb_matrix]") {
+TEST_CASE("empty matrix", "[tdb_matrix]") {
   tiledb::Context ctx;
   std::string tmp_matrix_uri =
       (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
@@ -337,7 +332,7 @@ TEST_CASE("tdb_matrix: empty matrix", "[tdb_matrix]") {
   }
 }
 
-TEST_CASE("tdb_matrix: time travel", "[tdb_matrix]") {
+TEST_CASE("time travel", "[tdb_matrix]") {
   tiledb::Context ctx;
   std::string tmp_matrix_uri =
       (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();

--- a/src/include/test/unit_tdb_matrix_with_ids.cc
+++ b/src/include/test/unit_tdb_matrix_with_ids.cc
@@ -36,12 +36,8 @@
 #include "test/utils/array_defs.h"
 #include "test/utils/test_utils.h"
 
-TEST_CASE("tdb_matrix_with_ids: test test", "[tdb_matrix_with_ids]") {
-  REQUIRE(true);
-}
-
 TEMPLATE_TEST_CASE(
-    "tdb_matrix_with_ids: constructors",
+    "constructors",
     "[tdb_matrix_with_ids]",
     float,
     double,
@@ -105,7 +101,7 @@ TEMPLATE_TEST_CASE(
   }
 }
 
-TEST_CASE("tdb_matrix_with_ids: different types", "[tdb_matrix_with_ids]") {
+TEST_CASE("different types", "[tdb_matrix_with_ids]") {
   tiledb::Context ctx;
   std::string tmp_matrix_uri =
       (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
@@ -147,10 +143,7 @@ TEST_CASE("tdb_matrix_with_ids: different types", "[tdb_matrix_with_ids]") {
 }
 
 TEMPLATE_TEST_CASE(
-    "tdb_matrix_with_ids: assign to matrix",
-    "[tdb_matrix_with_ids]",
-    float,
-    uint8_t) {
+    "assign to matrix", "[tdb_matrix_with_ids]", float, uint8_t) {
   tiledb::Context ctx;
   std::string tmp_matrix_uri =
       (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
@@ -229,7 +222,7 @@ TEMPLATE_TEST_CASE(
   }
 }
 
-TEST_CASE("tdb_matrix_with_ids: load from uri", "[tdb_matrix_with_ids]") {
+TEST_CASE("load from uri", "[tdb_matrix_with_ids]") {
   tiledb::Context ctx;
 
   auto ck = tdbColMajorMatrixWithIds<float>(ctx, sift_inputs_uri, sift_ids_uri);
@@ -243,7 +236,7 @@ TEST_CASE("tdb_matrix_with_ids: load from uri", "[tdb_matrix_with_ids]") {
   CHECK(qk.num_ids() == num_queries);
 }
 
-TEST_CASE("tdb_matrix_with_ids: empty matrix", "[tdb_matrix_with_ids]") {
+TEST_CASE("empty matrix", "[tdb_matrix_with_ids]") {
   tiledb::Context ctx;
   std::string tmp_matrix_uri =
       (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
@@ -306,8 +299,7 @@ TEST_CASE("tdb_matrix_with_ids: empty matrix", "[tdb_matrix_with_ids]") {
   }
 }
 
-TEMPLATE_TEST_CASE(
-    "tdb_matrix_with_ids: preload", "[tdb_matrix_with_ids]", float, uint8_t) {
+TEMPLATE_TEST_CASE("preload", "[tdb_matrix_with_ids]", float, uint8_t) {
   tiledb::Context ctx;
   std::string tmp_matrix_uri =
       (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();
@@ -370,7 +362,7 @@ TEMPLATE_TEST_CASE(
   }
 }
 
-TEST_CASE("tdb_matrix_with_ids: time travel", "[tdb_matrix_with_ids]") {
+TEST_CASE("time travel", "[tdb_matrix_with_ids]") {
   tiledb::Context ctx;
   std::string tmp_matrix_uri =
       (std::filesystem::temp_directory_path() / "tmp_tdb_matrix").string();

--- a/src/include/test/unit_tdb_partitioned_matrix.cc
+++ b/src/include/test/unit_tdb_partitioned_matrix.cc
@@ -84,12 +84,7 @@ std::vector<std::vector<T>> generateSubsets(int num_parts) {
   return all_subsets;
 }
 
-TEST_CASE("tdb_partitioned_matrix: test test", "[tdb_partitioned_matrix]") {
-  REQUIRE(true);
-}
-
-TEST_CASE(
-    "tdb_partitioned_matrix: can load correctly", "[tdb_partitioned_matrix]") {
+TEST_CASE("can load correctly", "[tdb_partitioned_matrix]") {
   return;
   tiledb::Context ctx;
   tiledb::VFS vfs(ctx);
@@ -191,8 +186,7 @@ TEST_CASE(
   }
 }
 
-TEST_CASE(
-    "tdb_partitioned_matrix: generateSubsets", "[tdb_partitioned_matrix]") {
+TEST_CASE("generateSubsets", "[tdb_partitioned_matrix]") {
   SECTION("generateSubsets with num_parts = 0") {
     auto subsets = generateSubsets<int>(0);
     REQUIRE(subsets.empty());
@@ -239,9 +233,7 @@ TEST_CASE(
   }
 }
 
-TEST_CASE(
-    "tdb_partitioned_matrix: test different combinations",
-    "[tdb_partitioned_matrix]") {
+TEST_CASE("test different combinations", "[tdb_partitioned_matrix]") {
   tiledb::Context ctx;
   tiledb::VFS vfs(ctx);
 

--- a/src/include/test/unit_utils.cc
+++ b/src/include/test/unit_utils.cc
@@ -41,7 +41,7 @@ std::string operator/(const std::string& lhs, const std::string& rhs) {
 
 }  // namespace
 
-TEST_CASE("utils: test", "[utils]") {
+TEST_CASE("test", "[utils]") {
   CHECK(is_http_address("http://www.tiledb.com"));
   CHECK(is_http_address("http://www.tiledb.com/index.html"));
   CHECK(is_http_address("https://www.tiledb.com"));

--- a/src/include/test/unit_vamana_group.cc
+++ b/src/include/test/unit_vamana_group.cc
@@ -33,10 +33,6 @@
 #include "index/vamana_group.h"
 #include "test/utils/array_defs.h"
 
-TEST_CASE("vamana_group: test test", "[vamana_group]") {
-  REQUIRE(true);
-}
-
 struct dummy_index {
   using feature_type = float;
   using id_type = int;
@@ -54,8 +50,7 @@ struct dummy_index {
   constexpr static tiledb_datatype_t adjacency_ids_datatype = TILEDB_UINT64;
 };
 
-TEST_CASE(
-    "vamana_group: read constructor for non-existent group", "[vamana_group]") {
+TEST_CASE("read constructor for non-existent group", "[vamana_group]") {
   tiledb::Context ctx;
 
   CHECK_THROWS_WITH(
@@ -63,7 +58,7 @@ TEST_CASE(
       "Group uri I dont exist does not exist.");
 }
 
-TEST_CASE("vamana_group: write constructor - create", "[vamana_group]") {
+TEST_CASE("write constructor - create", "[vamana_group]") {
   std::string tmp_uri = (std::filesystem::temp_directory_path() /
                          "vamana_group_test_write_constructor")
                             .string();
@@ -79,8 +74,7 @@ TEST_CASE("vamana_group: write constructor - create", "[vamana_group]") {
   CHECK(x.get_dimensions() == 10);
 }
 
-TEST_CASE(
-    "vamana_group: write constructor - create and open", "[vamana_group]") {
+TEST_CASE("write constructor - create and open", "[vamana_group]") {
   std::string tmp_uri = (std::filesystem::temp_directory_path() /
                          "vamana_group_test_write_constructor")
                             .string();
@@ -100,8 +94,7 @@ TEST_CASE(
   CHECK(x.get_dimensions() == 10);
 }
 
-TEST_CASE(
-    "vamana_group: write constructor - create and read", "[vamana_group]") {
+TEST_CASE("write constructor - create and read", "[vamana_group]") {
   std::string tmp_uri = (std::filesystem::temp_directory_path() /
                          "vamana_group_test_write_constructor")
                             .string();
@@ -131,9 +124,7 @@ TEST_CASE(
       vamana_index_group<dummy_index>(ctx, tmp_uri, TILEDB_READ);
 }
 
-TEST_CASE(
-    "vamana_group: write constructor - invalid create and read",
-    "[vamana_group]") {
+TEST_CASE("write constructor - invalid create and read", "[vamana_group]") {
   std::string tmp_uri = (std::filesystem::temp_directory_path() /
                          "vamana_group_test_write_constructor")
                             .string();
@@ -162,9 +153,7 @@ TEST_CASE(
       "No ingestion timestamps found.");
 }
 
-TEST_CASE(
-    "vamana_group: group metadata - bases, ingestions, partitions",
-    "[vamana_group]") {
+TEST_CASE("group metadata - bases, ingestions, partitions", "[vamana_group]") {
   std::string tmp_uri = (std::filesystem::temp_directory_path() /
                          "vamana_group_test_write_constructor")
                             .string();
@@ -367,7 +356,7 @@ TEST_CASE(
   CHECK(x.get_dimensions() == expected_dimension + offset);
 }
 
-TEST_CASE("vamana_group: storage version", "[vamana_group]") {
+TEST_CASE("storage version", "[vamana_group]") {
   std::string tmp_uri =
       (std::filesystem::temp_directory_path() / "vamana_group").string();
 
@@ -424,7 +413,7 @@ TEST_CASE("vamana_group: storage version", "[vamana_group]") {
   CHECK(x.get_dimensions() == expected_dimension + offset);
 }
 
-TEST_CASE("vamana_group: invalid storage version", "[vamana_group]") {
+TEST_CASE("invalid storage version", "[vamana_group]") {
   std::string tmp_uri =
       (std::filesystem::temp_directory_path() / "vamana_group").string();
 
@@ -442,7 +431,7 @@ TEST_CASE("vamana_group: invalid storage version", "[vamana_group]") {
       10));
 }
 
-TEST_CASE("vamana_group: mismatched storage version", "[vamana_group]") {
+TEST_CASE("mismatched storage version", "[vamana_group]") {
   std::string tmp_uri =
       (std::filesystem::temp_directory_path() / "vamana_group").string();
 
@@ -466,7 +455,7 @@ TEST_CASE("vamana_group: mismatched storage version", "[vamana_group]") {
       "Version mismatch. Requested different_version but found 0.3");
 }
 
-TEST_CASE("vamana_group: clear history", "[vamana_group]") {
+TEST_CASE("clear history", "[vamana_group]") {
   std::string tmp_uri =
       (std::filesystem::temp_directory_path() / "vamana_group").string();
 

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -54,13 +54,7 @@ namespace fs = std::filesystem;
 
 #include <tiledb/tiledb>
 
-bool global_debug = false;
-
-TEST_CASE("vamana: test test", "[vamana]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("vamana: diskann", "[vamana]") {
+TEST_CASE("diskann", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -191,7 +185,7 @@ TEST_CASE("vamana: diskann", "[vamana]") {
   //  }
 }
 
-TEST_CASE("vamana: small256 build index", "[vamana]") {
+TEST_CASE("small256 build index", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -234,7 +228,7 @@ TEST_CASE("vamana: small256 build index", "[vamana]") {
  * See DiskANN/rust//diskann/src/algorithm/search/search.rs
  * function search_for_point_works_with_edges()
  */
-TEST_CASE("vamana: small greedy search", "[vamana]") {
+TEST_CASE("small greedy search", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -455,7 +449,7 @@ TEST_CASE("vamana: small greedy search", "[vamana]") {
   */
 }
 
-TEST_CASE("vamana: greedy grid search", "[vamana]") {
+TEST_CASE("greedy grid search", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -545,7 +539,7 @@ TEST_CASE("vamana: greedy grid search", "[vamana]") {
   }
 }
 
-TEST_CASE("vamana: greedy search hypercube", "[vamana]") {
+TEST_CASE("greedy search hypercube", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -600,7 +594,7 @@ TEST_CASE("vamana: greedy search hypercube", "[vamana]") {
   }
 }
 
-TEST_CASE("vamana: greedy search with nn descent", "[vamana]") {
+TEST_CASE("greedy search with nn descent", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -663,7 +657,7 @@ TEST_CASE("vamana: greedy search with nn descent", "[vamana]") {
   }
 }
 
-TEST_CASE("vamana: diskann fbin", "[vamana]") {
+TEST_CASE("diskann fbin", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -710,7 +704,7 @@ TEST_CASE("vamana: diskann fbin", "[vamana]") {
   }
 }
 
-TEST_CASE("vamana: fmnist", "[vamana]") {
+TEST_CASE("fmnist", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -839,7 +833,7 @@ TEST_CASE("vamana: fmnist", "[vamana]") {
   }
 }
 
-TEST_CASE("vamana: fmnist compare greedy search", "[vamana]") {
+TEST_CASE("fmnist compare greedy search", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -904,7 +898,7 @@ TEST_CASE("vamana: fmnist compare greedy search", "[vamana]") {
   }
 }
 
-TEST_CASE("vamana: robust prune hypercube", "[vamana]") {
+TEST_CASE("robust prune hypercube", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -1007,7 +1001,7 @@ TEST_CASE("vamana: robust prune hypercube", "[vamana]") {
   }
 }
 
-TEST_CASE("vamana: robust prune fmnist", "[vamana]") {
+TEST_CASE("robust prune fmnist", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -1129,7 +1123,7 @@ TEST_CASE("vamana: robust prune fmnist", "[vamana]") {
 #endif
 }
 
-TEST_CASE("vamana: vamana_index vector diskann_test_256bin", "[vamana]") {
+TEST_CASE("vamana_index vector diskann_test_256bin", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -1175,7 +1169,7 @@ TEST_CASE("vamana: vamana_index vector diskann_test_256bin", "[vamana]") {
   CHECK(v0[0] == 0);
 }
 
-TEST_CASE("vamana: vamana by hand random index", "[vamana]") {
+TEST_CASE("vamana by hand random index", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -1256,7 +1250,7 @@ TEST_CASE("vamana: vamana by hand random index", "[vamana]") {
 /**
  * This test recapitulates the 200 node 2D graph in the DiskANN paper
  */
-TEST_CASE("vamana: vamana_index geometric 2D graph", "[vamana]") {
+TEST_CASE("vamana_index geometric 2D graph", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -1308,7 +1302,7 @@ TEST_CASE("vamana: vamana_index geometric 2D graph", "[vamana]") {
   }
 }
 
-TEST_CASE("vamana: vamana_index siftsmall", "[vamana]") {
+TEST_CASE("vamana_index siftsmall", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -1359,7 +1353,7 @@ TEST_CASE("vamana: vamana_index siftsmall", "[vamana]") {
   }
 }
 
-TEST_CASE("vamana: vamana_index write and read", "[vamana]") {
+TEST_CASE("vamana_index write and read", "[vamana]") {
   const bool debug = false;
   const bool noisy = false;
 
@@ -1442,7 +1436,7 @@ TEST_CASE("vamana: vamana_index write and read", "[vamana]") {
   }
 }
 
-TEST_CASE("vamana: query empty index", "[vamana]") {
+TEST_CASE("query empty index", "[vamana]") {
   size_t L = 100;
   size_t R = 100;
   size_t B = 2;

--- a/src/include/test/unit_vamana_metadata.cc
+++ b/src/include/test/unit_vamana_metadata.cc
@@ -39,16 +39,12 @@
 #include "test/utils/array_defs.h"
 #include "test/utils/test_utils.h"
 
-TEST_CASE("vamana_metadata: test test", "[vamana_metadata]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("vamana_metadata: default constructor", "[vamana_metadata]") {
+TEST_CASE("default constructor", "[vamana_metadata]") {
   auto x = vamana_index_metadata();
   vamana_index_metadata y;
 }
 
-TEST_CASE("vamana_metadata: default constructor compare", "[vamana_metadata]") {
+TEST_CASE("default constructor compare", "[vamana_metadata]") {
   auto x = vamana_index_metadata();
   vamana_index_metadata y;
 
@@ -56,7 +52,7 @@ TEST_CASE("vamana_metadata: default constructor compare", "[vamana_metadata]") {
   CHECK(y.compare_metadata(x));
 }
 
-TEST_CASE("vamana_metadata: load metadata from index", "[vamana_metadata]") {
+TEST_CASE("load metadata from index", "[vamana_metadata]") {
   tiledb::Context ctx;
   tiledb::Config cfg;
 

--- a/src/include/test/unit_vector.cc
+++ b/src/include/test/unit_vector.cc
@@ -36,18 +36,14 @@
 #include <vector>
 #include "detail/linalg/vector.h"
 
-TEST_CASE("vector: test test", "[vector]") {
-  REQUIRE(true);
-}
-
-TEST_CASE("vector: test constructor", "[vector]") {
+TEST_CASE("test constructor", "[vector]") {
   Vector<int> v(10);
   REQUIRE(v.num_rows() == 10);
   REQUIRE(v.size() == 10);
   REQUIRE(v.data() != nullptr);
 }
 
-TEST_CASE("vector: test move constructor", "[vector]") {
+TEST_CASE("test move constructor", "[vector]") {
   Vector<int> v(10);
   auto p = v.data();
   Vector<int> w(std::move(v));
@@ -56,7 +52,7 @@ TEST_CASE("vector: test move constructor", "[vector]") {
   REQUIRE(w.data() == p);
 }
 
-TEST_CASE("vector: test operator()", "[vector]") {
+TEST_CASE("test operator()", "[vector]") {
   Vector<int> v(10);
   for (int i = 0; i < 10; ++i) {
     v(i) = i;
@@ -66,7 +62,7 @@ TEST_CASE("vector: test operator()", "[vector]") {
   }
 }
 
-TEST_CASE("vector: test initializer_list", "[vector]") {
+TEST_CASE("test initializer_list", "[vector]") {
   std::vector<int> u{8, 6, 7, 5, 3, 0, 9};
   Vector<int> v{8, 6, 7, 5, 3, 0, 9};
 
@@ -76,7 +72,7 @@ TEST_CASE("vector: test initializer_list", "[vector]") {
   REQUIRE(std::equal(begin(v), end(v), u.begin()));
 }
 
-TEST_CASE("vector: test move constructor too", "[vector]") {
+TEST_CASE("test move constructor too", "[vector]") {
   std::vector<int> u{8, 6, 7, 5, 3, 0, 9};
   Vector<int> v{8, 6, 7, 5, 3, 0, 9};
   Vector<int> w{std::move(v)};

--- a/src/src/flat/flat_l2.cc
+++ b/src/src/flat/flat_l2.cc
@@ -140,7 +140,6 @@ int main(int argc, char* argv[]) {
     return 0;
   }
 
-  // global_debug = debug = args["--debug"].asBool();
   verbose = args["--verbose"].asBool();
   enable_stats = args["--stats"].asBool();
 

--- a/src/src/flat/ivf_flat.cc
+++ b/src/src/flat/ivf_flat.cc
@@ -137,8 +137,6 @@ int main(int argc, char* argv[]) {
   if (nthreads == 0) {
     nthreads = std::thread::hardware_concurrency();
   }
-  // global_debug = args["--debug"].asBool();
-  // global_verbose = args["--verbose"].asBool();
   enable_stats = args["--stats"].asBool();
 
   auto part_uri = args["--parts_uri"].asString();


### PR DESCRIPTION
### What
There is a bug in CLion where if you have a test with a long enough name, it will show up as multiple unit tests which have failed:

<img width="2032" alt="Screenshot 2024-05-28 at 1 51 55 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/66b71ddd-eaf2-4952-a1f2-7250ed503e7a">

While we could go through and rename specific tests to be shorter, or investigate the root cause, here I make a change I had been thinking of anyways, and which happens to also fix this: we remove the extra tag from each unit test name. This seems fine to me because the tests are all tagged anyways, so doing it twice doesn't add anything that I can see. The result is that tests which used to show as failed in CLion now show as passing:

<img width="2032" alt="Screenshot 2024-05-28 at 1 55 26 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/931f7ac3-284a-40d9-85cb-94a0e18d4bb2">

Along with this we also:
* Remove the `test test` unit tests, as if Catch2 stops working then we'll know easily, so I don' think it's necessary to add extra code to every file just for it.
* Removes some unused debug variables.

### Testing
Tests pass.