### PR TITLE
Update to TileDB Core 2.24.1

### DIFF
--- a/apis/python/requirements-py.txt
+++ b/apis/python/requirements-py.txt
@@ -1,4 +1,4 @@
 numpy==1.24.3
 tiledb-cloud==0.10.24
-tiledb==0.30.0
+tiledb==0.30.1
 scikit-learn==1.3.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 dependencies = [
     "tiledb-cloud>=0.11",
-    "tiledb>=0.30.0",
+    "tiledb>=0.30.1",
     "typing-extensions", # for tiledb-cloud indirect, x-ref https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/428
     "scikit-learn",
     "numpy<2.0.0",

--- a/src/cmake/Modules/FindTileDB_EP.cmake
+++ b/src/cmake/Modules/FindTileDB_EP.cmake
@@ -54,13 +54,13 @@ else()
     # Try to download prebuilt artifacts unless the user specifies to build from source
     if(DOWNLOAD_TILEDB_PREBUILT)
         fetch_prebuilt_tiledb(
-                VERSION 2.24.0
-                RELLIST_HASH SHA256=e5aa7e6d747bb956730e438d0b29c90096226d4a553c26c5cb9161680f1d489c
+                VERSION 2.24.1
+                RELLIST_HASH SHA256=76d4deebd42afd059729fac7f13b172e1187ab43b8e3d2404f0328a47221a231
         )
     else() # Build from source
         fetch_source_tiledb(
-                VERSION 2.24.0
-                RELLIST_HASH SHA256=e5aa7e6d747bb956730e438d0b29c90096226d4a553c26c5cb9161680f1d489c
+                VERSION 2.24.1
+                RELLIST_HASH SHA256=76d4deebd42afd059729fac7f13b172e1187ab43b8e3d2404f0328a47221a231
         )
     endif()
 


### PR DESCRIPTION
### What
Update to TileDB Core 2.24.1. Based on [this message](https://tiledb.slack.com/archives/C05R1S5AZGC/p1719911926999669).

### Testing
Tests pass.