### PR TITLE
Fix type-erased indexes writing fragments at timestamp=0, thus fixing IVF PQ time travel

### DIFF
--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -957,10 +957,6 @@ def test_ingestion_with_updates_and_timetravel(tmp_path):
         assert ingestion_timestamps == [1]
         assert base_sizes == [size]
 
-        if index_type == "IVF_PQ":
-            # TODO(SC-48897): Fix time travelling for IVF_PQ and re-enable.
-            continue
-
         if index_type == "IVF_FLAT":
             assert index.partitions == partitions
 
@@ -1226,9 +1222,6 @@ def test_ingestion_with_additions_and_timetravel(tmp_path):
         )
         if index_type == "IVF_FLAT":
             assert index.partitions == partitions
-        if index_type == "IVF_PQ":
-            # TODO(SC-48897): Fix time travelling for IVF_PQ and re-enable.
-            continue
         _, result = index.query(queries, k=k, nprobe=partitions)
         assert accuracy(result, gt_i) == 1.0
 

--- a/src/include/index/ivf_pq_index.h
+++ b/src/include/index/ivf_pq_index.h
@@ -1040,6 +1040,15 @@ class ivf_pq_index {
       write_group.append_num_partitions(num_partitions_);
     }
 
+    // When creating from Python we initially call write_index() at timestamp 0.
+    // The goal here is just to create the arrays and save metadata. Return here
+    // so that we don't write the arrays, as if we write with timestamp=0 then
+    // TileDB Core will interpret this as the current timestamp instead, leading
+    // to array fragments created at the current time.
+    if (temporal_policy_.timestamp_end() == 0) {
+      return true;
+    }
+
     // flat_ivf_centroids_, cluster_centroids_, distance_tables_
     // pq_ivf_centroids_, partitioned_pq_vectors_, unpartitioned_pq_vectors_
 

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -757,6 +757,15 @@ class vamana_index {
       write_group.append_num_edges(graph_.num_edges());
     }
 
+    // When creating from Python we initially call write_index() at timestamp 0.
+    // The goal here is just to create the arrays and save metadata. Return here
+    // so that we don't write the arrays, as if we write with timestamp=0 then
+    // TileDB Core will interpret this as the current timestamp instead, leading
+    // to array fragments created at the current time.
+    if (temporal_policy_.timestamp_end() == 0) {
+      return true;
+    }
+
     write_matrix(
         ctx,
         feature_vectors_,


### PR DESCRIPTION
### What
When creating from Python we initially call `write_index()` at timestamp 0. The goal here is just to create the arrays and save metadata. But I did not know that when you create an array at timestamp 0, it will interpret 0 as a special flag meaning "use current timestamp". Thus for IVF PQ and Vamana, we could end up writing an array fragment at the current timestamp. This becomes an issue in unit tests when we want to first write at timestamp 0, and then write at timestamp X, where X is some test value like 99. We we did that, we ended up with `uncompressed_centroids` which had an empty fragment at a later timestamp than the fragment at timestamp 99, leading to issues querying:

<img width="1109" alt="Screenshot 2024-06-20 at 5 39 55 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/9279f820-0fbf-4650-a50a-2c42758e84b0">

The fix we make here is to not write the arrays if the timestamp is 0. With this change we now have this:

<img width="1098" alt="Screenshot 2024-06-20 at 5 46 01 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/fce403ff-21b3-411f-a905-86e61aa41dbc">

### Testing
* Exists tests pass.
* Adds a new C++ IVF PQ unit test which fails without this change.
* IVF PQ Python tests now pass which previously did not.