### PR TITLE
Initial scaling strategy

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -2113,7 +2113,6 @@ def ingest(
                 ),
                 namespace=namespace,
             )
-            cpu_scale_factor = max(1, int(DEFAULT_PARTITION_BYTE_SIZE / size_in_bytes))
             threads = 16
 
             if acn:
@@ -2156,7 +2155,12 @@ def ingest(
             max_input_size,
             input_size,
         ):
-            cpu = str(min(max(min_resource_cpu, threads * input_size / max_input_size), max_resource_cpu))
+            cpu = str(
+                max(
+                    min(max_resource_cpu, threads * input_size / max_input_size),
+                    min_resource_cpu,
+                )
+            )
             ram = (
                 str(
                     max(
@@ -2174,10 +2178,14 @@ def ingest(
         # We can't set as default in the function due to the use of `str(threads)`
         # For consistency we then apply all defaults for resources here.
         if ingest_resources is None:
-            ingest_resources = scale_resources(2, 16, 2, 16, DEFAULT_PARTITION_BYTE_SIZE, size_in_bytes)
+            ingest_resources = scale_resources(
+                2, 16, 2, 16, DEFAULT_PARTITION_BYTE_SIZE, size_in_bytes
+            )
 
         if consolidate_partition_resources is None:
-            consolidate_partition_resources = scale_resources(2, 16, 2, 16, DEFAULT_PARTITION_BYTE_SIZE, size_in_bytes)
+            consolidate_partition_resources = scale_resources(
+                2, 16, 2, 16, DEFAULT_PARTITION_BYTE_SIZE, size_in_bytes
+            )
 
         if copy_centroids_resources is None:
             copy_centroids_resources = {"cpu": "1", "memory": "2Gi"}
@@ -2189,8 +2197,14 @@ def ingest(
             }
 
         if kmeans_resources is None:
-            kmeans_resources = scale_resources(4, 32, 2, 8, DEFAULT_KMEANS_BYTES_PER_SAMPLE, training_sample_size_in_bytes)
-
+            kmeans_resources = scale_resources(
+                4,
+                32,
+                2,
+                8,
+                DEFAULT_KMEANS_BYTES_PER_SAMPLE,
+                training_sample_size_in_bytes,
+            )
 
         if compute_new_centroids_resources is None:
             compute_new_centroids_resources = {

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -2212,7 +2212,7 @@ def ingest(
         if random_sample_resources is None:
             random_sample_resources = {
                 "cpu": "2",
-                "memory": get_scaled_ram_gi_kmeans("6Gi"),
+                "memory": "6Gi",
             }
 
         if kmeans_resources is None:
@@ -2221,13 +2221,13 @@ def ingest(
         if compute_new_centroids_resources is None:
             compute_new_centroids_resources = {
                 "cpu": "1",
-                "memory": get_scaled_ram_gi_kmeans("8Gi"),
+                "memory": "8Gi",
             }
 
         if assign_points_and_partial_new_centroids_resources is None:
             assign_points_and_partial_new_centroids_resources = {
                 "cpu": str(threads),
-                "memory": get_scaled_ram_gi_kmeans("12Gi"),
+                "memory": "12Gi",
             }
 
         if write_centroids_resources is None:

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -303,7 +303,7 @@ def ingest(
     VECTORS_PER_SAMPLE_WORK_ITEM = 1000000
     MAX_TASKS_PER_STAGE = 100
     CENTRALISED_KMEANS_MAX_SAMPLE_SIZE = 1000000
-    DEFAULT_KMEANS_BYTES_PER_SAMPLE = 128000000  # ~ 128MB 
+    DEFAULT_KMEANS_BYTES_PER_SAMPLE = 128000000  # ~ 128MB
     DEFAULT_IMG_NAME = "3.9-vectorsearch"
     MAX_INT32 = 2**31 - 1
 
@@ -2099,7 +2099,9 @@ def ingest(
         logger.debug("Size: %d", size)
         this_batch_size_bytes = size * dimensions * np.dtype(vector_type).itemsize
         logger.debug("Batch size in bytes: %d", this_batch_size_bytes)
-        kmeans_batch_size_bytes = training_sample_size * dimensions * np.dtype(vector_type).itemsize
+        kmeans_batch_size_bytes = (
+            training_sample_size * dimensions * np.dtype(vector_type).itemsize
+        )
         logger.debug("Kmeans batch size in bytes: %d", kmeans_batch_size_bytes)
         logger.debug("Training sample size: %d", training_sample_size)
         if mode == Mode.BATCH:
@@ -2162,7 +2164,7 @@ def ingest(
             return int(task_memory_overhead[overhead]) * this_batch_size_bytes
 
         kmeans_requirement_bytes = kmeans_batch_size_bytes * 250
-        
+
         # Function to convert ram_requirement_bytes to ram string (approximates to nearest multiple of 2)
         def get_scaled_ram_gi(base):
             return (
@@ -2176,7 +2178,7 @@ def ingest(
                 )
                 + "Gi"
             )
-        
+
         def get_scaled_ram_gi_kmeans(base):
             return (
                 str(
@@ -2189,7 +2191,7 @@ def ingest(
                 )
                 + "Gi"
             )
-    
+
         # We can't set as default in the function due to the use of `str(threads)`
         # For consistency we then apply all defaults for resources here.
         if ingest_resources is None:
@@ -2208,7 +2210,10 @@ def ingest(
             copy_centroids_resources = {"cpu": "1", "memory": "2Gi"}
 
         if random_sample_resources is None:
-            random_sample_resources = {"cpu": "2", "memory": get_scaled_ram_gi_kmeans("6Gi")}
+            random_sample_resources = {
+                "cpu": "2",
+                "memory": get_scaled_ram_gi_kmeans("6Gi"),
+            }
 
         if kmeans_resources is None:
             kmeans_resources = {"cpu": "8", "memory": get_scaled_ram_gi_kmeans("32Gi")}
@@ -2230,19 +2235,6 @@ def ingest(
 
         if partial_index_resources is None:
             partial_index_resources = {"cpu": "1", "memory": "2Gi"}
-
-        # log all the resources
-        logger.debug(f"ingest_resources: {ingest_resources}")
-        logger.debug(f"consolidate_partition_resources: {consolidate_partition_resources}")
-        logger.debug(f"copy_centroids_resources: {copy_centroids_resources}")
-        logger.debug(f"random_sample_resources: {random_sample_resources}")
-        logger.debug(f"kmeans_resources: {kmeans_resources}")
-        logger.debug(f"compute_new_centroids_resources: {compute_new_centroids_resources}")
-        logger.debug(f"assign_points_and_partial_new_centroids_resources: {assign_points_and_partial_new_centroids_resources}")
-        logger.debug(f"write_centroids_resources: {write_centroids_resources}")
-        logger.debug(f"partial_index_resources: {partial_index_resources}")
-
-
 
         if index_type == "FLAT":
             ingest_node = submit(


### PR DESCRIPTION
Scaling resources linearly (with heuristic on using less cpu resources for smaller datasets - introduces at most 10 seconds on < 20mil vectors from initial tests - but could be from resource allocation.

Also scales partition size based on the baseline (20 mil vectors of 128 dimensions (int8)) keeping bytesize the same. Idea here was that we don't use less than int8 so there wouldn't be overhead from larger data types (that reduces total number of vectors)