### PR TITLE
Fix Vamana index not setting metadata when loaded by URI

### DIFF
--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -181,6 +181,11 @@ class IndexVamana {
     if (dispatch_table.find(type) == dispatch_table.end()) {
       throw std::runtime_error("Unsupported datatype combination");
     }
+
+    // Create a new index. Note that we may have already loaded an existing
+    // index by URI. In that case, we have updated our local state (i.e.
+    // l_build_, r_max_degree_, b_backtrack_), but we should also use the
+    // timestamp from that already loaded index..
     index_ = dispatch_table.at(type)(
         training_set.num_vectors(),
         l_build_,

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -729,8 +729,6 @@ class vamana_index {
     write_group.set_alpha_max(alpha_max_);
     write_group.set_medoid(medoid_);
 
-    write_group.dump();
-
     // When we create an index with Python, we will call write_index() twice,
     // once with empty data and once with the actual data. Here we add custom
     // logic so that during that second call to write_index(), we will overwrite

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -690,7 +690,6 @@ class vamana_index {
    *
    * @param ctx TileDB context
    * @param group_uri The URI of the TileDB group where the index will be saved
-   * @param group_uri The URI of the TileDB group where the index will be saved
    * @param temporal_policy If set, we'll use the end timestamp of the policy as
    * the write timestamp.
    * @param storage_version The storage version to use. If empty, use the most

--- a/src/include/stats.h
+++ b/src/include/stats.h
@@ -222,7 +222,7 @@ static auto dump_logs = [](std::string filename,
   }
 };
 
-static auto build_config() {
+[[maybe_unused]] static auto build_config() {
   // This is failing today, but could perhaps be added back in the future.
   // char host_[16];
   // if (int e = gethostname(host_, sizeof(host_))) {

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -33,283 +33,294 @@
 #include "catch2/catch_all.hpp"
 #include "test/utils/query_common.h"
 
-TEST_CASE("init constructor", "[api_vamana_index]") {
-  SECTION("default") {
-    auto a = IndexVamana();
-    CHECK(a.feature_type() == TILEDB_ANY);
-    CHECK(a.feature_type_string() == datatype_to_string(TILEDB_ANY));
-    CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.id_type_string() == datatype_to_string(TILEDB_UINT32));
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-    CHECK(
-        a.adjacency_row_index_type_string() ==
-        datatype_to_string(TILEDB_UINT32));
-    CHECK(dimensions(a) == 0);
-  }
+// TEST_CASE("init constructor", "[api_vamana_index]") {
+//   SECTION("default") {
+//     auto a = IndexVamana();
+//     CHECK(a.feature_type() == TILEDB_ANY);
+//     CHECK(a.feature_type_string() == datatype_to_string(TILEDB_ANY));
+//     CHECK(a.id_type() == TILEDB_UINT32);
+//     CHECK(a.id_type_string() == datatype_to_string(TILEDB_UINT32));
+//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+//     CHECK(
+//         a.adjacency_row_index_type_string() ==
+//         datatype_to_string(TILEDB_UINT32));
+//     CHECK(dimensions(a) == 0);
+//   }
 
-  SECTION("float uint32 uint32") {
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "float32"},
-         {"id_type", "uint32"},
-         {"adjacency_row_index_type", "uint32"}}));
-    CHECK(a.feature_type() == TILEDB_FLOAT32);
-    CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-    CHECK(dimensions(a) == 0);
-  }
+//   SECTION("float uint32 uint32") {
+//     auto a = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", "float32"},
+//          {"id_type", "uint32"},
+//          {"adjacency_row_index_type", "uint32"}}));
+//     CHECK(a.feature_type() == TILEDB_FLOAT32);
+//     CHECK(a.id_type() == TILEDB_UINT32);
+//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+//     CHECK(dimensions(a) == 0);
+//   }
 
-  SECTION("int8 uint32 uint32") {
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "int8"},
-         {"id_type", "uint32"},
-         {"adjacency_row_index_type", "uint32"}}));
-    CHECK(a.feature_type() == TILEDB_INT8);
-    CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-  }
+//   SECTION("int8 uint32 uint32") {
+//     auto a = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", "int8"},
+//          {"id_type", "uint32"},
+//          {"adjacency_row_index_type", "uint32"}}));
+//     CHECK(a.feature_type() == TILEDB_INT8);
+//     CHECK(a.id_type() == TILEDB_UINT32);
+//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+//   }
 
-  SECTION("uint8 uint32 uint32") {
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "uint8"},
-         {"id_type", "uint32"},
-         {"adjacency_row_index_type", "uint32"}}));
-    CHECK(a.feature_type() == TILEDB_UINT8);
-    CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-  }
+//   SECTION("uint8 uint32 uint32") {
+//     auto a = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", "uint8"},
+//          {"id_type", "uint32"},
+//          {"adjacency_row_index_type", "uint32"}}));
+//     CHECK(a.feature_type() == TILEDB_UINT8);
+//     CHECK(a.id_type() == TILEDB_UINT32);
+//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+//   }
 
-  SECTION("float uint64 uint32") {
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "float32"},
-         {"id_type", "uint64"},
-         {"adjacency_row_index_type", "uint32"}}));
-    CHECK(a.feature_type() == TILEDB_FLOAT32);
-    CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-  }
+//   SECTION("float uint64 uint32") {
+//     auto a = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", "float32"},
+//          {"id_type", "uint64"},
+//          {"adjacency_row_index_type", "uint32"}}));
+//     CHECK(a.feature_type() == TILEDB_FLOAT32);
+//     CHECK(a.id_type() == TILEDB_UINT64);
+//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+//   }
 
-  SECTION("float uint32 uint64") {
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "float32"},
-         {"id_type", "uint32"},
-         {"adjacency_row_index_type", "uint64"}}));
-    CHECK(a.feature_type() == TILEDB_FLOAT32);
-    CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
-  }
+//   SECTION("float uint32 uint64") {
+//     auto a = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", "float32"},
+//          {"id_type", "uint32"},
+//          {"adjacency_row_index_type", "uint64"}}));
+//     CHECK(a.feature_type() == TILEDB_FLOAT32);
+//     CHECK(a.id_type() == TILEDB_UINT32);
+//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
+//   }
 
-  SECTION("int8 uint64 uint32") {
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "int8"},
-         {"id_type", "uint64"},
-         {"adjacency_row_index_type", "uint32"}}));
-    CHECK(a.feature_type() == TILEDB_INT8);
-    CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-  }
+//   SECTION("int8 uint64 uint32") {
+//     auto a = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", "int8"},
+//          {"id_type", "uint64"},
+//          {"adjacency_row_index_type", "uint32"}}));
+//     CHECK(a.feature_type() == TILEDB_INT8);
+//     CHECK(a.id_type() == TILEDB_UINT64);
+//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+//   }
 
-  SECTION("uint8 uint64 uint32") {
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "uint8"},
-         {"id_type", "uint64"},
-         {"adjacency_row_index_type", "uint32"}}));
-    CHECK(a.feature_type() == TILEDB_UINT8);
-    CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-  }
+//   SECTION("uint8 uint64 uint32") {
+//     auto a = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", "uint8"},
+//          {"id_type", "uint64"},
+//          {"adjacency_row_index_type", "uint32"}}));
+//     CHECK(a.feature_type() == TILEDB_UINT8);
+//     CHECK(a.id_type() == TILEDB_UINT64);
+//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+//   }
 
-  SECTION("int8 uint32 uint64") {
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "int8"},
-         {"id_type", "uint32"},
-         {"adjacency_row_index_type", "uint64"}}));
-    CHECK(a.feature_type() == TILEDB_INT8);
-    CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
-  }
+//   SECTION("int8 uint32 uint64") {
+//     auto a = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", "int8"},
+//          {"id_type", "uint32"},
+//          {"adjacency_row_index_type", "uint64"}}));
+//     CHECK(a.feature_type() == TILEDB_INT8);
+//     CHECK(a.id_type() == TILEDB_UINT32);
+//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
+//   }
 
-  SECTION("uint8 uint32 uint64") {
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "uint8"},
-         {"id_type", "uint32"},
-         {"adjacency_row_index_type", "uint64"}}));
-    CHECK(a.feature_type() == TILEDB_UINT8);
-    CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
-  }
+//   SECTION("uint8 uint32 uint64") {
+//     auto a = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", "uint8"},
+//          {"id_type", "uint32"},
+//          {"adjacency_row_index_type", "uint64"}}));
+//     CHECK(a.feature_type() == TILEDB_UINT8);
+//     CHECK(a.id_type() == TILEDB_UINT32);
+//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
+//   }
 
-  SECTION("float uint64 uint64") {
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "float32"},
-         {"id_type", "uint64"},
-         {"adjacency_row_index_type", "uint64"}}));
-    CHECK(a.feature_type() == TILEDB_FLOAT32);
-    CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
-  }
+//   SECTION("float uint64 uint64") {
+//     auto a = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", "float32"},
+//          {"id_type", "uint64"},
+//          {"adjacency_row_index_type", "uint64"}}));
+//     CHECK(a.feature_type() == TILEDB_FLOAT32);
+//     CHECK(a.id_type() == TILEDB_UINT64);
+//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
+//   }
 
-  SECTION("int8 uint64 uint64") {
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "int8"},
-         {"id_type", "uint64"},
-         {"adjacency_row_index_type", "uint64"}}));
-    CHECK(a.feature_type() == TILEDB_INT8);
-    CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
-  }
+//   SECTION("int8 uint64 uint64") {
+//     auto a = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", "int8"},
+//          {"id_type", "uint64"},
+//          {"adjacency_row_index_type", "uint64"}}));
+//     CHECK(a.feature_type() == TILEDB_INT8);
+//     CHECK(a.id_type() == TILEDB_UINT64);
+//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
+//   }
 
-  SECTION("uint8 uint64 uint64") {
-    auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "uint8"},
-         {"id_type", "uint64"},
-         {"adjacency_row_index_type", "uint64"}}));
-    CHECK(a.feature_type() == TILEDB_UINT8);
-    CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
-  }
-}
+//   SECTION("uint8 uint64 uint64") {
+//     auto a = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", "uint8"},
+//          {"id_type", "uint64"},
+//          {"adjacency_row_index_type", "uint64"}}));
+//     CHECK(a.feature_type() == TILEDB_UINT8);
+//     CHECK(a.id_type() == TILEDB_UINT64);
+//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
+//   }
+// }
 
-TEST_CASE("create empty index and then train and query", "[api_vamana_index]") {
-  auto ctx = tiledb::Context{};
-  using feature_type_type = uint8_t;
-  using id_type_type = uint32_t;
-  auto feature_type = "uint8";
-  auto id_type = "uint32";
-  auto adjacency_row_index_type = "uint32";
-  size_t dimensions = 3;
+// TEST_CASE("create empty index and then train and query",
+// "[api_vamana_index]") {
+//   auto ctx = tiledb::Context{};
+//   using feature_type_type = uint8_t;
+//   using id_type_type = uint32_t;
+//   auto feature_type = "uint8";
+//   auto id_type = "uint32";
+//   auto adjacency_row_index_type = "uint32";
+//   size_t dimensions = 3;
 
-  std::string index_uri =
-      (std::filesystem::temp_directory_path() / "api_vamana_index").string();
-  tiledb::VFS vfs(ctx);
-  if (vfs.is_dir(index_uri)) {
-    vfs.remove_dir(index_uri);
-  }
+//   std::string index_uri =
+//       (std::filesystem::temp_directory_path() / "api_vamana_index").string();
+//   tiledb::VFS vfs(ctx);
+//   if (vfs.is_dir(index_uri)) {
+//     vfs.remove_dir(index_uri);
+//   }
 
-  {
-    auto index = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", feature_type},
-         {"id_type", id_type},
-         {"adjacency_row_index_type", adjacency_row_index_type}}));
+//   {
+//     auto index = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", feature_type},
+//          {"id_type", id_type},
+//          {"adjacency_row_index_type", adjacency_row_index_type}}));
 
-    size_t num_vectors = 0;
-    auto empty_training_vector_array =
-        FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
-    index.train(empty_training_vector_array);
-    index.add(empty_training_vector_array);
-    index.write_index(ctx, index_uri);
+//     size_t num_vectors = 0;
+//     auto empty_training_vector_array =
+//         FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
+//     index.train(empty_training_vector_array);
+//     index.add(empty_training_vector_array);
+//     index.write_index(ctx, index_uri);
 
-    CHECK(index.feature_type_string() == feature_type);
-    CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
-  }
+//     CHECK(index.feature_type_string() == feature_type);
+//     CHECK(index.id_type_string() == id_type);
+//     CHECK(index.adjacency_row_index_type_string() ==
+//     adjacency_row_index_type);
+//   }
 
-  {
-    auto index = IndexVamana(ctx, index_uri);
+//   {
+//     auto index = IndexVamana(ctx, index_uri);
 
-    CHECK(index.feature_type_string() == feature_type);
-    CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
+//     CHECK(index.feature_type_string() == feature_type);
+//     CHECK(index.id_type_string() == id_type);
+//     CHECK(index.adjacency_row_index_type_string() ==
+//     adjacency_row_index_type);
 
-    auto training = ColMajorMatrix<feature_type_type>{
-        {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
-    auto training_vector_array = FeatureVectorArray(training);
-    index.train(training_vector_array);
-    index.add(training_vector_array);
-    index.write_index(ctx, index_uri);
+//     auto training = ColMajorMatrix<feature_type_type>{
+//         {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
+//     auto training_vector_array = FeatureVectorArray(training);
+//     index.train(training_vector_array);
+//     index.add(training_vector_array);
+//     index.write_index(ctx, index_uri);
 
-    CHECK(index.feature_type_string() == feature_type);
-    CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
+//     CHECK(index.feature_type_string() == feature_type);
+//     CHECK(index.id_type_string() == id_type);
+//     CHECK(index.adjacency_row_index_type_string() ==
+//     adjacency_row_index_type);
 
-    auto queries = ColMajorMatrix<feature_type_type>{
-        {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
-    auto query_vector_array = FeatureVectorArray(queries);
-    auto&& [scores_vector_array, ids_vector_array] =
-        index.query(query_vector_array, 1);
+//     auto queries = ColMajorMatrix<feature_type_type>{
+//         {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
+//     auto query_vector_array = FeatureVectorArray(queries);
+//     auto&& [scores_vector_array, ids_vector_array] =
+//         index.query(query_vector_array, 1);
 
-    auto scores = std::span<float>(
-        (float*)scores_vector_array.data(), scores_vector_array.num_vectors());
-    auto ids = std::span<uint32_t>(
-        (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
-    CHECK(std::equal(
-        scores.begin(), scores.end(), std::vector<float>{0, 0, 0, 0}.begin()));
-    CHECK(std::equal(
-        ids.begin(), ids.end(), std::vector<int>{0, 1, 2, 3}.begin()));
-  }
-}
+//     auto scores = std::span<float>(
+//         (float*)scores_vector_array.data(),
+//         scores_vector_array.num_vectors());
+//     auto ids = std::span<uint32_t>(
+//         (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
+//     CHECK(std::equal(
+//         scores.begin(), scores.end(), std::vector<float>{0, 0, 0,
+//         0}.begin()));
+//     CHECK(std::equal(
+//         ids.begin(), ids.end(), std::vector<int>{0, 1, 2, 3}.begin()));
+//   }
+// }
 
-TEST_CASE(
-    "create empty index and then train and query with "
-    "external IDs",
-    "[api_vamana_index]") {
-  auto ctx = tiledb::Context{};
-  using feature_type_type = uint8_t;
-  using id_type_type = uint32_t;
-  auto feature_type = "uint8";
-  auto id_type = "uint32";
-  auto adjacency_row_index_type = "uint32";
-  size_t dimensions = 3;
+// TEST_CASE(
+//     "create empty index and then train and query with "
+//     "external IDs",
+//     "[api_vamana_index]") {
+//   auto ctx = tiledb::Context{};
+//   using feature_type_type = uint8_t;
+//   using id_type_type = uint32_t;
+//   auto feature_type = "uint8";
+//   auto id_type = "uint32";
+//   auto adjacency_row_index_type = "uint32";
+//   size_t dimensions = 3;
 
-  std::string index_uri =
-      (std::filesystem::temp_directory_path() / "api_vamana_index").string();
-  tiledb::VFS vfs(ctx);
-  if (vfs.is_dir(index_uri)) {
-    vfs.remove_dir(index_uri);
-  }
+//   std::string index_uri =
+//       (std::filesystem::temp_directory_path() / "api_vamana_index").string();
+//   tiledb::VFS vfs(ctx);
+//   if (vfs.is_dir(index_uri)) {
+//     vfs.remove_dir(index_uri);
+//   }
 
-  {
-    auto index = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", feature_type},
-         {"id_type", id_type},
-         {"adjacency_row_index_type", adjacency_row_index_type}}));
+//   {
+//     auto index = IndexVamana(std::make_optional<IndexOptions>(
+//         {{"feature_type", feature_type},
+//          {"id_type", id_type},
+//          {"adjacency_row_index_type", adjacency_row_index_type}}));
 
-    size_t num_vectors = 0;
-    auto empty_training_vector_array =
-        FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
-    index.train(empty_training_vector_array);
-    index.add(empty_training_vector_array);
-    index.write_index(ctx, index_uri);
+//     size_t num_vectors = 0;
+//     auto empty_training_vector_array =
+//         FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
+//     index.train(empty_training_vector_array);
+//     index.add(empty_training_vector_array);
+//     index.write_index(ctx, index_uri);
 
-    CHECK(index.feature_type_string() == feature_type);
-    CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
-  }
+//     CHECK(index.feature_type_string() == feature_type);
+//     CHECK(index.id_type_string() == id_type);
+//     CHECK(index.adjacency_row_index_type_string() ==
+//     adjacency_row_index_type);
+//   }
 
-  {
-    auto index = IndexVamana(ctx, index_uri);
+//   {
+//     auto index = IndexVamana(ctx, index_uri);
 
-    CHECK(index.feature_type_string() == feature_type);
-    CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
+//     CHECK(index.feature_type_string() == feature_type);
+//     CHECK(index.id_type_string() == id_type);
+//     CHECK(index.adjacency_row_index_type_string() ==
+//     adjacency_row_index_type);
 
-    auto training = ColMajorMatrixWithIds<feature_type_type, id_type_type>{
-        {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}, {10, 11, 12, 13}};
+//     auto training = ColMajorMatrixWithIds<feature_type_type, id_type_type>{
+//         {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}, {10, 11, 12, 13}};
 
-    auto training_vector_array = FeatureVectorArray(training);
-    index.train(training_vector_array);
-    index.add(training_vector_array);
-    index.write_index(ctx, index_uri);
+//     auto training_vector_array = FeatureVectorArray(training);
+//     index.train(training_vector_array);
+//     index.add(training_vector_array);
+//     index.write_index(ctx, index_uri);
 
-    CHECK(index.feature_type_string() == feature_type);
-    CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
+//     CHECK(index.feature_type_string() == feature_type);
+//     CHECK(index.id_type_string() == id_type);
+//     CHECK(index.adjacency_row_index_type_string() ==
+//     adjacency_row_index_type);
 
-    auto queries = ColMajorMatrix<feature_type_type>{
-        {8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
-    auto query_vector_array = FeatureVectorArray(queries);
-    auto&& [scores_vector_array, ids_vector_array] =
-        index.query(query_vector_array, 1);
+//     auto queries = ColMajorMatrix<feature_type_type>{
+//         {8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
+//     auto query_vector_array = FeatureVectorArray(queries);
+//     auto&& [scores_vector_array, ids_vector_array] =
+//         index.query(query_vector_array, 1);
 
-    auto scores = std::span<float>(
-        (float*)scores_vector_array.data(), scores_vector_array.num_vectors());
-    auto ids = std::span<uint32_t>(
-        (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
-    CHECK(std::equal(
-        scores.begin(), scores.end(), std::vector<float>{0, 0, 0, 0}.begin()));
-    CHECK(std::equal(
-        ids.begin(), ids.end(), std::vector<int>{10, 11, 12, 13}.begin()));
-  }
-}
+//     auto scores = std::span<float>(
+//         (float*)scores_vector_array.data(),
+//         scores_vector_array.num_vectors());
+//     auto ids = std::span<uint32_t>(
+//         (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
+//     CHECK(std::equal(
+//         scores.begin(), scores.end(), std::vector<float>{0, 0, 0,
+//         0}.begin()));
+//     CHECK(std::equal(
+//         ids.begin(), ids.end(), std::vector<int>{10, 11, 12, 13}.begin()));
+//   }
+// }
 
 TEST_CASE(
     "create empty index and then train and query with sift",
@@ -348,6 +359,8 @@ TEST_CASE(
   {
     auto index = IndexVamana(ctx, index_uri);
 
+    // If we do not specify b_backtrack, it will be equal to l_build.
+    CHECK(index.l_build() == index.b_backtrack());
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
     CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
@@ -371,76 +384,76 @@ TEST_CASE(
   }
 }
 
-TEST_CASE("infer feature type", "[api_vamana_index]") {
-  auto a = IndexVamana(std::make_optional<IndexOptions>(
-      {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
-  auto ctx = tiledb::Context{};
-  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-  a.train(training_set);
-  CHECK(a.feature_type() == TILEDB_FLOAT32);
-  CHECK(a.id_type() == TILEDB_UINT32);
-  CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-}
+// TEST_CASE("infer feature type", "[api_vamana_index]") {
+//   auto a = IndexVamana(std::make_optional<IndexOptions>(
+//       {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
+//   auto ctx = tiledb::Context{};
+//   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+//   a.train(training_set);
+//   CHECK(a.feature_type() == TILEDB_FLOAT32);
+//   CHECK(a.id_type() == TILEDB_UINT32);
+//   CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+// }
 
-TEST_CASE("infer dimension", "[api_vamana_index]") {
-  auto a = IndexVamana(std::make_optional<IndexOptions>(
-      {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
-  auto ctx = tiledb::Context{};
-  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-  CHECK(dimensions(a) == 0);
-  a.train(training_set);
-  CHECK(a.feature_type() == TILEDB_FLOAT32);
-  CHECK(a.id_type() == TILEDB_UINT32);
-  CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-  CHECK(dimensions(a) == 128);
-}
+// TEST_CASE("infer dimension", "[api_vamana_index]") {
+//   auto a = IndexVamana(std::make_optional<IndexOptions>(
+//       {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
+//   auto ctx = tiledb::Context{};
+//   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+//   CHECK(dimensions(a) == 0);
+//   a.train(training_set);
+//   CHECK(a.feature_type() == TILEDB_FLOAT32);
+//   CHECK(a.id_type() == TILEDB_UINT32);
+//   CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+//   CHECK(dimensions(a) == 128);
+// }
 
-TEST_CASE("api_vamana_index write and read", "[api_vamana_index]") {
-  auto ctx = tiledb::Context{};
-  std::string api_vamana_index_uri =
-      (std::filesystem::temp_directory_path() / "api_vamana_index").string();
-  tiledb::VFS vfs(ctx);
-  if (vfs.is_dir(api_vamana_index_uri)) {
-    vfs.remove_dir(api_vamana_index_uri);
-  }
+// TEST_CASE("api_vamana_index write and read", "[api_vamana_index]") {
+//   auto ctx = tiledb::Context{};
+//   std::string api_vamana_index_uri =
+//       (std::filesystem::temp_directory_path() / "api_vamana_index").string();
+//   tiledb::VFS vfs(ctx);
+//   if (vfs.is_dir(api_vamana_index_uri)) {
+//     vfs.remove_dir(api_vamana_index_uri);
+//   }
 
-  auto a = IndexVamana(std::make_optional<IndexOptions>(
-      {{"feature_type", "float32"},
-       {"id_type", "uint32"},
-       {"adjacency_row_index_type", "uint32"}}));
-  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-  a.train(training_set);
-  a.add(training_set);
-  a.write_index(ctx, api_vamana_index_uri);
+//   auto a = IndexVamana(std::make_optional<IndexOptions>(
+//       {{"feature_type", "float32"},
+//        {"id_type", "uint32"},
+//        {"adjacency_row_index_type", "uint32"}}));
+//   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+//   a.train(training_set);
+//   a.add(training_set);
+//   a.write_index(ctx, api_vamana_index_uri);
 
-  auto b = IndexVamana(ctx, api_vamana_index_uri);
+//   auto b = IndexVamana(ctx, api_vamana_index_uri);
 
-  CHECK(dimensions(a) == dimensions(b));
-  CHECK(a.feature_type() == b.feature_type());
-  CHECK(a.id_type() == b.id_type());
-  CHECK(a.adjacency_row_index_type() == b.adjacency_row_index_type());
-}
+//   CHECK(dimensions(a) == dimensions(b));
+//   CHECK(a.feature_type() == b.feature_type());
+//   CHECK(a.id_type() == b.id_type());
+//   CHECK(a.adjacency_row_index_type() == b.adjacency_row_index_type());
+// }
 
-TEST_CASE("build index and query", "[api_vamana_index]") {
-  auto ctx = tiledb::Context{};
-  size_t k_nn = 10;
-  size_t nprobe = GENERATE(8, 32);
+// TEST_CASE("build index and query", "[api_vamana_index]") {
+//   auto ctx = tiledb::Context{};
+//   size_t k_nn = 10;
+//   size_t nprobe = GENERATE(8, 32);
 
-  auto a = IndexVamana(std::make_optional<IndexOptions>(
-      {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
-  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-  auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
-  auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
-  a.train(training_set);
-  a.add(training_set);
+//   auto a = IndexVamana(std::make_optional<IndexOptions>(
+//       {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
+//   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+//   auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
+//   auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
+//   a.train(training_set);
+//   a.add(training_set);
 
-  auto&& [s, t] = a.query(query_set, k_nn);
+//   auto&& [s, t] = a.query(query_set, k_nn);
 
-  auto intersections = count_intersections(t, groundtruth_set, k_nn);
-  auto nt = num_vectors(t);
-  auto recall = ((double)intersections) / ((double)nt * k_nn);
-  CHECK(recall == 1.0);
-}
+//   auto intersections = count_intersections(t, groundtruth_set, k_nn);
+//   auto nt = num_vectors(t);
+//   auto recall = ((double)intersections) / ((double)nt * k_nn);
+//   CHECK(recall == 1.0);
+// }
 
 TEST_CASE("read index and query", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
@@ -448,6 +461,10 @@ TEST_CASE("read index and query", "[api_vamana_index]") {
 
   std::string api_vamana_index_uri =
       (std::filesystem::temp_directory_path() / "api_vamana_index").string();
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(api_vamana_index_uri)) {
+    vfs.remove_dir(api_vamana_index_uri);
+  }
 
   auto a = IndexVamana(std::make_optional<IndexOptions>(
       {{"feature_type", "float32"},
@@ -542,6 +559,9 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
   auto id_type = "uint32";
   auto adjacency_row_index_type = "uint32";
   size_t dimensions = 3;
+  size_t l_build = 100;
+  size_t r_max_degree = 64;
+  size_t b_backtrack = 50;
 
   std::string index_uri =
       (std::filesystem::temp_directory_path() / "api_vamana_index").string();
@@ -556,7 +576,10 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     auto index = IndexVamana(std::make_optional<IndexOptions>(
         {{"feature_type", feature_type},
          {"id_type", id_type},
-         {"adjacency_row_index_type", adjacency_row_index_type}}));
+         {"adjacency_row_index_type", adjacency_row_index_type},
+         {"l_build", std::to_string(l_build)},
+         {"r_max_degree", std::to_string(r_max_degree)},
+         {"b_backtrack", std::to_string(b_backtrack)}}));
 
     size_t num_vectors = 0;
     auto empty_training_vector_array =
@@ -566,6 +589,9 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     index.write_index(ctx, index_uri, TemporalPolicy(TimeTravel, 0));
 
     CHECK(index.temporal_policy().timestamp_end() == 0);
+    CHECK(index.l_build() == l_build);
+    CHECK(index.r_max_degree() == r_max_degree);
+    CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
     CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
@@ -600,6 +626,9 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(
         index.temporal_policy().timestamp_end() ==
         std::numeric_limits<uint64_t>::max());
+    CHECK(index.l_build() == l_build);
+    CHECK(index.r_max_degree() == r_max_degree);
+    CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
     CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
@@ -615,6 +644,9 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
 
     // This also updates the timestamp of the index - we're now at timestamp 99.
     CHECK(index.temporal_policy().timestamp_end() == 99);
+    CHECK(index.l_build() == l_build);
+    CHECK(index.r_max_degree() == r_max_degree);
+    CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
     CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
@@ -661,6 +693,9 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(
         index.temporal_policy().timestamp_end() ==
         std::numeric_limits<uint64_t>::max());
+    CHECK(index.l_build() == l_build);
+    CHECK(index.r_max_degree() == r_max_degree);
+    CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
     CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
@@ -733,6 +768,9 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     auto index = IndexVamana(ctx, index_uri, temporal_policy);
 
     CHECK(index.temporal_policy().timestamp_end() == 99);
+    CHECK(index.l_build() == l_build);
+    CHECK(index.r_max_degree() == r_max_degree);
+    CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
     CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
@@ -790,6 +828,9 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
 
     CHECK(index.temporal_policy().timestamp_start() == 0);
     CHECK(index.temporal_policy().timestamp_end() == 0);
+    CHECK(index.l_build() == l_build);
+    CHECK(index.r_max_degree() == r_max_degree);
+    CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
     CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
@@ -852,6 +893,9 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     auto index = IndexVamana(ctx, index_uri, temporal_policy);
 
     CHECK(index.temporal_policy().timestamp_end() == 99);
+    CHECK(index.l_build() == l_build);
+    CHECK(index.r_max_degree() == r_max_degree);
+    CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
     CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -33,294 +33,283 @@
 #include "catch2/catch_all.hpp"
 #include "test/utils/query_common.h"
 
-// TEST_CASE("init constructor", "[api_vamana_index]") {
-//   SECTION("default") {
-//     auto a = IndexVamana();
-//     CHECK(a.feature_type() == TILEDB_ANY);
-//     CHECK(a.feature_type_string() == datatype_to_string(TILEDB_ANY));
-//     CHECK(a.id_type() == TILEDB_UINT32);
-//     CHECK(a.id_type_string() == datatype_to_string(TILEDB_UINT32));
-//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-//     CHECK(
-//         a.adjacency_row_index_type_string() ==
-//         datatype_to_string(TILEDB_UINT32));
-//     CHECK(dimensions(a) == 0);
-//   }
+TEST_CASE("init constructor", "[api_vamana_index]") {
+  SECTION("default") {
+    auto a = IndexVamana();
+    CHECK(a.feature_type() == TILEDB_ANY);
+    CHECK(a.feature_type_string() == datatype_to_string(TILEDB_ANY));
+    CHECK(a.id_type() == TILEDB_UINT32);
+    CHECK(a.id_type_string() == datatype_to_string(TILEDB_UINT32));
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+    CHECK(
+        a.adjacency_row_index_type_string() ==
+        datatype_to_string(TILEDB_UINT32));
+    CHECK(dimensions(a) == 0);
+  }
 
-//   SECTION("float uint32 uint32") {
-//     auto a = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", "float32"},
-//          {"id_type", "uint32"},
-//          {"adjacency_row_index_type", "uint32"}}));
-//     CHECK(a.feature_type() == TILEDB_FLOAT32);
-//     CHECK(a.id_type() == TILEDB_UINT32);
-//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-//     CHECK(dimensions(a) == 0);
-//   }
+  SECTION("float uint32 uint32") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "float32"},
+         {"id_type", "uint32"},
+         {"adjacency_row_index_type", "uint32"}}));
+    CHECK(a.feature_type() == TILEDB_FLOAT32);
+    CHECK(a.id_type() == TILEDB_UINT32);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+    CHECK(dimensions(a) == 0);
+  }
 
-//   SECTION("int8 uint32 uint32") {
-//     auto a = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", "int8"},
-//          {"id_type", "uint32"},
-//          {"adjacency_row_index_type", "uint32"}}));
-//     CHECK(a.feature_type() == TILEDB_INT8);
-//     CHECK(a.id_type() == TILEDB_UINT32);
-//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-//   }
+  SECTION("int8 uint32 uint32") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "int8"},
+         {"id_type", "uint32"},
+         {"adjacency_row_index_type", "uint32"}}));
+    CHECK(a.feature_type() == TILEDB_INT8);
+    CHECK(a.id_type() == TILEDB_UINT32);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+  }
 
-//   SECTION("uint8 uint32 uint32") {
-//     auto a = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", "uint8"},
-//          {"id_type", "uint32"},
-//          {"adjacency_row_index_type", "uint32"}}));
-//     CHECK(a.feature_type() == TILEDB_UINT8);
-//     CHECK(a.id_type() == TILEDB_UINT32);
-//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-//   }
+  SECTION("uint8 uint32 uint32") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "uint8"},
+         {"id_type", "uint32"},
+         {"adjacency_row_index_type", "uint32"}}));
+    CHECK(a.feature_type() == TILEDB_UINT8);
+    CHECK(a.id_type() == TILEDB_UINT32);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+  }
 
-//   SECTION("float uint64 uint32") {
-//     auto a = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", "float32"},
-//          {"id_type", "uint64"},
-//          {"adjacency_row_index_type", "uint32"}}));
-//     CHECK(a.feature_type() == TILEDB_FLOAT32);
-//     CHECK(a.id_type() == TILEDB_UINT64);
-//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-//   }
+  SECTION("float uint64 uint32") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "float32"},
+         {"id_type", "uint64"},
+         {"adjacency_row_index_type", "uint32"}}));
+    CHECK(a.feature_type() == TILEDB_FLOAT32);
+    CHECK(a.id_type() == TILEDB_UINT64);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+  }
 
-//   SECTION("float uint32 uint64") {
-//     auto a = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", "float32"},
-//          {"id_type", "uint32"},
-//          {"adjacency_row_index_type", "uint64"}}));
-//     CHECK(a.feature_type() == TILEDB_FLOAT32);
-//     CHECK(a.id_type() == TILEDB_UINT32);
-//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
-//   }
+  SECTION("float uint32 uint64") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "float32"},
+         {"id_type", "uint32"},
+         {"adjacency_row_index_type", "uint64"}}));
+    CHECK(a.feature_type() == TILEDB_FLOAT32);
+    CHECK(a.id_type() == TILEDB_UINT32);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
+  }
 
-//   SECTION("int8 uint64 uint32") {
-//     auto a = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", "int8"},
-//          {"id_type", "uint64"},
-//          {"adjacency_row_index_type", "uint32"}}));
-//     CHECK(a.feature_type() == TILEDB_INT8);
-//     CHECK(a.id_type() == TILEDB_UINT64);
-//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-//   }
+  SECTION("int8 uint64 uint32") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "int8"},
+         {"id_type", "uint64"},
+         {"adjacency_row_index_type", "uint32"}}));
+    CHECK(a.feature_type() == TILEDB_INT8);
+    CHECK(a.id_type() == TILEDB_UINT64);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+  }
 
-//   SECTION("uint8 uint64 uint32") {
-//     auto a = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", "uint8"},
-//          {"id_type", "uint64"},
-//          {"adjacency_row_index_type", "uint32"}}));
-//     CHECK(a.feature_type() == TILEDB_UINT8);
-//     CHECK(a.id_type() == TILEDB_UINT64);
-//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-//   }
+  SECTION("uint8 uint64 uint32") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "uint8"},
+         {"id_type", "uint64"},
+         {"adjacency_row_index_type", "uint32"}}));
+    CHECK(a.feature_type() == TILEDB_UINT8);
+    CHECK(a.id_type() == TILEDB_UINT64);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+  }
 
-//   SECTION("int8 uint32 uint64") {
-//     auto a = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", "int8"},
-//          {"id_type", "uint32"},
-//          {"adjacency_row_index_type", "uint64"}}));
-//     CHECK(a.feature_type() == TILEDB_INT8);
-//     CHECK(a.id_type() == TILEDB_UINT32);
-//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
-//   }
+  SECTION("int8 uint32 uint64") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "int8"},
+         {"id_type", "uint32"},
+         {"adjacency_row_index_type", "uint64"}}));
+    CHECK(a.feature_type() == TILEDB_INT8);
+    CHECK(a.id_type() == TILEDB_UINT32);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
+  }
 
-//   SECTION("uint8 uint32 uint64") {
-//     auto a = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", "uint8"},
-//          {"id_type", "uint32"},
-//          {"adjacency_row_index_type", "uint64"}}));
-//     CHECK(a.feature_type() == TILEDB_UINT8);
-//     CHECK(a.id_type() == TILEDB_UINT32);
-//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
-//   }
+  SECTION("uint8 uint32 uint64") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "uint8"},
+         {"id_type", "uint32"},
+         {"adjacency_row_index_type", "uint64"}}));
+    CHECK(a.feature_type() == TILEDB_UINT8);
+    CHECK(a.id_type() == TILEDB_UINT32);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
+  }
 
-//   SECTION("float uint64 uint64") {
-//     auto a = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", "float32"},
-//          {"id_type", "uint64"},
-//          {"adjacency_row_index_type", "uint64"}}));
-//     CHECK(a.feature_type() == TILEDB_FLOAT32);
-//     CHECK(a.id_type() == TILEDB_UINT64);
-//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
-//   }
+  SECTION("float uint64 uint64") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "float32"},
+         {"id_type", "uint64"},
+         {"adjacency_row_index_type", "uint64"}}));
+    CHECK(a.feature_type() == TILEDB_FLOAT32);
+    CHECK(a.id_type() == TILEDB_UINT64);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
+  }
 
-//   SECTION("int8 uint64 uint64") {
-//     auto a = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", "int8"},
-//          {"id_type", "uint64"},
-//          {"adjacency_row_index_type", "uint64"}}));
-//     CHECK(a.feature_type() == TILEDB_INT8);
-//     CHECK(a.id_type() == TILEDB_UINT64);
-//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
-//   }
+  SECTION("int8 uint64 uint64") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "int8"},
+         {"id_type", "uint64"},
+         {"adjacency_row_index_type", "uint64"}}));
+    CHECK(a.feature_type() == TILEDB_INT8);
+    CHECK(a.id_type() == TILEDB_UINT64);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
+  }
 
-//   SECTION("uint8 uint64 uint64") {
-//     auto a = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", "uint8"},
-//          {"id_type", "uint64"},
-//          {"adjacency_row_index_type", "uint64"}}));
-//     CHECK(a.feature_type() == TILEDB_UINT8);
-//     CHECK(a.id_type() == TILEDB_UINT64);
-//     CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
-//   }
-// }
+  SECTION("uint8 uint64 uint64") {
+    auto a = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", "uint8"},
+         {"id_type", "uint64"},
+         {"adjacency_row_index_type", "uint64"}}));
+    CHECK(a.feature_type() == TILEDB_UINT8);
+    CHECK(a.id_type() == TILEDB_UINT64);
+    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
+  }
+}
 
-// TEST_CASE("create empty index and then train and query",
-// "[api_vamana_index]") {
-//   auto ctx = tiledb::Context{};
-//   using feature_type_type = uint8_t;
-//   using id_type_type = uint32_t;
-//   auto feature_type = "uint8";
-//   auto id_type = "uint32";
-//   auto adjacency_row_index_type = "uint32";
-//   size_t dimensions = 3;
+TEST_CASE("create empty index and then train and query", "[api_vamana_index]") {
+  auto ctx = tiledb::Context{};
+  using feature_type_type = uint8_t;
+  using id_type_type = uint32_t;
+  auto feature_type = "uint8";
+  auto id_type = "uint32";
+  auto adjacency_row_index_type = "uint32";
+  size_t dimensions = 3;
 
-//   std::string index_uri =
-//       (std::filesystem::temp_directory_path() / "api_vamana_index").string();
-//   tiledb::VFS vfs(ctx);
-//   if (vfs.is_dir(index_uri)) {
-//     vfs.remove_dir(index_uri);
-//   }
+  std::string index_uri =
+      (std::filesystem::temp_directory_path() / "api_vamana_index").string();
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(index_uri)) {
+    vfs.remove_dir(index_uri);
+  }
 
-//   {
-//     auto index = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", feature_type},
-//          {"id_type", id_type},
-//          {"adjacency_row_index_type", adjacency_row_index_type}}));
+  {
+    auto index = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", feature_type},
+         {"id_type", id_type},
+         {"adjacency_row_index_type", adjacency_row_index_type}}));
 
-//     size_t num_vectors = 0;
-//     auto empty_training_vector_array =
-//         FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
-//     index.train(empty_training_vector_array);
-//     index.add(empty_training_vector_array);
-//     index.write_index(ctx, index_uri);
+    size_t num_vectors = 0;
+    auto empty_training_vector_array =
+        FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
+    index.train(empty_training_vector_array);
+    index.add(empty_training_vector_array);
+    index.write_index(ctx, index_uri);
 
-//     CHECK(index.feature_type_string() == feature_type);
-//     CHECK(index.id_type_string() == id_type);
-//     CHECK(index.adjacency_row_index_type_string() ==
-//     adjacency_row_index_type);
-//   }
+    CHECK(index.feature_type_string() == feature_type);
+    CHECK(index.id_type_string() == id_type);
+    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
+  }
 
-//   {
-//     auto index = IndexVamana(ctx, index_uri);
+  {
+    auto index = IndexVamana(ctx, index_uri);
 
-//     CHECK(index.feature_type_string() == feature_type);
-//     CHECK(index.id_type_string() == id_type);
-//     CHECK(index.adjacency_row_index_type_string() ==
-//     adjacency_row_index_type);
+    CHECK(index.feature_type_string() == feature_type);
+    CHECK(index.id_type_string() == id_type);
+    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
-//     auto training = ColMajorMatrix<feature_type_type>{
-//         {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
-//     auto training_vector_array = FeatureVectorArray(training);
-//     index.train(training_vector_array);
-//     index.add(training_vector_array);
-//     index.write_index(ctx, index_uri);
+    auto training = ColMajorMatrix<feature_type_type>{
+        {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
+    auto training_vector_array = FeatureVectorArray(training);
+    index.train(training_vector_array);
+    index.add(training_vector_array);
+    index.write_index(ctx, index_uri);
 
-//     CHECK(index.feature_type_string() == feature_type);
-//     CHECK(index.id_type_string() == id_type);
-//     CHECK(index.adjacency_row_index_type_string() ==
-//     adjacency_row_index_type);
+    CHECK(index.feature_type_string() == feature_type);
+    CHECK(index.id_type_string() == id_type);
+    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
-//     auto queries = ColMajorMatrix<feature_type_type>{
-//         {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
-//     auto query_vector_array = FeatureVectorArray(queries);
-//     auto&& [scores_vector_array, ids_vector_array] =
-//         index.query(query_vector_array, 1);
+    auto queries = ColMajorMatrix<feature_type_type>{
+        {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
+    auto query_vector_array = FeatureVectorArray(queries);
+    auto&& [scores_vector_array, ids_vector_array] =
+        index.query(query_vector_array, 1);
 
-//     auto scores = std::span<float>(
-//         (float*)scores_vector_array.data(),
-//         scores_vector_array.num_vectors());
-//     auto ids = std::span<uint32_t>(
-//         (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
-//     CHECK(std::equal(
-//         scores.begin(), scores.end(), std::vector<float>{0, 0, 0,
-//         0}.begin()));
-//     CHECK(std::equal(
-//         ids.begin(), ids.end(), std::vector<int>{0, 1, 2, 3}.begin()));
-//   }
-// }
+    auto scores = std::span<float>(
+        (float*)scores_vector_array.data(), scores_vector_array.num_vectors());
+    auto ids = std::span<uint32_t>(
+        (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
+    CHECK(std::equal(
+        scores.begin(), scores.end(), std::vector<float>{0, 0, 0, 0}.begin()));
+    CHECK(std::equal(
+        ids.begin(), ids.end(), std::vector<int>{0, 1, 2, 3}.begin()));
+  }
+}
 
-// TEST_CASE(
-//     "create empty index and then train and query with "
-//     "external IDs",
-//     "[api_vamana_index]") {
-//   auto ctx = tiledb::Context{};
-//   using feature_type_type = uint8_t;
-//   using id_type_type = uint32_t;
-//   auto feature_type = "uint8";
-//   auto id_type = "uint32";
-//   auto adjacency_row_index_type = "uint32";
-//   size_t dimensions = 3;
+TEST_CASE(
+    "create empty index and then train and query with "
+    "external IDs",
+    "[api_vamana_index]") {
+  auto ctx = tiledb::Context{};
+  using feature_type_type = uint8_t;
+  using id_type_type = uint32_t;
+  auto feature_type = "uint8";
+  auto id_type = "uint32";
+  auto adjacency_row_index_type = "uint32";
+  size_t dimensions = 3;
 
-//   std::string index_uri =
-//       (std::filesystem::temp_directory_path() / "api_vamana_index").string();
-//   tiledb::VFS vfs(ctx);
-//   if (vfs.is_dir(index_uri)) {
-//     vfs.remove_dir(index_uri);
-//   }
+  std::string index_uri =
+      (std::filesystem::temp_directory_path() / "api_vamana_index").string();
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(index_uri)) {
+    vfs.remove_dir(index_uri);
+  }
 
-//   {
-//     auto index = IndexVamana(std::make_optional<IndexOptions>(
-//         {{"feature_type", feature_type},
-//          {"id_type", id_type},
-//          {"adjacency_row_index_type", adjacency_row_index_type}}));
+  {
+    auto index = IndexVamana(std::make_optional<IndexOptions>(
+        {{"feature_type", feature_type},
+         {"id_type", id_type},
+         {"adjacency_row_index_type", adjacency_row_index_type}}));
 
-//     size_t num_vectors = 0;
-//     auto empty_training_vector_array =
-//         FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
-//     index.train(empty_training_vector_array);
-//     index.add(empty_training_vector_array);
-//     index.write_index(ctx, index_uri);
+    size_t num_vectors = 0;
+    auto empty_training_vector_array =
+        FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
+    index.train(empty_training_vector_array);
+    index.add(empty_training_vector_array);
+    index.write_index(ctx, index_uri);
 
-//     CHECK(index.feature_type_string() == feature_type);
-//     CHECK(index.id_type_string() == id_type);
-//     CHECK(index.adjacency_row_index_type_string() ==
-//     adjacency_row_index_type);
-//   }
+    CHECK(index.feature_type_string() == feature_type);
+    CHECK(index.id_type_string() == id_type);
+    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
+  }
 
-//   {
-//     auto index = IndexVamana(ctx, index_uri);
+  {
+    auto index = IndexVamana(ctx, index_uri);
 
-//     CHECK(index.feature_type_string() == feature_type);
-//     CHECK(index.id_type_string() == id_type);
-//     CHECK(index.adjacency_row_index_type_string() ==
-//     adjacency_row_index_type);
+    CHECK(index.feature_type_string() == feature_type);
+    CHECK(index.id_type_string() == id_type);
+    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
-//     auto training = ColMajorMatrixWithIds<feature_type_type, id_type_type>{
-//         {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}, {10, 11, 12, 13}};
+    auto training = ColMajorMatrixWithIds<feature_type_type, id_type_type>{
+        {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}, {10, 11, 12, 13}};
 
-//     auto training_vector_array = FeatureVectorArray(training);
-//     index.train(training_vector_array);
-//     index.add(training_vector_array);
-//     index.write_index(ctx, index_uri);
+    auto training_vector_array = FeatureVectorArray(training);
+    index.train(training_vector_array);
+    index.add(training_vector_array);
+    index.write_index(ctx, index_uri);
 
-//     CHECK(index.feature_type_string() == feature_type);
-//     CHECK(index.id_type_string() == id_type);
-//     CHECK(index.adjacency_row_index_type_string() ==
-//     adjacency_row_index_type);
+    CHECK(index.feature_type_string() == feature_type);
+    CHECK(index.id_type_string() == id_type);
+    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
-//     auto queries = ColMajorMatrix<feature_type_type>{
-//         {8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
-//     auto query_vector_array = FeatureVectorArray(queries);
-//     auto&& [scores_vector_array, ids_vector_array] =
-//         index.query(query_vector_array, 1);
+    auto queries = ColMajorMatrix<feature_type_type>{
+        {8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
+    auto query_vector_array = FeatureVectorArray(queries);
+    auto&& [scores_vector_array, ids_vector_array] =
+        index.query(query_vector_array, 1);
 
-//     auto scores = std::span<float>(
-//         (float*)scores_vector_array.data(),
-//         scores_vector_array.num_vectors());
-//     auto ids = std::span<uint32_t>(
-//         (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
-//     CHECK(std::equal(
-//         scores.begin(), scores.end(), std::vector<float>{0, 0, 0,
-//         0}.begin()));
-//     CHECK(std::equal(
-//         ids.begin(), ids.end(), std::vector<int>{10, 11, 12, 13}.begin()));
-//   }
-// }
+    auto scores = std::span<float>(
+        (float*)scores_vector_array.data(), scores_vector_array.num_vectors());
+    auto ids = std::span<uint32_t>(
+        (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
+    CHECK(std::equal(
+        scores.begin(), scores.end(), std::vector<float>{0, 0, 0, 0}.begin()));
+    CHECK(std::equal(
+        ids.begin(), ids.end(), std::vector<int>{10, 11, 12, 13}.begin()));
+  }
+}
 
 TEST_CASE(
     "create empty index and then train and query with sift",

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -373,76 +373,76 @@ TEST_CASE(
   }
 }
 
-// TEST_CASE("infer feature type", "[api_vamana_index]") {
-//   auto a = IndexVamana(std::make_optional<IndexOptions>(
-//       {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
-//   auto ctx = tiledb::Context{};
-//   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-//   a.train(training_set);
-//   CHECK(a.feature_type() == TILEDB_FLOAT32);
-//   CHECK(a.id_type() == TILEDB_UINT32);
-//   CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-// }
+TEST_CASE("infer feature type", "[api_vamana_index]") {
+  auto a = IndexVamana(std::make_optional<IndexOptions>(
+      {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
+  auto ctx = tiledb::Context{};
+  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+  a.train(training_set);
+  CHECK(a.feature_type() == TILEDB_FLOAT32);
+  CHECK(a.id_type() == TILEDB_UINT32);
+  CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+}
 
-// TEST_CASE("infer dimension", "[api_vamana_index]") {
-//   auto a = IndexVamana(std::make_optional<IndexOptions>(
-//       {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
-//   auto ctx = tiledb::Context{};
-//   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-//   CHECK(dimensions(a) == 0);
-//   a.train(training_set);
-//   CHECK(a.feature_type() == TILEDB_FLOAT32);
-//   CHECK(a.id_type() == TILEDB_UINT32);
-//   CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-//   CHECK(dimensions(a) == 128);
-// }
+TEST_CASE("infer dimension", "[api_vamana_index]") {
+  auto a = IndexVamana(std::make_optional<IndexOptions>(
+      {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
+  auto ctx = tiledb::Context{};
+  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+  CHECK(dimensions(a) == 0);
+  a.train(training_set);
+  CHECK(a.feature_type() == TILEDB_FLOAT32);
+  CHECK(a.id_type() == TILEDB_UINT32);
+  CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
+  CHECK(dimensions(a) == 128);
+}
 
-// TEST_CASE("api_vamana_index write and read", "[api_vamana_index]") {
-//   auto ctx = tiledb::Context{};
-//   std::string api_vamana_index_uri =
-//       (std::filesystem::temp_directory_path() / "api_vamana_index").string();
-//   tiledb::VFS vfs(ctx);
-//   if (vfs.is_dir(api_vamana_index_uri)) {
-//     vfs.remove_dir(api_vamana_index_uri);
-//   }
+TEST_CASE("api_vamana_index write and read", "[api_vamana_index]") {
+  auto ctx = tiledb::Context{};
+  std::string api_vamana_index_uri =
+      (std::filesystem::temp_directory_path() / "api_vamana_index").string();
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(api_vamana_index_uri)) {
+    vfs.remove_dir(api_vamana_index_uri);
+  }
 
-//   auto a = IndexVamana(std::make_optional<IndexOptions>(
-//       {{"feature_type", "float32"},
-//        {"id_type", "uint32"},
-//        {"adjacency_row_index_type", "uint32"}}));
-//   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-//   a.train(training_set);
-//   a.add(training_set);
-//   a.write_index(ctx, api_vamana_index_uri);
+  auto a = IndexVamana(std::make_optional<IndexOptions>(
+      {{"feature_type", "float32"},
+       {"id_type", "uint32"},
+       {"adjacency_row_index_type", "uint32"}}));
+  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+  a.train(training_set);
+  a.add(training_set);
+  a.write_index(ctx, api_vamana_index_uri);
 
-//   auto b = IndexVamana(ctx, api_vamana_index_uri);
+  auto b = IndexVamana(ctx, api_vamana_index_uri);
 
-//   CHECK(dimensions(a) == dimensions(b));
-//   CHECK(a.feature_type() == b.feature_type());
-//   CHECK(a.id_type() == b.id_type());
-//   CHECK(a.adjacency_row_index_type() == b.adjacency_row_index_type());
-// }
+  CHECK(dimensions(a) == dimensions(b));
+  CHECK(a.feature_type() == b.feature_type());
+  CHECK(a.id_type() == b.id_type());
+  CHECK(a.adjacency_row_index_type() == b.adjacency_row_index_type());
+}
 
-// TEST_CASE("build index and query", "[api_vamana_index]") {
-//   auto ctx = tiledb::Context{};
-//   size_t k_nn = 10;
-//   size_t nprobe = GENERATE(8, 32);
+TEST_CASE("build index and query", "[api_vamana_index]") {
+  auto ctx = tiledb::Context{};
+  size_t k_nn = 10;
+  size_t nprobe = GENERATE(8, 32);
 
-//   auto a = IndexVamana(std::make_optional<IndexOptions>(
-//       {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
-//   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-//   auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
-//   auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
-//   a.train(training_set);
-//   a.add(training_set);
+  auto a = IndexVamana(std::make_optional<IndexOptions>(
+      {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
+  auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
+  auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
+  auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
+  a.train(training_set);
+  a.add(training_set);
 
-//   auto&& [s, t] = a.query(query_set, k_nn);
+  auto&& [s, t] = a.query(query_set, k_nn);
 
-//   auto intersections = count_intersections(t, groundtruth_set, k_nn);
-//   auto nt = num_vectors(t);
-//   auto recall = ((double)intersections) / ((double)nt * k_nn);
-//   CHECK(recall == 1.0);
-// }
+  auto intersections = count_intersections(t, groundtruth_set, k_nn);
+  auto nt = num_vectors(t);
+  auto recall = ((double)intersections) / ((double)nt * k_nn);
+  CHECK(recall == 1.0);
+}
 
 TEST_CASE("read index and query", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -1149,10 +1149,11 @@ TEST_CASE("vamana_index vector diskann_test_256bin", "[vamana]") {
   binary_file.read((char*)x.data(), npoints * ndim);
   binary_file.close();
 
-  size_t L = 50;
-  size_t R = 4;
+  size_t l_build = 50;
+  size_t r_max_degree = 4;
+  size_t b_backtrack = L;
   auto index = vamana_index<siftsmall_feature_type, siftsmall_ids_type>(
-      num_vectors(x), L, R);
+      num_vectors(x), l_build, r_max_degree, b_backtrack);
 
   auto x0 = std::vector<float>(ndim);
   std::copy(x.data(), x.data() + ndim, begin(x0));
@@ -1180,20 +1181,21 @@ TEST_CASE("vamana by hand random index", "[vamana]") {
   float alpha_0 = 1.0;
   float alpha_1 = 1.2;
 
-  size_t l_build_ = 2;
-  size_t r_max_degree_ = 2;
+  size_t l_build = 2;
+  size_t r_max_degree = 2;
+  size_t b_backtrack = l_build;
 
   auto training_set_ = random_geometric_2D(num_nodes);
   dump_coordinates("coords.txt", training_set_);
 
   auto g = ::detail::graph::init_random_adj_list<float, uint32_t>(
-      training_set_, r_max_degree_);
+      training_set_, r_max_degree);
 
   auto dimensions_ = ::dimensions(training_set_);
   auto num_vectors_ = ::num_vectors(training_set_);
   auto graph_ = ::detail::graph::
       init_random_nn_graph<siftsmall_feature_type, siftsmall_ids_type>(
-          training_set_, r_max_degree_);
+          training_set_, r_max_degree);
 
   auto medioid_ = medoid(training_set_);
 
@@ -1209,12 +1211,12 @@ TEST_CASE("vamana by hand random index", "[vamana]") {
       }
 
       auto&& [top_k_scores, top_k, visited] = greedy_search(
-          graph_, training_set_, medioid_, training_set_[p], 1, l_build_);
+          graph_, training_set_, medioid_, training_set_[p], 1, l_build);
 
       if (debug) {
         std::cout << ":::: Post search prune" << std::endl;
       }
-      robust_prune(graph_, training_set_, p, visited, alpha, r_max_degree_);
+      robust_prune(graph_, training_set_, p, visited, alpha, r_max_degree);
 
       for (auto&& [i, j] : graph_.out_edges(p)) {
         if (debug) {
@@ -1231,11 +1233,11 @@ TEST_CASE("vamana by hand random index", "[vamana]") {
           }
         }
 
-        if (size(tmp) > r_max_degree_) {
+        if (size(tmp) > r_max_degree) {
           if (debug) {
             std::cout << ":::: Pruning neighbor " << j << std::endl;
           }
-          robust_prune(graph_, training_set_, j, tmp, alpha, r_max_degree_);
+          robust_prune(graph_, training_set_, j, tmp, alpha, r_max_degree);
         } else {
           graph_.add_edge(
               j,
@@ -1263,13 +1265,14 @@ TEST_CASE("vamana_index geometric 2D graph", "[vamana]") {
 
   size_t l_build = 15;
   size_t r_max_degree = 15;
+  size_t b_backtrack = l_build;
 
   size_t k_nn = 5;
 
   auto training_set = random_geometric_2D(num_nodes);
 
   auto idx = vamana_index<siftsmall_feature_type, siftsmall_ids_type>(
-      num_vectors(training_set), l_build, r_max_degree, 0);
+      num_vectors(training_set), l_build, r_max_degree, b_backtrack);
   std::vector<siftsmall_ids_type> ids(num_nodes);
   auto ids_start = 10;
   std::iota(begin(ids), end(ids), ids_start);
@@ -1316,6 +1319,7 @@ TEST_CASE("vamana_index siftsmall", "[vamana]") {
 
   size_t l_build = 15;
   size_t r_max_degree = 12;
+  size_t b_backtrack = l_build;
 
   size_t k_nn = 10;
 
@@ -1331,7 +1335,7 @@ TEST_CASE("vamana_index siftsmall", "[vamana]") {
   queries.load();
 
   auto idx = vamana_index<siftsmall_feature_type, siftsmall_ids_type>(
-      num_vectors(training_set), l_build, r_max_degree, 0);
+      num_vectors(training_set), l_build, r_max_degree, b_backtrack);
   idx.train(training_set, ids);
 
   auto&& [mat_scores, mat_top_k] = idx.query(queries, k_nn);
@@ -1362,7 +1366,7 @@ TEST_CASE("vamana_index write and read", "[vamana]") {
   size_t l_build{37};
   size_t r_max_degree{41};
   size_t k_nn{10};
-  size_t backtrack{3};
+  size_t b_backtrack{3};
 
   tiledb::Context ctx;
   std::string vamana_index_uri =
@@ -1377,7 +1381,7 @@ TEST_CASE("vamana_index write and read", "[vamana]") {
   std::iota(begin(ids), end(ids), 0);
 
   auto idx = vamana_index<siftsmall_feature_type, siftsmall_ids_type>(
-      num_vectors(training_set), l_build, r_max_degree, backtrack);
+      num_vectors(training_set), l_build, r_max_degree, b_backtrack);
   idx.train(training_set, ids);
   uint64_t write_timestamp = 1000;
   idx.write_index(
@@ -1390,7 +1394,7 @@ TEST_CASE("vamana_index write and read", "[vamana]") {
 
     CHECK(idx2.group().get_l_build() == l_build);
     CHECK(idx2.group().get_r_max_degree() == r_max_degree);
-    CHECK(idx2.group().get_b_backtrack() == backtrack);
+    CHECK(idx2.group().get_b_backtrack() == b_backtrack);
     CHECK(idx2.group().get_dimensions() == sift_dimensions);
     CHECK(idx2.group().get_temp_size() == 0);
 
@@ -1422,7 +1426,7 @@ TEST_CASE("vamana_index write and read", "[vamana]") {
 
     CHECK(idx2.group().get_l_build() == l_build);
     CHECK(idx2.group().get_r_max_degree() == r_max_degree);
-    CHECK(idx2.group().get_b_backtrack() == backtrack);
+    CHECK(idx2.group().get_b_backtrack() == b_backtrack);
     CHECK(idx2.group().get_dimensions() == sift_dimensions);
     CHECK(idx2.group().get_temp_size() == 0);
 
@@ -1437,13 +1441,13 @@ TEST_CASE("vamana_index write and read", "[vamana]") {
 }
 
 TEST_CASE("query empty index", "[vamana]") {
-  size_t L = 100;
-  size_t R = 100;
-  size_t B = 2;
+  size_t l_build = 100;
+  size_t r_max_degree = 100;
+  size_t b_backtrack = 2;
   size_t num_vectors = 0;
   size_t dimensions = 5;
   auto index = vamana_index<siftsmall_feature_type, siftsmall_ids_type>(
-      num_vectors, L, R, B);
+      num_vectors, l_build, r_max_degree, b_backtrack);
   auto data =
       ColMajorMatrixWithIds<siftsmall_feature_type>(dimensions, num_vectors);
   index.train(data, data.raveled_ids());

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -1151,7 +1151,7 @@ TEST_CASE("vamana_index vector diskann_test_256bin", "[vamana]") {
 
   size_t l_build = 50;
   size_t r_max_degree = 4;
-  size_t b_backtrack = L;
+  size_t b_backtrack = l_build;
   auto index = vamana_index<siftsmall_feature_type, siftsmall_ids_type>(
       num_vectors(x), l_build, r_max_degree, b_backtrack);
 


### PR DESCRIPTION
### What
Previously if you created a `IndexVamana()` with some configured `l_build`, `r_max_degree`, or `b_backtrack`, wrote it to a URI, and the loaded the index by URI, we would not set those values when loading the index. This is because in this code we would just use the default values from `src/include/api/vamana_index.h` when we re-recreated the `index_` in `train()`:
```
index_ = dispatch_table.at(type)(
        training_set.num_vectors(),
        l_build_,
        r_max_degree_,
        b_backtrack_,
        temporal_policy);
```
To fix this we make sure when we load an index by URI that we also set the state correctly:
```
    index_ = uri_dispatch_table.at(type)(ctx, group_uri, temporal_policy);
    l_build_ = index_->l_build();
    r_max_degree_ = index_->r_max_degree();
    b_backtrack_ = index_->b_backtrack();
```

The rest of the changes in this PR are just refactors and adding tests for this.

### Testing
* Adds tests for this.
* Existing tests pass.