### PR TITLE
Add missing `temporal_policy` to `open_array()` calls

### DIFF
--- a/src/include/api/feature_vector_array.h
+++ b/src/include/api/feature_vector_array.h
@@ -107,8 +107,8 @@ class FeatureVectorArray {
       vector_array = tdb_col_major_matrix_dispatch_table.at(feature_type_)(
           ctx, uri, num_vectors, temporal_policy);
     } else {
-      auto ids_array =
-          tiledb_helpers::open_array(tdb_func__, ctx, ids_uri, TILEDB_READ);
+      auto ids_array = tiledb_helpers::open_array(
+          tdb_func__, ctx, ids_uri, TILEDB_READ, temporal_policy);
       ids_type_ = get_array_datatype(*ids_array);
       array->close();
       ids_size_ = datatype_to_size(ids_type_);

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -285,7 +285,11 @@ class tdbPartitionedMatrix
       , partitioned_vectors_schema_{partitioned_vectors_array_->schema()}
       , partitioned_ids_uri_{ids_uri}
       , partitioned_ids_array_(tiledb_helpers::open_array(
-            tdb_func__, ctx_, partitioned_ids_uri_, TILEDB_READ))
+            tdb_func__,
+            ctx_,
+            partitioned_ids_uri_,
+            TILEDB_READ,
+            temporal_policy))
       , ids_schema_{partitioned_ids_array_->schema()}
       //      , master_indices_{std::move(indices)}
       //      , relevant_parts_(std::move(relevant_parts))


### PR DESCRIPTION
### What
In two places we were missing passing `temporal_policy` to `open_array()` calls. This was causing failures in #390. Here we add them.

### Testing
* Tests in #390 pass.
* Existing tests pass.