### PR TITLE
Add Vamana backwards compatibility data generation and tests

### DIFF
--- a/apis/python/src/tiledb/vector_search/ivf_pq_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_pq_index.py
@@ -163,6 +163,11 @@ def create(
     """
     warnings.warn("The IVF PQ index is not yet supported, please use with caution.")
     validate_storage_version(storage_version)
+    # TODO(SC-49166): Support old storage versions with type-erased indexes.
+    if storage_version == "0.1" or storage_version == "0.2":
+        raise ValueError(
+            f"Storage version {storage_version} is not supported for IVFPQIndex. IVFPQIndex requires storage version 0.3 or higher."
+        )
     ctx = vspy.Ctx(config)
     if num_subspaces <= 0:
         raise ValueError(

--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -159,6 +159,11 @@ def create(
         If not provided, use the latest stable storage version.
     """
     validate_storage_version(storage_version)
+    # TODO(SC-49166): Support old storage versions with type-erased indexes.
+    if storage_version == "0.1" or storage_version == "0.2":
+        raise ValueError(
+            f"Storage version {storage_version} is not supported for VamanaIndex. VamanaIndex requires storage version 0.3 or higher."
+        )
     ctx = vspy.Ctx(config)
     index = vspy.IndexVamana(
         feature_type=np.dtype(vector_type).name,

--- a/apis/python/test/test_backwards_compatibility.py
+++ b/apis/python/test/test_backwards_compatibility.py
@@ -3,6 +3,7 @@ from common import *
 from tiledb.vector_search.flat_index import FlatIndex
 from tiledb.vector_search.ivf_flat_index import IVFFlatIndex
 from tiledb.vector_search.utils import load_fvecs
+from tiledb.vector_search.vamana_index import VamanaIndex
 
 MINIMUM_ACCURACY = 0.85
 
@@ -60,6 +61,8 @@ def test_query_old_indices():
                 index = IVFFlatIndex(uri=index_uri)
             elif "flat" in index_name:
                 index = FlatIndex(uri=index_uri)
+            elif "vamana" in index_name:
+                index = VamanaIndex(uri=index_uri)
             else:
                 assert False, f"Unknown index name: {index_name}"
 

--- a/backwards-compatibility-data/generate_data.py
+++ b/backwards-compatibility-data/generate_data.py
@@ -66,7 +66,7 @@ def generate_indexes(version):
     queries = base[indices]
 
     # Generate each index and query to make sure it works before we write it.
-    index_types = ["FLAT", "IVF_FLAT"]
+    index_types = ["FLAT", "IVF_FLAT", "VAMANA"]
     data_types = ["float32", "uint8"]
     for index_type in index_types:
         for data_type in data_types:


### PR DESCRIPTION
### What
Add Vamana backwards compatibility data generation and tests.

### Testing
I generated data with `python generate_data.py 0.5.0`:
```
(TileDB-Vector-Search-3) ~/repo/TileDB-Vector-Search-4/backwards-compatibility-data python generate_data.py 0.5.0
false
(TileDB-Vector-Search-3) ~/repo/TileDB-Vector-Search-4/backwards-compatibility-data ls data
0.0.10    0.0.21    0.0.23    0.1.3     0.2.2     0.4.0     README.md
0.0.17    0.0.22    0.1.0     0.2.0     0.3.0     0.5.0
(TileDB-Vector-Search-3) ~/repo/TileDB-Vector-Search-4/backwards-compatibility-data 
```
And then I ran both python and C++ tests, and they both passed:
```
(TileDB-Vector-Search-3) ~/repo/TileDB-Vector-Search-4 pytest apis/python/test/test_backwards_compatibility.py -s

======================================= test session starts ========================================
platform darwin -- Python 3.9.18, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/parismorgan/repo/TileDB-Vector-Search-4
collected 1 item                                                                                   

apis/python/test/test_backwards_compatibility.py .

======================================== 1 passed in 1.56s =========================================
```