### PR TITLE
Fix bug with `adjacency_row_index_uri()` array type being incorrect, remove `adjacency_row_index_type` from API

### DIFF
--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -362,9 +362,6 @@ void init_type_erased_module(py::module_& m) {
           py::arg("storage_version") = "")
       .def("feature_type_string", &IndexVamana::feature_type_string)
       .def("id_type_string", &IndexVamana::id_type_string)
-      .def(
-          "adjacency_row_index_type_string",
-          &IndexVamana::adjacency_row_index_type_string)
       .def("dimensions", &IndexVamana::dimensions)
       .def_static(
           "clear_history",

--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -163,7 +163,6 @@ def create(
     index = vspy.IndexVamana(
         feature_type=np.dtype(vector_type).name,
         id_type=np.dtype(np.uint64).name,
-        adjacency_row_index_type=np.dtype(np.uint64).name,
         dimensions=dimensions,
     )
     # TODO(paris): Run all of this with a single C++ call.

--- a/apis/python/test/test_type_erased_module.py
+++ b/apis/python/test/test_type_erased_module.py
@@ -278,9 +278,7 @@ def test_construct_IndexVamana():
     assert a.id_type_string() == "uint64"
     assert a.dimensions() == 0
 
-    a = vspy.IndexVamana(
-        feature_type="float32", id_type="int64", adjacency_row_index_type="uint64"
-    )
+    a = vspy.IndexVamana(feature_type="float32", id_type="int64")
     assert a.feature_type_string() == "float32"
     assert a.id_type_string() == "int64"
     assert a.dimensions() == 0

--- a/apis/python/test/test_type_erased_module.py
+++ b/apis/python/test/test_type_erased_module.py
@@ -266,21 +266,16 @@ def test_construct_IndexVamana():
     a = vspy.IndexVamana()
     assert a.feature_type_string() == "any"
     assert a.id_type_string() == "uint32"
-    assert a.adjacency_row_index_type_string() == "uint32"
     assert a.dimensions() == 0
 
     a = vspy.IndexVamana(feature_type="float32")
     assert a.feature_type_string() == "float32"
     assert a.id_type_string() == "uint32"
-    assert a.adjacency_row_index_type_string() == "uint32"
     assert a.dimensions() == 0
 
-    a = vspy.IndexVamana(
-        feature_type="uint8", id_type="uint64", adjacency_row_index_type="int64"
-    )
+    a = vspy.IndexVamana(feature_type="uint8", id_type="uint64")
     assert a.feature_type_string() == "uint8"
     assert a.id_type_string() == "uint64"
-    assert a.adjacency_row_index_type_string() == "int64"
     assert a.dimensions() == 0
 
     a = vspy.IndexVamana(
@@ -288,7 +283,6 @@ def test_construct_IndexVamana():
     )
     assert a.feature_type_string() == "float32"
     assert a.id_type_string() == "int64"
-    assert a.adjacency_row_index_type_string() == "uint64"
     assert a.dimensions() == 0
 
 
@@ -299,13 +293,11 @@ def test_construct_IndexVamana_with_empty_vector(tmp_path):
     dimensions = 128
     feature_type = "float32"
     id_type = "uint64"
-    adjacency_row_index_type = "uint64"
 
     # First create an empty index.
     a = vspy.IndexVamana(
         feature_type=feature_type,
         id_type=id_type,
-        adjacency_row_index_type=adjacency_row_index_type,
         dimensions=dimensions,
     )
     empty_vector = vspy.FeatureVectorArray(dimensions, 0, feature_type, id_type)
@@ -335,9 +327,7 @@ def test_inplace_build_query_IndexVamana():
     opt_l = 100
     k_nn = 10
 
-    a = vspy.IndexVamana(
-        id_type="uint32", adjacency_row_index_type="uint32", feature_type="float32"
-    )
+    a = vspy.IndexVamana(id_type="uint32", feature_type="float32")
 
     training_set = vspy.FeatureVectorArray(ctx, siftsmall_inputs_uri)
     assert training_set.feature_type_string() == "float32"

--- a/src/include/index/index_metadata.h
+++ b/src/include/index/index_metadata.h
@@ -33,7 +33,7 @@
  *  "base_sizes",            // (json) list
  *  "dataset_type",          // "vector_search"
  *  "dtype",                 // "float32", etc (Python dtype names)
- *  "index_type",            // "FLAT", "IVF_FLAT", "VAMANA"
+ *  "index_type",            // "FLAT", "IVF_FLAT", "VAMANA", "IVF_PQ"
  *  "ingestion_timestamps",  // (json) list
  *  "storage_version",       // "0.3"
  *  "temp_size",             // TILEDB_INT64 or TILEDB_FLOAT64

--- a/src/include/index/vamana_group.h
+++ b/src/include/index/vamana_group.h
@@ -243,12 +243,12 @@ class vamana_index_group : public base_index_group<index_type> {
      * @todo Make this table-driven
      *************************************************************************/
     metadata_.adjacency_scores_datatype_ =
-        type_to_tiledb_v<typename index_type::score_type>;
+        type_to_tiledb_v<typename index_type::adjacency_scores_type>;
     metadata_.adjacency_row_index_datatype_ =
         type_to_tiledb_v<typename index_type::adjacency_row_index_type>;
 
     metadata_.adjacency_scores_type_str_ =
-        type_to_string_v<typename index_type::score_type>;
+        type_to_string_v<typename index_type::adjacency_scores_type>;
     metadata_.adjacency_row_index_type_str_ =
         type_to_string_v<typename index_type::adjacency_row_index_type>;
 
@@ -285,7 +285,7 @@ class vamana_index_group : public base_index_group<index_type> {
     tiledb_helpers::add_to_group(
         write_group, this->ids_uri(), this->ids_array_name());
 
-    create_empty_for_vector<typename index_type::score_type>(
+    create_empty_for_vector<typename index_type::adjacency_scores_type>(
         cached_ctx_,
         adjacency_scores_uri(),
         default_domain,
@@ -303,7 +303,7 @@ class vamana_index_group : public base_index_group<index_type> {
     tiledb_helpers::add_to_group(
         write_group, adjacency_ids_uri(), adjacency_ids_array_name());
 
-    create_empty_for_vector<typename index_type::id_type>(
+    create_empty_for_vector<typename index_type::adjacency_row_index_type>(
         cached_ctx_,
         adjacency_row_index_uri(),
         default_domain,

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -98,17 +98,22 @@ auto medoid(auto&& P, Distance distance = Distance{}) {
 }
 
 /**
- * @brief Index class for vamana search
- * @tparam feature_type Type of the elements in the feature vectors
- * @tparam id_type Type of the ids of the feature vectors
+ * @brief The Vamana index.
+ *
+ * @tparam FeatureType Type of the elements in the feature vectors.
+ * @tparam IdType Type of the ids of the feature vectors.
+ * @tparam AdjacencyRowIndexType Types of the indexes used in the graph.
  */
-template <class FeatureType, class IdType, class IndexType = uint64_t>
+template <
+    class FeatureType,
+    class IdType,
+    class AdjacencyRowIndexType = uint64_t>
 class vamana_index {
  public:
   using feature_type = FeatureType;
   using id_type = IdType;
-  using adjacency_row_index_type = IndexType;
-  using score_type = float;
+  using adjacency_row_index_type = AdjacencyRowIndexType;
+  using adjacency_scores_type = float;
 
   using group_type = vamana_index_group<vamana_index>;
   using metadata_type = vamana_index_metadata;
@@ -136,7 +141,7 @@ class vamana_index {
   uint64_t num_edges_{0};
 
   /** The graph representing the index over `feature_vectors_` */
-  ::detail::graph::adj_list<score_type, id_type> graph_;
+  ::detail::graph::adj_list<adjacency_scores_type, id_type> graph_;
 
   /*
    * The medoid of the feature vectors -- the vector in the set that is closest
@@ -250,7 +255,7 @@ class vamana_index {
      ****************************************************************************/
     graph_ = ::detail::graph::adj_list<feature_type, id_type>(num_vectors_);
 
-    auto adj_scores = read_vector<score_type>(
+    auto adj_scores = read_vector<adjacency_scores_type>(
         group_->cached_ctx(),
         group_->adjacency_scores_uri(),
         0,
@@ -467,7 +472,7 @@ class vamana_index {
 
     auto top_k = ColMajorMatrix<id_type>(k_nn, ::num_vectors(queries));
     auto top_k_scores =
-        ColMajorMatrix<score_type>(k_nn, ::num_vectors(queries));
+        ColMajorMatrix<adjacency_scores_type>(k_nn, ::num_vectors(queries));
 
     for (size_t i = 0; i < num_vectors(queries); ++i) {
       auto&& [tk_scores, tk, V] = ::best_first_O2(
@@ -494,7 +499,7 @@ class vamana_index {
 
     auto top_k = ColMajorMatrix<id_type>(k_nn, ::num_vectors(queries));
     auto top_k_scores =
-        ColMajorMatrix<score_type>(k_nn, ::num_vectors(queries));
+        ColMajorMatrix<adjacency_scores_type>(k_nn, ::num_vectors(queries));
 
     for (size_t i = 0; i < num_vectors(queries); ++i) {
       auto&& [tk_scores, tk, V] = ::best_first_O3(
@@ -521,7 +526,7 @@ class vamana_index {
 
     auto top_k = ColMajorMatrix<id_type>(k_nn, ::num_vectors(queries));
     auto top_k_scores =
-        ColMajorMatrix<score_type>(k_nn, ::num_vectors(queries));
+        ColMajorMatrix<adjacency_scores_type>(k_nn, ::num_vectors(queries));
 
     for (size_t i = 0; i < num_vectors(queries); ++i) {
       auto&& [tk_scores, tk, V] = ::best_first_O4(
@@ -548,7 +553,7 @@ class vamana_index {
 
     auto top_k = ColMajorMatrix<id_type>(k_nn, ::num_vectors(queries));
     auto top_k_scores =
-        ColMajorMatrix<score_type>(k_nn, ::num_vectors(queries));
+        ColMajorMatrix<adjacency_scores_type>(k_nn, ::num_vectors(queries));
 
     for (size_t i = 0; i < num_vectors(queries); ++i) {
       auto&& [tk_scores, tk, V] = ::best_first_O5(
@@ -588,7 +593,8 @@ class vamana_index {
     // L = std::min<size_t>(L, l_build_);
 
     auto top_k = ColMajorMatrix<id_type>(k, ::num_vectors(query_set));
-    auto top_k_scores = ColMajorMatrix<score_type>(k, ::num_vectors(query_set));
+    auto top_k_scores =
+        ColMajorMatrix<adjacency_scores_type>(k, ::num_vectors(query_set));
 
 #if 0
     // Parallelized implementation -- we stay single-threaded for now
@@ -768,7 +774,7 @@ class vamana_index {
         false,
         temporal_policy_);
 
-    auto adj_scores = Vector<score_type>(graph_.num_edges());
+    auto adj_scores = Vector<adjacency_scores_type>(graph_.num_edges());
     auto adj_ids = Vector<id_type>(graph_.num_edges());
     auto adj_index =
         Vector<adjacency_row_index_type>(graph_.num_vertices() + 1);

--- a/src/include/index/vamana_metadata.h
+++ b/src/include/index/vamana_metadata.h
@@ -117,10 +117,6 @@ class vamana_index_metadata
       {"alpha_min", &alpha_min_, TILEDB_FLOAT32, false},
       {"alpha_max", &alpha_max_, TILEDB_FLOAT32, false},
       {"medoid", &medoid_, TILEDB_UINT64, false},
-      {"adjacency_row_index_datatype",
-       &adjacency_row_index_datatype_,
-       TILEDB_UINT32,
-       false},
   };
 
   void clear_history_impl(uint64_t timestamp) {

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -123,9 +123,7 @@ TEST_CASE("init constructor", "[api_vamana_index]") {
 
   SECTION("uint8 uint64 uint64") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "uint8"},
-         {"id_type", "uint64"},
-         {"adjacency_row_index_type", "uint64"}}));
+        {{"feature_type", "uint8"}, {"id_type", "uint64"}}));
     CHECK(a.feature_type() == TILEDB_UINT8);
     CHECK(a.id_type() == TILEDB_UINT64);
   }
@@ -479,7 +477,7 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   using feature_type_type = uint8_t;
   using id_type_type = uint32_t;
-  using adjacency_row_index_type_type = uint32_t;
+  using adjacency_row_index_type_type = uint64_t;
   auto feature_type = "uint8";
   auto id_type = "uint32";
   size_t dimensions = 3;

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -40,122 +40,85 @@ TEST_CASE("init constructor", "[api_vamana_index]") {
     CHECK(a.feature_type_string() == datatype_to_string(TILEDB_ANY));
     CHECK(a.id_type() == TILEDB_UINT32);
     CHECK(a.id_type_string() == datatype_to_string(TILEDB_UINT32));
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
-    CHECK(
-        a.adjacency_row_index_type_string() ==
-        datatype_to_string(TILEDB_UINT32));
     CHECK(dimensions(a) == 0);
   }
 
   SECTION("float uint32 uint32") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "float32"},
-         {"id_type", "uint32"},
-         {"adjacency_row_index_type", "uint32"}}));
+        {{"feature_type", "float32"}, {"id_type", "uint32"}}));
     CHECK(a.feature_type() == TILEDB_FLOAT32);
     CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
     CHECK(dimensions(a) == 0);
   }
 
   SECTION("int8 uint32 uint32") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "int8"},
-         {"id_type", "uint32"},
-         {"adjacency_row_index_type", "uint32"}}));
+        {{"feature_type", "int8"}, {"id_type", "uint32"}}));
     CHECK(a.feature_type() == TILEDB_INT8);
     CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
   }
 
   SECTION("uint8 uint32 uint32") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "uint8"},
-         {"id_type", "uint32"},
-         {"adjacency_row_index_type", "uint32"}}));
+        {{"feature_type", "uint8"}, {"id_type", "uint32"}}));
     CHECK(a.feature_type() == TILEDB_UINT8);
     CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
   }
 
   SECTION("float uint64 uint32") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "float32"},
-         {"id_type", "uint64"},
-         {"adjacency_row_index_type", "uint32"}}));
+        {{"feature_type", "float32"}, {"id_type", "uint64"}}));
     CHECK(a.feature_type() == TILEDB_FLOAT32);
     CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
   }
 
   SECTION("float uint32 uint64") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "float32"},
-         {"id_type", "uint32"},
-         {"adjacency_row_index_type", "uint64"}}));
+        {{"feature_type", "float32"}, {"id_type", "uint32"}}));
     CHECK(a.feature_type() == TILEDB_FLOAT32);
     CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
   }
 
   SECTION("int8 uint64 uint32") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "int8"},
-         {"id_type", "uint64"},
-         {"adjacency_row_index_type", "uint32"}}));
+        {{"feature_type", "int8"}, {"id_type", "uint64"}}));
     CHECK(a.feature_type() == TILEDB_INT8);
     CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
   }
 
   SECTION("uint8 uint64 uint32") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "uint8"},
-         {"id_type", "uint64"},
-         {"adjacency_row_index_type", "uint32"}}));
+        {{"feature_type", "uint8"}, {"id_type", "uint64"}}));
     CHECK(a.feature_type() == TILEDB_UINT8);
     CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
   }
 
   SECTION("int8 uint32 uint64") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "int8"},
-         {"id_type", "uint32"},
-         {"adjacency_row_index_type", "uint64"}}));
+        {{"feature_type", "int8"}, {"id_type", "uint32"}}));
     CHECK(a.feature_type() == TILEDB_INT8);
     CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
   }
 
   SECTION("uint8 uint32 uint64") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "uint8"},
-         {"id_type", "uint32"},
-         {"adjacency_row_index_type", "uint64"}}));
+        {{"feature_type", "uint8"}, {"id_type", "uint32"}}));
     CHECK(a.feature_type() == TILEDB_UINT8);
     CHECK(a.id_type() == TILEDB_UINT32);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
   }
 
   SECTION("float uint64 uint64") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "float32"},
-         {"id_type", "uint64"},
-         {"adjacency_row_index_type", "uint64"}}));
+        {{"feature_type", "float32"}, {"id_type", "uint64"}}));
     CHECK(a.feature_type() == TILEDB_FLOAT32);
     CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
   }
 
   SECTION("int8 uint64 uint64") {
     auto a = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", "int8"},
-         {"id_type", "uint64"},
-         {"adjacency_row_index_type", "uint64"}}));
+        {{"feature_type", "int8"}, {"id_type", "uint64"}}));
     CHECK(a.feature_type() == TILEDB_INT8);
     CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
   }
 
   SECTION("uint8 uint64 uint64") {
@@ -165,17 +128,14 @@ TEST_CASE("init constructor", "[api_vamana_index]") {
          {"adjacency_row_index_type", "uint64"}}));
     CHECK(a.feature_type() == TILEDB_UINT8);
     CHECK(a.id_type() == TILEDB_UINT64);
-    CHECK(a.adjacency_row_index_type() == TILEDB_UINT64);
   }
 }
 
 TEST_CASE("create empty index and then train and query", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   using feature_type_type = uint8_t;
-  using id_type_type = uint32_t;
   auto feature_type = "uint8";
   auto id_type = "uint32";
-  auto adjacency_row_index_type = "uint32";
   size_t dimensions = 3;
 
   std::string index_uri =
@@ -187,9 +147,7 @@ TEST_CASE("create empty index and then train and query", "[api_vamana_index]") {
 
   {
     auto index = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", feature_type},
-         {"id_type", id_type},
-         {"adjacency_row_index_type", adjacency_row_index_type}}));
+        {{"feature_type", feature_type}, {"id_type", id_type}}));
 
     size_t num_vectors = 0;
     auto empty_training_vector_array =
@@ -200,7 +158,6 @@ TEST_CASE("create empty index and then train and query", "[api_vamana_index]") {
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
   }
 
   {
@@ -208,7 +165,6 @@ TEST_CASE("create empty index and then train and query", "[api_vamana_index]") {
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto training = ColMajorMatrix<feature_type_type>{
         {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
@@ -219,7 +175,6 @@ TEST_CASE("create empty index and then train and query", "[api_vamana_index]") {
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
         {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
@@ -247,7 +202,6 @@ TEST_CASE(
   using id_type_type = uint32_t;
   auto feature_type = "uint8";
   auto id_type = "uint32";
-  auto adjacency_row_index_type = "uint32";
   size_t dimensions = 3;
 
   std::string index_uri =
@@ -259,9 +213,7 @@ TEST_CASE(
 
   {
     auto index = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", feature_type},
-         {"id_type", id_type},
-         {"adjacency_row_index_type", adjacency_row_index_type}}));
+        {{"feature_type", feature_type}, {"id_type", id_type}}));
 
     size_t num_vectors = 0;
     auto empty_training_vector_array =
@@ -272,7 +224,6 @@ TEST_CASE(
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
   }
 
   {
@@ -280,7 +231,6 @@ TEST_CASE(
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto training = ColMajorMatrixWithIds<feature_type_type, id_type_type>{
         {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}, {10, 11, 12, 13}};
@@ -292,7 +242,6 @@ TEST_CASE(
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
         {8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
@@ -318,7 +267,6 @@ TEST_CASE(
   size_t k_nn = 10;
   auto feature_type = "float32";
   auto id_type = "uint32";
-  auto adjacency_row_index_type = "uint32";
 
   std::string index_uri =
       (std::filesystem::temp_directory_path() / "api_vamana_index").string();
@@ -329,9 +277,7 @@ TEST_CASE(
 
   {
     auto index = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", feature_type},
-         {"id_type", id_type},
-         {"adjacency_row_index_type", adjacency_row_index_type}}));
+        {{"feature_type", feature_type}, {"id_type", id_type}}));
 
     size_t num_vectors = 0;
     auto empty_training_vector_array = FeatureVectorArray(
@@ -342,7 +288,6 @@ TEST_CASE(
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
   }
 
   {
@@ -352,7 +297,6 @@ TEST_CASE(
     CHECK(index.l_build() == index.b_backtrack());
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
     index.train(training_set);
@@ -361,7 +305,6 @@ TEST_CASE(
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
     auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
@@ -374,26 +317,24 @@ TEST_CASE(
 }
 
 TEST_CASE("infer feature type", "[api_vamana_index]") {
-  auto a = IndexVamana(std::make_optional<IndexOptions>(
-      {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
+  auto a =
+      IndexVamana(std::make_optional<IndexOptions>({{"id_type", "uint32"}}));
   auto ctx = tiledb::Context{};
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   a.train(training_set);
   CHECK(a.feature_type() == TILEDB_FLOAT32);
   CHECK(a.id_type() == TILEDB_UINT32);
-  CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
 }
 
 TEST_CASE("infer dimension", "[api_vamana_index]") {
-  auto a = IndexVamana(std::make_optional<IndexOptions>(
-      {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
+  auto a =
+      IndexVamana(std::make_optional<IndexOptions>({{"id_type", "uint32"}}));
   auto ctx = tiledb::Context{};
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   CHECK(dimensions(a) == 0);
   a.train(training_set);
   CHECK(a.feature_type() == TILEDB_FLOAT32);
   CHECK(a.id_type() == TILEDB_UINT32);
-  CHECK(a.adjacency_row_index_type() == TILEDB_UINT32);
   CHECK(dimensions(a) == 128);
 }
 
@@ -406,10 +347,10 @@ TEST_CASE("api_vamana_index write and read", "[api_vamana_index]") {
     vfs.remove_dir(api_vamana_index_uri);
   }
 
-  auto a = IndexVamana(std::make_optional<IndexOptions>(
-      {{"feature_type", "float32"},
-       {"id_type", "uint32"},
-       {"adjacency_row_index_type", "uint32"}}));
+  auto a = IndexVamana(std::make_optional<IndexOptions>({
+      {"feature_type", "float32"},
+      {"id_type", "uint32"},
+  }));
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   a.train(training_set);
   a.add(training_set);
@@ -420,7 +361,6 @@ TEST_CASE("api_vamana_index write and read", "[api_vamana_index]") {
   CHECK(dimensions(a) == dimensions(b));
   CHECK(a.feature_type() == b.feature_type());
   CHECK(a.id_type() == b.id_type());
-  CHECK(a.adjacency_row_index_type() == b.adjacency_row_index_type());
 }
 
 TEST_CASE("build index and query", "[api_vamana_index]") {
@@ -428,8 +368,8 @@ TEST_CASE("build index and query", "[api_vamana_index]") {
   size_t k_nn = 10;
   size_t nprobe = GENERATE(8, 32);
 
-  auto a = IndexVamana(std::make_optional<IndexOptions>(
-      {{"id_type", "uint32"}, {"adjacency_row_index_type", "uint32"}}));
+  auto a =
+      IndexVamana(std::make_optional<IndexOptions>({{"id_type", "uint32"}}));
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
   auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
@@ -455,10 +395,10 @@ TEST_CASE("read index and query", "[api_vamana_index]") {
     vfs.remove_dir(api_vamana_index_uri);
   }
 
-  auto a = IndexVamana(std::make_optional<IndexOptions>(
-      {{"feature_type", "float32"},
-       {"id_type", "uint32"},
-       {"adjacency_row_index_type", "uint32"}}));
+  auto a = IndexVamana(std::make_optional<IndexOptions>({
+      {"feature_type", "float32"},
+      {"id_type", "uint32"},
+  }));
 
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   a.train(training_set);
@@ -488,7 +428,6 @@ TEST_CASE("storage_version", "[api_vamana_index]") {
   using id_type_type = uint32_t;
   auto feature_type = "uint8";
   auto id_type = "uint32";
-  auto adjacency_row_index_type = "uint32";
   size_t dimensions = 3;
 
   std::string index_uri =
@@ -501,9 +440,7 @@ TEST_CASE("storage_version", "[api_vamana_index]") {
   {
     // First we create the index with a storage_version.
     auto index = IndexVamana(std::make_optional<IndexOptions>(
-        {{"feature_type", feature_type},
-         {"id_type", id_type},
-         {"adjacency_row_index_type", adjacency_row_index_type}}));
+        {{"feature_type", feature_type}, {"id_type", id_type}}));
 
     size_t num_vectors = 0;
     auto empty_training_vector_array =
@@ -514,7 +451,6 @@ TEST_CASE("storage_version", "[api_vamana_index]") {
 
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
   }
 
   {
@@ -546,7 +482,6 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
   using adjacency_row_index_type_type = uint32_t;
   auto feature_type = "uint8";
   auto id_type = "uint32";
-  auto adjacency_row_index_type = "uint32";
   size_t dimensions = 3;
   size_t l_build = 100;
   size_t r_max_degree = 64;
@@ -565,7 +500,6 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     auto index = IndexVamana(std::make_optional<IndexOptions>(
         {{"feature_type", feature_type},
          {"id_type", id_type},
-         {"adjacency_row_index_type", adjacency_row_index_type},
          {"l_build", std::to_string(l_build)},
          {"r_max_degree", std::to_string(r_max_degree)},
          {"b_backtrack", std::to_string(b_backtrack)}}));
@@ -583,7 +517,6 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto typed_index = vamana_index<
         feature_type_type,
@@ -620,7 +553,6 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto training = ColMajorMatrixWithIds<feature_type_type, id_type_type>{
         {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}, {1, 2, 3, 4}};
@@ -638,7 +570,6 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
         {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
@@ -687,7 +618,6 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto training = ColMajorMatrixWithIds<feature_type_type, id_type_type>{
         {{11, 11, 11}, {22, 22, 22}, {33, 33, 33}, {44, 44, 44}, {55, 55, 55}},
@@ -704,7 +634,6 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(index.temporal_policy().timestamp_end() == 100);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
         {11, 11, 11}, {22, 22, 22}, {33, 33, 33}, {44, 44, 44}, {55, 55, 55}};
@@ -762,7 +691,6 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
         {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
@@ -822,7 +750,6 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{{1, 1, 1}};
     auto query_vector_array = FeatureVectorArray(queries);
@@ -887,7 +814,6 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(index.b_backtrack() == b_backtrack);
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
-    CHECK(index.adjacency_row_index_type_string() == adjacency_row_index_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
         {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};

--- a/src/include/test/unit_vamana_group.cc
+++ b/src/include/test/unit_vamana_group.cc
@@ -37,7 +37,7 @@ struct dummy_index {
   using feature_type = float;
   using id_type = int;
   using adjacency_row_index_type = int;
-  using score_type = float;
+  using adjacency_scores_type = float;
 
   using group_type = vamana_index_group<dummy_index>;
   using metadata_type = vamana_index_metadata;


### PR DESCRIPTION
### What
Two main changes:
1. Fix a bug where when creating adjacency_row_index_uri()` we would use `typename index_type::id_type` instead of `typename index_type::adjacency_row_index_type`.
2. Update the C++ Vamana API and the Python code to not expose `adjacency_row_index_type` as configurable, and instead hard-code to `uint64_t`. This is the same as IVF Flat which hard-codes the `"INDEX_ARRAY_NAME": "partition_indexes"` type, so seems fine. And also simplifies the API a bit which is nice.

### Testing
Existing tests pass.