### PR TITLE
Update `feature_vector_array_with_ids` to require `id()` accessor

### DIFF
--- a/src/include/concepts.h
+++ b/src/include/concepts.h
@@ -160,8 +160,9 @@ concept feature_vector_array = requires(D d, size_t n) {
 
 template <class D>
 concept feature_vector_array_with_ids =
-    feature_vector_array<D> && requires(D d) {
+    feature_vector_array<D> && requires(D d, size_t i) {
       { d.ids() };
+      { d.id(i) };
     };
 
 /**


### PR DESCRIPTION
### What
Update `feature_vector_array_with_ids` to require `id()` accessor so we can use it safely with template types.

### Testing
Everything builds b/c we were already implicitly relying on this.