### PR TITLE
Add query with driver implementation

### DIFF
--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -127,7 +127,6 @@ class FlatIndex(index.Index):
                 (queries.shape[0], k), MAX_UINT64
             )
 
-        assert queries.dtype == np.float32
 
         queries_m = array_to_matrix(np.transpose(queries))
         d, i = query_vq_heap(self._db, queries_m, self._ids, k, nthreads)

--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -35,9 +35,9 @@ class FlatIndex(index.Index):
     timestamp: int or tuple(int)
         If int, open the index at a given timestamp.
         If tuple, open at the given start and end timestamps.
-    load_index_data: bool
-        If `False`, do not load any index data in main memory locally, and instead load index data in the TileDB Cloud taskgraph created when a non-`None` `driver_mode` is passed to `query()`.
-        If `True`, load index data in main memory locally. Note that you can still use a taskgraph for query execution, you'll just end up loading the data both on your local machine and in the cloud taskgraph.
+    open_for_remote_query_execution: bool
+        If `True`, do not load any index data in main memory locally, and instead load index data in the TileDB Cloud taskgraph created when a non-`None` `driver_mode` is passed to `query()`.
+        If `False`, load index data in main memory locally. Note that you can still use a taskgraph for query execution, you'll just end up loading the data both on your local machine and in the cloud taskgraph.
     """
 
     def __init__(
@@ -45,7 +45,7 @@ class FlatIndex(index.Index):
         uri: str,
         config: Optional[Mapping[str, Any]] = None,
         timestamp=None,
-        load_index_data: bool = True,
+        open_for_remote_query_execution: bool = False,
         **kwargs,
     ):
         self.index_open_kwargs = {
@@ -56,7 +56,10 @@ class FlatIndex(index.Index):
         self.index_open_kwargs.update(kwargs)
         self.index_type = INDEX_TYPE
         super().__init__(
-            uri=uri, config=config, timestamp=timestamp, load_index_data=load_index_data
+            uri=uri,
+            config=config,
+            timestamp=timestamp,
+            open_for_remote_query_execution=open_for_remote_query_execution,
         )
         self._index = None
         self.db_uri = self.group[
@@ -81,7 +84,7 @@ class FlatIndex(index.Index):
             ].uri
         else:
             self.ids_uri = ""
-        if self.size > 0 and load_index_data:
+        if self.size > 0 and not open_for_remote_query_execution:
             self._db = load_as_matrix(
                 self.db_uri,
                 ctx=self.ctx,

--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -44,6 +44,12 @@ class FlatIndex(index.Index):
         timestamp=None,
         **kwargs,
     ):
+        self.index_open_kwargs = {
+            "uri": uri,
+            "config": config,
+            "timestamp": timestamp,
+        }
+        self.index_open_kwargs.update(kwargs)
         self.index_type = INDEX_TYPE
         super().__init__(uri=uri, config=config, timestamp=timestamp)
         self._index = None

--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -127,7 +127,6 @@ class FlatIndex(index.Index):
                 (queries.shape[0], k), MAX_UINT64
             )
 
-
         queries_m = array_to_matrix(np.transpose(queries))
         d, i = query_vq_heap(self._db, queries_m, self._ids, k, nthreads)
 

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -4,13 +4,13 @@ import os
 import time
 from typing import Any, Mapping, Optional
 
+from tiledb.cloud.dag import Mode
 from tiledb.vector_search import _tiledbvspy as vspy
 from tiledb.vector_search.module import *
 from tiledb.vector_search.storage_formats import storage_formats
 from tiledb.vector_search.utils import MAX_FLOAT32
 from tiledb.vector_search.utils import MAX_UINT64
 from tiledb.vector_search.utils import add_to_group
-from tiledb.cloud.dag import Mode
 
 DATASET_TYPE = "vector_search"
 
@@ -159,7 +159,6 @@ class Index:
         self, queries: np.ndarray, k: int, mode=None, resources=None, acn=None, **kwargs
     ):
         from tiledb.cloud import dag
-        from tiledb.cloud.dag import Mode
 
         def query_udf(index_type, index_open_kwargs, query_kwargs):
             from tiledb.vector_search.flat_index import FlatIndex
@@ -202,13 +201,14 @@ class Index:
         return node.result()
 
     def query(
-            self, 
-            queries: np.ndarray, 
-            k: int, 
-            driver_mode: Mode = None,
-            driver_resources: Optional[str] = None,
-            driver_access_credentials_name: Optional[str] = None,
-            **kwargs):
+        self,
+        queries: np.ndarray,
+        k: int,
+        driver_mode: Mode = None,
+        driver_resources: Optional[str] = None,
+        driver_access_credentials_name: Optional[str] = None,
+        **kwargs,
+    ):
         """
         Queries an index with a set of query vectors, retrieving the `k` most similar vectors for each query.
 
@@ -248,20 +248,21 @@ class Index:
             raise TypeError(
                 f"A query in queries has {query_dimensions} dimensions, but the indexed data had {self.dimensions} dimensions"
             )
-        
+
         if queries.dtype != np.float32:
             raise TypeError(
                 f"Expected queries to have dtype np.float32, but it had dtype {queries.dtype}"
             )
-        
+
         if driver_mode is not None:
             return self._query_with_driver(
-                queries, 
-                k, 
+                queries,
+                k,
                 driver_mode,
                 driver_resources,
                 driver_access_credentials_name,
-                **kwargs)
+                **kwargs,
+            )
 
         with tiledb.scope_ctx(ctx_or_config=self.config):
             if not self.has_updates:

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -156,7 +156,13 @@ class Index:
         self.has_updates = self._check_has_updates()
 
     def _query_with_driver(
-        self, queries: np.ndarray, k: int, mode=None, resources=None, acn=None, **kwargs
+        self,
+        queries: np.ndarray,
+        k: int,
+        driver_mode=None,
+        driver_resources=None,
+        driver_access_credentials_name=None,
+        **kwargs,
     ):
         from tiledb.cloud import dag
 
@@ -178,7 +184,7 @@ class Index:
 
         d = dag.DAG(
             name="vector-query",
-            mode=mode,
+            mode=driver_mode,
             max_workers=1,
         )
         query_kwargs = {
@@ -192,9 +198,9 @@ class Index:
             self.index_open_kwargs,
             query_kwargs,
             name="vector-query-driver",
-            resources=resources,
+            resources=driver_resources,
             image_name="vectorsearch",
-            access_credentials_name=acn,
+            access_credentials_name=driver_access_credentials_name,
         )
         d.compute()
         d.wait()

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -241,7 +241,7 @@ class Index:
         k: int
             Number of results to return per query vector.
         driver_mode: Mode
-            If not `None`, the query will be executed in the cloud using the driver mode specified.
+            If not `None`, the query will be executed in a TileDB cloud taskgraph using the driver mode specified.
         driver_resources: Optional[str]
             If `driver_mode` was not `None`, the resources to use for the driver execution.
         driver_access_credentials_name: Optional[str]

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -265,6 +265,12 @@ class Index:
                 f"Expected queries to have dtype np.float32, but it had dtype {queries.dtype}"
             )
 
+        if driver_mode == Mode.LOCAL:
+            # @todo: Fix bug with driver_mode=Mode.LOCAL and remove this check.
+            raise TypeError(
+                "Cannot pass driver_mode=Mode.LOCAL to query() - use driver_mode=None to query locally."
+            )
+
         if driver_mode is not None:
             return self._query_with_driver(
                 queries,

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -36,15 +36,15 @@ class Index:
     timestamp: int or tuple(int)
         If int, open the index at a given timestamp.
         If tuple, open at the given start and end timestamps.
-    load_index_data: bool
-        If `False`, do not load any index data in main memory locally, and instead load index data in the TileDB Cloud taskgraph created when a non-`None` `driver_mode` is passed to `query()`.
-        If `True`, load index data in main memory locally. Note that you can still use a taskgraph for query execution, you'll just end up loading the data both on your local machine and in the cloud taskgraph.
+    open_for_remote_query_execution: bool
+        If `True`, do not load any index data in main memory locally, and instead load index data in the TileDB Cloud taskgraph created when a non-`None` `driver_mode` is passed to `query()`.
+        If `False`, load index data in main memory locally. Note that you can still use a taskgraph for query execution, you'll just end up loading the data both on your local machine and in the cloud taskgraph.
     """
 
     def __init__(
         self,
         uri: str,
-        load_index_data: bool,
+        open_for_remote_query_execution: bool,
         config: Optional[Mapping[str, Any]] = None,
         timestamp=None,
     ):
@@ -53,7 +53,7 @@ class Index:
             config = dict(config)
 
         self.uri = uri
-        self.load_index_data = load_index_data
+        self.open_for_remote_query_execution = open_for_remote_query_execution
         self.config = config
         self.ctx = vspy.Ctx(config)
         self.group = tiledb.Group(self.uri, "r", ctx=tiledb.Ctx(config))
@@ -281,9 +281,9 @@ class Index:
                 **kwargs,
             )
 
-        if not self.load_index_data:
+        if self.open_for_remote_query_execution:
             raise ValueError(
-                "Cannot query an index with driver_mode=None without loading the index data in main memory. Set load_index_data=True when creating the index to load the index data before query."
+                "Cannot query an index with driver_mode=None without loading the index data in main memory. Set open_for_remote_query_execution=False when creating the index to load the index data before query."
             )
 
         with tiledb.scope_ctx(ctx_or_config=self.config):

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -277,7 +277,7 @@ class Index:
 
         if not self.load_index_data:
             raise ValueError(
-                "Cannot query an index with mode=None without loading the index data in main memory. Set load_index_data=True when creating the index to load the index data before query."
+                "Cannot query an index with driver_mode=None without loading the index data in main memory. Set load_index_data=True when creating the index to load the index data before query."
             )
 
         with tiledb.scope_ctx(ctx_or_config=self.config):

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -2855,9 +2855,7 @@ def ingest(
         if index_type == "FLAT":
             return flat_index.FlatIndex(uri=index_group_uri, config=config)
         elif index_type == "VAMANA":
-            return vamana_index.VamanaIndex(
-                uri=index_group_uri, config=config, debug=True
-            )
+            return vamana_index.VamanaIndex(uri=index_group_uri, config=config)
         elif index_type == "IVF_FLAT":
             return ivf_flat_index.IVFFlatIndex(
                 uri=index_group_uri, memory_budget=1000000, config=config

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -70,9 +70,9 @@ class IVFFlatIndex(index.Index):
         If not provided, all index data are loaded in main memory.
         Otherwise, no index data are loaded in main memory and this memory budget is
         applied during queries.
-    load_index_data: bool
-        If `False`, do not load any index data in main memory locally, and instead load index data in the TileDB Cloud taskgraph created when a non-`None` `driver_mode` is passed to `query()`. We then load index data in the taskgraph based on `memory_budget`.
-        If `True`, load index data in main memory locally according to `memory_budget`. Note that you can still use a taskgraph for query execution, you'll just end up loading the data both on your local machine and in the cloud taskgraph..
+    open_for_remote_query_execution: bool
+        If `True`, do not load any index data in main memory locally, and instead load index data in the TileDB Cloud taskgraph created when a non-`None` `driver_mode` is passed to `query()`. We then load index data in the taskgraph based on `memory_budget`.
+        If `False`, load index data in main memory locally according to `memory_budget`. Note that you can still use a taskgraph for query execution, you'll just end up loading the data both on your local machine and in the cloud taskgraph..
     """
 
     def __init__(
@@ -81,7 +81,7 @@ class IVFFlatIndex(index.Index):
         config: Optional[Mapping[str, Any]] = None,
         timestamp=None,
         memory_budget: int = -1,
-        load_index_data: bool = True,
+        open_for_remote_query_execution: bool = False,
         **kwargs,
     ):
         self.index_open_kwargs = {
@@ -93,7 +93,10 @@ class IVFFlatIndex(index.Index):
         self.index_open_kwargs.update(kwargs)
         self.index_type = INDEX_TYPE
         super().__init__(
-            uri=uri, config=config, timestamp=timestamp, load_index_data=load_index_data
+            uri=uri,
+            config=config,
+            timestamp=timestamp,
+            open_for_remote_query_execution=open_for_remote_query_execution,
         )
         self.db_uri = self.group[
             storage_formats[self.storage_version]["PARTS_ARRAY_NAME"]
@@ -138,7 +141,7 @@ class IVFFlatIndex(index.Index):
         else:
             self.partitions = self.partition_history[self.history_index]
 
-        if load_index_data:
+        if not open_for_remote_query_execution:
             self._centroids = load_as_matrix(
                 self.centroids_uri,
                 ctx=self.ctx,
@@ -160,7 +163,7 @@ class IVFFlatIndex(index.Index):
             self.size = self.base_size
 
         # TODO pass in a context
-        if load_index_data and self.memory_budget == -1:
+        if not open_for_remote_query_execution and self.memory_budget == -1:
             self._db = load_as_matrix(
                 self.db_uri,
                 ctx=self.ctx,

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -80,6 +80,13 @@ class IVFFlatIndex(index.Index):
         memory_budget: int = -1,
         **kwargs,
     ):
+        self.index_open_kwargs = {
+            "uri": uri,
+            "config": config,
+            "timestamp": timestamp,
+            "memory_budget": memory_budget,
+        }
+        self.index_open_kwargs.update(kwargs)
         self.index_type = INDEX_TYPE
         super().__init__(uri=uri, config=config, timestamp=timestamp)
         self.db_uri = self.group[

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -232,8 +232,6 @@ class IVFFlatIndex(index.Index):
         if (mode != Mode.REALTIME and mode != Mode.BATCH) and resource_class:
             raise TypeError("Can only pass resource_class in REALTIME or BATCH mode")
 
-        assert queries.dtype == np.float32
-
         if queries.ndim == 1:
             queries = np.array([queries])
 
@@ -398,7 +396,6 @@ class IVFFlatIndex(index.Index):
                 results.append(tmp_results)
             return results
 
-        assert queries.dtype == np.float32
         if num_partitions == -1:
             num_partitions = 5
         if num_workers == -1:

--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -109,7 +109,6 @@ class VamanaIndex(index.Index):
         opt_l: int
             How deep to search. Should be >= k, and if it's not, we will set it to k.
         """
-        warnings.warn("The Vamana index is not yet supported, please use with caution.")
         if self.size == 0:
             return np.full((queries.shape[0], k), MAX_FLOAT32), np.full(
                 (queries.shape[0], k), MAX_UINT64
@@ -156,7 +155,6 @@ def create(
         The TileDB vector search storage version to use.
         If not provided, use the latest stable storage version.
     """
-    warnings.warn("The Vamana index is not yet supported, please use with caution.")
     validate_storage_version(storage_version)
     ctx = vspy.Ctx(config)
     index = vspy.IndexVamana(

--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -47,6 +47,12 @@ class VamanaIndex(index.Index):
         timestamp=None,
         **kwargs,
     ):
+        self.index_open_kwargs = {
+            "uri": uri,
+            "config": config,
+            "timestamp": timestamp,
+        }
+        self.index_open_kwargs.update(kwargs)
         super().__init__(uri=uri, config=config, timestamp=timestamp)
         self.index_type = INDEX_TYPE
         self.index = vspy.IndexVamana(self.ctx, uri, to_temporal_policy(timestamp))

--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -108,7 +108,6 @@ class VamanaIndex(index.Index):
                 (queries.shape[0], k), MAX_UINT64
             )
 
-        assert queries.dtype == np.float32
         if opt_l < k:
             warnings.warn(f"opt_l ({opt_l}) should be >= k ({k}), setting to k")
             opt_l = k

--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -38,9 +38,9 @@ class VamanaIndex(index.Index):
         URI of the index.
     config: Optional[Mapping[str, Any]]
         TileDB config dictionary.
-    load_index_data: bool
-        If `False`, do not load any index data in main memory locally, and instead load index data in the TileDB Cloud taskgraph created when a non-`None` `driver_mode` is passed to `query()`.
-        If `True`, load index data in main memory locally. Note that you can still use a taskgraph for query execution, you'll just end up loading the data both on your local machine and in the cloud taskgraph.
+    open_for_remote_query_execution: bool
+        If `True`, do not load any index data in main memory locally, and instead load index data in the TileDB Cloud taskgraph created when a non-`None` `driver_mode` is passed to `query()`.
+        If `False`, load index data in main memory locally. Note that you can still use a taskgraph for query execution, you'll just end up loading the data both on your local machine and in the cloud taskgraph.
     """
 
     def __init__(
@@ -48,7 +48,7 @@ class VamanaIndex(index.Index):
         uri: str,
         config: Optional[Mapping[str, Any]] = None,
         timestamp=None,
-        load_index_data: bool = True,
+        open_for_remote_query_execution: bool = False,
         **kwargs,
     ):
         self.index_open_kwargs = {
@@ -58,10 +58,13 @@ class VamanaIndex(index.Index):
         }
         self.index_open_kwargs.update(kwargs)
         super().__init__(
-            uri=uri, config=config, timestamp=timestamp, load_index_data=load_index_data
+            uri=uri,
+            config=config,
+            timestamp=timestamp,
+            open_for_remote_query_execution=open_for_remote_query_execution,
         )
         self.index_type = INDEX_TYPE
-        # TODO(SC-48710): Add support for `load_index_data`. We don't leave `self.index`` as `None`` because we need to be able to call index.dimensions().
+        # TODO(SC-48710): Add support for `open_for_remote_query_execution`. We don't leave `self.index`` as `None` because we need to be able to call index.dimensions().
         self.index = vspy.IndexVamana(self.ctx, uri, to_temporal_policy(timestamp))
         self.db_uri = self.group[
             storage_formats[self.storage_version]["PARTS_ARRAY_NAME"]

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -65,24 +65,6 @@ class CloudTests(unittest.TestCase):
             mode=Mode.BATCH,
         )
 
-        # Test query().
-        tiledb_index_uri = groups.info(index_uri).tiledb_uri
-        index = index_class(
-            uri=tiledb_index_uri,
-            config=tiledb.cloud.Config().dict(),
-        )
-        for driver_mode in [None, Mode.REALTIME]:
-            for mode in [None, Mode.LOCAL, Mode.REALTIME]:
-                _, result_i = index.query(
-                    queries=queries,
-                    k=k,
-                    nprobe=nprobe,
-                    mode=mode,
-                    driver_mode=driver_mode,
-                    num_partitions=2,
-                )
-                assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
-
         # Test without loading index data into memory.
         index = index_class(
             uri=tiledb_index_uri,
@@ -101,6 +83,24 @@ class CloudTests(unittest.TestCase):
             num_partitions=2,
         )
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
+
+        # Test query().
+        tiledb_index_uri = groups.info(index_uri).tiledb_uri
+        index = index_class(
+            uri=tiledb_index_uri,
+            config=tiledb.cloud.Config().dict(),
+        )
+        for driver_mode in [None, Mode.REALTIME]:
+            for mode in [None, Mode.LOCAL, Mode.REALTIME]:
+                _, result_i = index.query(
+                    queries=queries,
+                    k=k,
+                    nprobe=nprobe,
+                    mode=mode,
+                    driver_mode=driver_mode,
+                    num_partitions=2,
+                )
+                assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
         # We now will test for invalid scenarios when setting the query() resources.
         resources = {"cpu": "9", "memory": "12Gi", "gpu": 0}

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -64,6 +64,7 @@ class CloudTests(unittest.TestCase):
             config=tiledb.cloud.Config().dict(),
             mode=Mode.BATCH,
         )
+        tiledb_index_uri = groups.info(index_uri).tiledb_uri
 
         # Test without loading index data into memory.
         index = index_class(
@@ -85,7 +86,6 @@ class CloudTests(unittest.TestCase):
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
         # Test query().
-        tiledb_index_uri = groups.info(index_uri).tiledb_uri
         index = index_class(
             uri=tiledb_index_uri,
             config=tiledb.cloud.Config().dict(),

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -70,7 +70,7 @@ class CloudTests(unittest.TestCase):
         index = index_class(
             uri=tiledb_index_uri,
             config=tiledb.cloud.Config().dict(),
-            load_index_data=False,
+            open_for_remote_query_execution=True,
         )
         # Throws if we try to query locally.
         with self.assertRaises(ValueError):
@@ -157,34 +157,7 @@ class CloudTests(unittest.TestCase):
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
     def test_cloud_flat(self):
-        source_uri = "tiledb://TileDB-Inc/sift_10k"
-        queries_uri = siftsmall_query_file
-        gt_uri = siftsmall_groundtruth_file
-        index_uri = CloudTests.flat_index_uri
-        k = 100
-        nqueries = 100
-
-        queries = load_fvecs(queries_uri)
-        gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
-
-        index = vs.ingest(
-            index_type="FLAT",
-            index_uri=index_uri,
-            source_uri=source_uri,
-            config=tiledb.cloud.Config().dict(),
-            mode=Mode.BATCH,
-        )
-        tiledb_index_uri = groups.info(index_uri).tiledb_uri
-        index = vs.flat_index.FlatIndex(
-            uri=tiledb_index_uri, config=tiledb.cloud.Config().dict()
-        )
-
-        _, result_i = index.query(queries, k=k)
-        assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
-
-        index.delete(external_id=42)
-        _, result_i = index.query(queries, k=k)
-        assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
+        self.run_cloud_test(CloudTests.flat_index_uri, "FLAT", vs.flat_index.FlatIndex)
 
     def test_cloud_vamana(self):
         self.run_cloud_test(

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -26,11 +26,16 @@ class CloudTests(unittest.TestCase):
         storage_path = storage_path.replace("//", "/").replace("/", "//", 1)
         rand_name = random_name("vector_search")
         test_path = f"tiledb://{namespace}/{storage_path}/{rand_name}"
-        cls.flat_index_uri = f"{test_path}/test_flat_array"
-        cls.vamana_index_uri = f"{test_path}/vamana_array"
-        cls.ivf_flat_index_uri = f"{test_path}/test_ivf_flat_array"
+        cls.flat_index_uri = f"{test_path}/test_cloud_flat_index"
+        cls.vamana_index_uri = f"{test_path}/test_cloud_vamana_index"
+        cls.ivf_flat_index_uri = f"{test_path}/test_cloud_ivf_flat_index"
+
+        cls.small_flat_index_uri = f"{test_path}/test_cloud_small_flat_index"
+        cls.small_vamana_index_uri = f"{test_path}/test_cloud_small_vamana_index"
+        cls.small_ivf_flat_index_uri = f"{test_path}/test_cloud_small_ivf_flat_index"
+
         cls.ivf_flat_random_sampling_index_uri = (
-            f"{test_path}/test_ivf_flat_random_sampling_array"
+            f"{test_path}/test_cloud_ivf_flat_random_sampling_index"
         )
 
     @classmethod
@@ -39,70 +44,22 @@ class CloudTests(unittest.TestCase):
         vs.Index.delete_index(uri=cls.vamana_index_uri, config=tiledb.cloud.Config())
         vs.Index.delete_index(uri=cls.ivf_flat_index_uri, config=tiledb.cloud.Config())
         vs.Index.delete_index(
+            uri=cls.small_flat_index_uri, config=tiledb.cloud.Config()
+        )
+        vs.Index.delete_index(
+            uri=cls.small_vamana_index_uri, config=tiledb.cloud.Config()
+        )
+        vs.Index.delete_index(
+            uri=cls.small_ivf_flat_index_uri, config=tiledb.cloud.Config()
+        )
+        vs.Index.delete_index(
             uri=cls.ivf_flat_random_sampling_index_uri, config=tiledb.cloud.Config()
         )
 
-    def test_cloud_flat(self):
+    def run_cloud_test(self, index_uri, index_type, index_class):
         source_uri = "tiledb://TileDB-Inc/sift_10k"
         queries_uri = siftsmall_query_file
         gt_uri = siftsmall_groundtruth_file
-        index_uri = CloudTests.flat_index_uri
-        k = 100
-        nqueries = 100
-
-        queries = load_fvecs(queries_uri)
-        gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
-
-        index = vs.ingest(
-            index_type="FLAT",
-            index_uri=index_uri,
-            source_uri=source_uri,
-            config=tiledb.cloud.Config().dict(),
-            mode=Mode.BATCH,
-        )
-        tiledb_index_uri = groups.info(index_uri).tiledb_uri
-        index = vs.flat_index.FlatIndex(
-            uri=tiledb_index_uri, config=tiledb.cloud.Config().dict()
-        )
-
-        _, result_i = index.query(queries, k=k)
-        assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
-
-        index.delete(external_id=42)
-        _, result_i = index.query(queries, k=k)
-        assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
-
-    def test_cloud_vamana(self):
-        source_uri = "tiledb://TileDB-Inc/sift_10k"
-        queries_uri = siftsmall_query_file
-        gt_uri = siftsmall_groundtruth_file
-        index_uri = CloudTests.vamana_index_uri
-        k = 100
-        nqueries = 100
-
-        load_fvecs(queries_uri)
-        gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
-
-        vs.ingest(
-            index_type="VAMANA",
-            index_uri=index_uri,
-            source_uri=source_uri,
-            input_vectors_per_work_item=5000,
-            config=tiledb.cloud.Config().dict(),
-            # TODO(paris): Fix and then change to Mode.BATCH.
-            mode=Mode.LOCAL,
-        )
-
-        tiledb_index_uri = groups.info(index_uri).tiledb_uri
-        vs.vamana_index.VamanaIndex(
-            uri=tiledb_index_uri, config=tiledb.cloud.Config().dict()
-        )
-
-    def test_cloud_ivf_flat(self):
-        source_uri = "tiledb://TileDB-Inc/sift_10k"
-        queries_uri = siftsmall_query_file
-        gt_uri = siftsmall_groundtruth_file
-        index_uri = CloudTests.ivf_flat_index_uri
         k = 100
         partitions = 100
         nqueries = 100
@@ -112,7 +69,7 @@ class CloudTests(unittest.TestCase):
         gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
 
         index = vs.ingest(
-            index_type="IVF_FLAT",
+            index_type=index_type,
             index_uri=index_uri,
             source_uri=source_uri,
             partitions=partitions,
@@ -122,14 +79,29 @@ class CloudTests(unittest.TestCase):
         )
 
         tiledb_index_uri = groups.info(index_uri).tiledb_uri
-        index = vs.ivf_flat_index.IVFFlatIndex(
+        index = index_class(
             uri=tiledb_index_uri,
             config=tiledb.cloud.Config().dict(),
         )
 
+        for driver_mode in [None, Mode.LOCAL, Mode.REALTIME]:
+            for mode in [None, Mode.LOCAL, Mode.REALTIME]:
+                _, result_i = index.query(
+                    queries=queries,
+                    k=k,
+                    nprobe=nprobe,
+                    mode=mode,
+                    driver_mode=driver_mode,
+                    num_partitions=2,
+                    resource_class="standard",
+                )
+                assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
+
+        # Query with mode = None.
         _, result_i = index.query(queries, k=k, nprobe=nprobe)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
+        # Query with mode = REALTIME.
         _, result_i = index.query(
             queries,
             k=k,
@@ -140,6 +112,7 @@ class CloudTests(unittest.TestCase):
         )
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
+        # Query with mode = LOCAL.
         _, result_i = index.query(
             queries, k=k, nprobe=nprobe, mode=Mode.LOCAL, num_partitions=2
         )
@@ -188,7 +161,7 @@ class CloudTests(unittest.TestCase):
                 resources=resources,
             )
 
-        index = vs.ivf_flat_index.IVFFlatIndex(
+        index = index_class(
             uri=index_uri,
             config=tiledb.cloud.Config().dict(),
         )
@@ -199,6 +172,125 @@ class CloudTests(unittest.TestCase):
         index = index.consolidate_updates()
         _, result_i = index.query(queries, k=k, nprobe=nprobe)
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
+
+    def run_small_cloud_test(self, index_uri, index_type):
+        print()
+        print("[test_cloud@run_small_cloud_test]", index_type, index_uri)
+        data = np.array(
+            [
+                [1.0, 1.1, 1.2, 1.3],
+                [2.0, 2.1, 2.2, 2.3],
+                [3.0, 3.1, 3.2, 3.3],
+                [4.0, 4.1, 4.2, 4.3],
+                [5.0, 5.1, 5.2, 5.3],
+            ],
+            dtype=np.float32,
+        )
+        print("[test_cloud@run_small_cloud_test] vs.ingest()")
+        index = vs.ingest(
+            index_type=index_type,
+            index_uri=index_uri,
+            input_vectors=data,
+            config=tiledb.cloud.Config().dict(),
+            mode=Mode.BATCH,
+        )
+        print("[test_cloud@run_small_cloud_test] vs.ingest() done")
+
+        queries = np.array([data[1]], dtype=np.float32)
+
+        print(
+            "[test_cloud@run_small_cloud_test] vs.query() mode = None ----------------------------"
+        )
+        result_d, result_i = index.query(queries, k=1)
+        print("[test_cloud@run_small_cloud_test] result_d", result_d)
+        print("[test_cloud@run_small_cloud_test] result_i", result_i)
+        expected_result_i = [[1]]
+        expected_result_d = [[0]]
+        assert np.array_equal(
+            result_i, expected_result_i
+        ), f"result_i: {result_i} != expected_result_i: {expected_result_i}"
+        assert np.array_equal(
+            result_d, expected_result_d
+        ), f"result_d: {result_d} != expected_result_d: {expected_result_d}"
+
+        print(
+            "[test_cloud@run_small_cloud_test] vs.query() mode = LOCAL ----------------------------"
+        )
+        result_d, result_i = index.query(queries, k=1, mode=Mode.LOCAL)
+        print("[test_cloud@run_small_cloud_test] result_d", result_d)
+        print("[test_cloud@run_small_cloud_test] result_i", result_i)
+        expected_result_i = [[1]]
+        expected_result_d = [[0]]
+        assert np.array_equal(
+            result_i, expected_result_i
+        ), f"result_i: {result_i} != expected_result_i: {expected_result_i}"
+        assert np.array_equal(
+            result_d, expected_result_d
+        ), f"result_d: {result_d} != expected_result_d: {expected_result_d}"
+
+        print(
+            "[test_cloud@run_small_cloud_test] vs.query() mode = REALTIME ----------------------------"
+        )
+        result_d, result_i = index.query(queries, k=1, mode=Mode.REALTIME)
+        print("[test_cloud@run_small_cloud_test] result_d", result_d)
+        print("[test_cloud@run_small_cloud_test] result_i", result_i)
+        expected_result_i = [[1]]
+        expected_result_d = [[0]]
+        assert np.array_equal(
+            result_i, expected_result_i
+        ), f"result_i: {result_i} != expected_result_i: {expected_result_i}"
+        assert np.array_equal(
+            result_d, expected_result_d
+        ), f"result_d: {result_d} != expected_result_d: {expected_result_d}"
+
+    def test_cloud_small_flat(self):
+        self.run_small_cloud_test(CloudTests.small_flat_index_uri, "FLAT")
+
+    def test_cloud_small_vamana(self):
+        self.run_small_cloud_test(CloudTests.small_vamana_index_uri, "VAMANA")
+
+    def test_cloud_small_ivf_flat(self):
+        self.run_small_cloud_test(CloudTests.small_ivf_flat_index_uri, "IVF_FLAT")
+
+    def test_cloud_flat(self):
+        source_uri = "tiledb://TileDB-Inc/sift_10k"
+        queries_uri = siftsmall_query_file
+        gt_uri = siftsmall_groundtruth_file
+        index_uri = CloudTests.flat_index_uri
+        k = 100
+        nqueries = 100
+
+        queries = load_fvecs(queries_uri)
+        gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)
+
+        index = vs.ingest(
+            index_type="FLAT",
+            index_uri=index_uri,
+            source_uri=source_uri,
+            config=tiledb.cloud.Config().dict(),
+            mode=Mode.BATCH,
+        )
+        tiledb_index_uri = groups.info(index_uri).tiledb_uri
+        index = vs.flat_index.FlatIndex(
+            uri=tiledb_index_uri, config=tiledb.cloud.Config().dict()
+        )
+
+        _, result_i = index.query(queries, k=k)
+        assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
+
+        index.delete(external_id=42)
+        _, result_i = index.query(queries, k=k)
+        assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
+
+    def test_cloud_vamana(self):
+        self.run_cloud_test(
+            CloudTests.vamana_index_uri, "VAMANA", vs.vamana_index.VamanaIndex
+        )
+
+    def test_cloud_ivf_flat(self):
+        self.run_cloud_test(
+            CloudTests.ivf_flat_index_uri, "IVF_FLAT", vs.ivf_flat_index.IVFFlatIndex
+        )
 
     def test_cloud_ivf_flat_random_sampling(self):
         # NOTE(paris): This was also tested with the following (and also with mode=Mode.BATCH):

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -93,7 +93,6 @@ class CloudTests(unittest.TestCase):
                     mode=mode,
                     driver_mode=driver_mode,
                     num_partitions=2,
-                    resource_class="standard",
                 )
                 assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
@@ -174,8 +173,6 @@ class CloudTests(unittest.TestCase):
         assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
     def run_small_cloud_test(self, index_uri, index_type):
-        print()
-        print("[test_cloud@run_small_cloud_test]", index_type, index_uri)
         data = np.array(
             [
                 [1.0, 1.1, 1.2, 1.3],
@@ -186,7 +183,6 @@ class CloudTests(unittest.TestCase):
             ],
             dtype=np.float32,
         )
-        print("[test_cloud@run_small_cloud_test] vs.ingest()")
         index = vs.ingest(
             index_type=index_type,
             index_uri=index_uri,
@@ -194,16 +190,10 @@ class CloudTests(unittest.TestCase):
             config=tiledb.cloud.Config().dict(),
             mode=Mode.BATCH,
         )
-        print("[test_cloud@run_small_cloud_test] vs.ingest() done")
 
         queries = np.array([data[1]], dtype=np.float32)
 
-        print(
-            "[test_cloud@run_small_cloud_test] vs.query() mode = None ----------------------------"
-        )
         result_d, result_i = index.query(queries, k=1)
-        print("[test_cloud@run_small_cloud_test] result_d", result_d)
-        print("[test_cloud@run_small_cloud_test] result_i", result_i)
         expected_result_i = [[1]]
         expected_result_d = [[0]]
         assert np.array_equal(
@@ -213,12 +203,7 @@ class CloudTests(unittest.TestCase):
             result_d, expected_result_d
         ), f"result_d: {result_d} != expected_result_d: {expected_result_d}"
 
-        print(
-            "[test_cloud@run_small_cloud_test] vs.query() mode = LOCAL ----------------------------"
-        )
         result_d, result_i = index.query(queries, k=1, mode=Mode.LOCAL)
-        print("[test_cloud@run_small_cloud_test] result_d", result_d)
-        print("[test_cloud@run_small_cloud_test] result_i", result_i)
         expected_result_i = [[1]]
         expected_result_d = [[0]]
         assert np.array_equal(
@@ -228,12 +213,7 @@ class CloudTests(unittest.TestCase):
             result_d, expected_result_d
         ), f"result_d: {result_d} != expected_result_d: {expected_result_d}"
 
-        print(
-            "[test_cloud@run_small_cloud_test] vs.query() mode = REALTIME ----------------------------"
-        )
         result_d, result_i = index.query(queries, k=1, mode=Mode.REALTIME)
-        print("[test_cloud@run_small_cloud_test] result_d", result_d)
-        print("[test_cloud@run_small_cloud_test] result_i", result_i)
         expected_result_i = [[1]]
         expected_result_d = [[0]]
         assert np.array_equal(

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -103,44 +103,45 @@ class CloudTests(unittest.TestCase):
                 assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
         # We now will test for invalid scenarios when setting the query() resources.
-        resources = {"cpu": "9", "memory": "12Gi", "gpu": 0}
-        # Cannot pass resource_class or resources to LOCAL mode or to no mode.
-        with self.assertRaises(TypeError):
-            index.query(
-                queries, k=k, nprobe=nprobe, mode=Mode.LOCAL, resource_class="large"
-            )
-        with self.assertRaises(TypeError):
-            index.query(
-                queries, k=k, nprobe=nprobe, mode=Mode.LOCAL, resources=resources
-            )
-        with self.assertRaises(TypeError):
-            index.query(queries, k=k, nprobe=nprobe, resource_class="large")
-        with self.assertRaises(TypeError):
-            index.query(queries, k=k, nprobe=nprobe, resources=resources)
-        # Cannot pass resources to REALTIME.
-        with self.assertRaises(TypeError):
-            index.query(
-                queries, k=k, nprobe=nprobe, mode=Mode.REALTIME, resources=resources
-            )
-        # Cannot pass both resource_class and resources.
-        with self.assertRaises(TypeError):
-            index.query(
-                queries,
-                k=k,
-                nprobe=nprobe,
-                mode=Mode.REALTIME,
-                resource_class="large",
-                resources=resources,
-            )
-        with self.assertRaises(TypeError):
-            index.query(
-                queries,
-                k=k,
-                nprobe=nprobe,
-                mode=Mode.BATCH,
-                resource_class="large",
-                resources=resources,
-            )
+        if index_type == "IVF_FLAT":
+            resources = {"cpu": "9", "memory": "12Gi", "gpu": 0}
+            # Cannot pass resource_class or resources to LOCAL mode or to no mode.
+            with self.assertRaises(TypeError):
+                index.query(
+                    queries, k=k, nprobe=nprobe, mode=Mode.LOCAL, resource_class="large"
+                )
+            with self.assertRaises(TypeError):
+                index.query(
+                    queries, k=k, nprobe=nprobe, mode=Mode.LOCAL, resources=resources
+                )
+            with self.assertRaises(TypeError):
+                index.query(queries, k=k, nprobe=nprobe, resource_class="large")
+            with self.assertRaises(TypeError):
+                index.query(queries, k=k, nprobe=nprobe, resources=resources)
+            # Cannot pass resources to REALTIME.
+            with self.assertRaises(TypeError):
+                index.query(
+                    queries, k=k, nprobe=nprobe, mode=Mode.REALTIME, resources=resources
+                )
+            # Cannot pass both resource_class and resources.
+            with self.assertRaises(TypeError):
+                index.query(
+                    queries,
+                    k=k,
+                    nprobe=nprobe,
+                    mode=Mode.REALTIME,
+                    resource_class="large",
+                    resources=resources,
+                )
+            with self.assertRaises(TypeError):
+                index.query(
+                    queries,
+                    k=k,
+                    nprobe=nprobe,
+                    mode=Mode.BATCH,
+                    resource_class="large",
+                    resources=resources,
+                )
 
         # Test delete and consolidate_updates.
         index = index_class(

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -92,17 +92,15 @@ class CloudTests(unittest.TestCase):
         # Throws if we try to query locally.
         with self.assertRaises(ValueError):
             index.query(queries, k=k, nprobe=nprobe)
-        # Succeeeds if we try query locally with a taskgraph.
-        for driver_mode in [None, Mode.LOCAL, Mode.REALTIME]:
-            _, result_i = index.query(
-                queries=queries,
-                k=k,
-                nprobe=nprobe,
-                mode=mode,
-                driver_mode=driver_mode,
-                num_partitions=2,
-            )
-            assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
+        # Succeeeds if we try query with a taskgraph.
+        _, result_i = index.query(
+            queries=queries,
+            k=k,
+            nprobe=nprobe,
+            driver_mode=Mode.REALTIME,
+            num_partitions=2,
+        )
+        assert accuracy(result_i, gt_i) > MINIMUM_ACCURACY
 
         # We now will test for invalid scenarios when setting the query() resources.
         resources = {"cpu": "9", "memory": "12Gi", "gpu": 0}

--- a/apis/python/test/test_cloud.py
+++ b/apis/python/test/test_cloud.py
@@ -71,7 +71,7 @@ class CloudTests(unittest.TestCase):
             uri=tiledb_index_uri,
             config=tiledb.cloud.Config().dict(),
         )
-        for driver_mode in [None, Mode.LOCAL, Mode.REALTIME]:
+        for driver_mode in [None, Mode.REALTIME]:
             for mode in [None, Mode.LOCAL, Mode.REALTIME]:
                 _, result_i = index.query(
                     queries=queries,


### PR DESCRIPTION
### What
Add an option to use a driver UDF which will spin up a cloud taskgraph. This is useful for both Vamana and Flat because you can now run queries in a TileDB cloud taskgraph. It is also useful for them (and IVF Flat) because if you use this mode you can access resources which you may not have local permissions to access.

Addresses SC-48813.

### Testing
* Adds new Vamana cloud tests
* Adds tests for the new `driver_mode`'s