### PR TITLE
Remove `apis/python/requirements-py.txt`

### DIFF
--- a/apis/python/requirements-py.txt
+++ b/apis/python/requirements-py.txt
@@ -1,4 +1,0 @@
-numpy==1.24.3
-tiledb-cloud==0.10.24
-tiledb==0.30.1
-scikit-learn==1.3.2


### PR DESCRIPTION
### What
It seems we do not use this, so removing. It was also not used in the PR that it was introduced in: https://github.com/TileDB-Inc/TileDB-Vector-Search/commit/bdf72cd54a273644841659ad1927b20fbd253794

### Testing
CI still passes.