### PR TITLE
Pin mdspan version

### DIFF
--- a/src/cmake/mdspan.cmake
+++ b/src/cmake/mdspan.cmake
@@ -9,6 +9,6 @@ include(FetchContent)
 FetchContent_Declare(
         mdspan
         GIT_REPOSITORY https://github.com/kokkos/mdspan.git
-        GIT_TAG stable)
+        GIT_TAG 96b3985b291c2ed3e24f22302d5a372522655a2c)
 
 FetchContent_MakeAvailable(mdspan)


### PR DESCRIPTION
For `mdspan` we were depending on a local build of their [`stable`](https://github.com/kokkos/mdspan/commits/stable/) github tag which is under active development. [PR-337](https://github.com/kokkos/mdspan/pull/337) started breaking our unit tests.

Here we pin the version of `mdspan` to a commit tag before the breaking PR. I also tried pining using their latest release tag `mdspan-0.6.0` but this also fails with compilation problems on the vector search side. 