### PR TITLE
Pin numpy to fix Python CI failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "tiledb>=0.30.0",
     "typing-extensions", # for tiledb-cloud indirect, x-ref https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/428
     "scikit-learn",
+    "numpy<2.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This pins `numpy<2` as the new numpy release is causing Python CI failures