### PR TITLE
Update `tile_size` calculations to be based on the array feature type

### DIFF
--- a/apis/python/src/tiledb/vector_search/flat_index.py
+++ b/apis/python/src/tiledb/vector_search/flat_index.py
@@ -185,7 +185,6 @@ def create(
     )
     with tiledb.scope_ctx(ctx_or_config=config):
         group = tiledb.Group(uri, "w")
-        tile_size = TILE_SIZE_BYTES / np.dtype(vector_type).itemsize / dimensions
         ids_array_name = storage_formats[storage_version]["IDS_ARRAY_NAME"]
         parts_array_name = storage_formats[storage_version]["PARTS_ARRAY_NAME"]
         updates_array_name = storage_formats[storage_version]["UPDATES_ARRAY_NAME"]
@@ -196,7 +195,7 @@ def create(
         ids_array_rows_dim = tiledb.Dim(
             name="rows",
             domain=(0, MAX_INT32),
-            tile=tile_size,
+            tile=int(TILE_SIZE_BYTES / np.dtype(np.uint64).itemsize / dimensions),
             dtype=np.dtype(np.int32),
         )
         ids_array_dom = tiledb.Domain(ids_array_rows_dim)
@@ -224,7 +223,7 @@ def create(
         parts_array_cols_dim = tiledb.Dim(
             name="cols",
             domain=(0, MAX_INT32),
-            tile=tile_size,
+            tile=int(TILE_SIZE_BYTES / np.dtype(vector_type).itemsize / dimensions),
             dtype=np.dtype(np.int32),
         )
         parts_array_dom = tiledb.Domain(parts_array_rows_dim, parts_array_cols_dim)

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -539,7 +539,6 @@ def create(
     )
     with tiledb.scope_ctx(ctx_or_config=config):
         group = tiledb.Group(uri, "w")
-        tile_size = int(TILE_SIZE_BYTES / np.dtype(vector_type).itemsize / dimensions)
         group.meta["partition_history"] = json.dumps([0])
         centroids_array_name = storage_formats[storage_version]["CENTROIDS_ARRAY_NAME"]
         index_array_name = storage_formats[storage_version]["INDEX_ARRAY_NAME"]
@@ -607,7 +606,7 @@ def create(
         ids_array_rows_dim = tiledb.Dim(
             name="rows",
             domain=(0, MAX_INT32),
-            tile=tile_size,
+            tile=int(TILE_SIZE_BYTES / np.dtype(np.uint64).itemsize / dimensions),
             dtype=np.dtype(np.int32),
         )
         ids_array_dom = tiledb.Domain(ids_array_rows_dim)
@@ -635,7 +634,7 @@ def create(
         parts_array_cols_dim = tiledb.Dim(
             name="cols",
             domain=(0, MAX_INT32),
-            tile=tile_size,
+            tile=int(TILE_SIZE_BYTES / np.dtype(vector_type).itemsize / dimensions),
             dtype=np.dtype(np.int32),
         )
         parts_array_dom = tiledb.Domain(parts_array_rows_dim, parts_array_cols_dim)

--- a/src/include/index/ivf_pq_group.h
+++ b/src/include/index/ivf_pq_group.h
@@ -245,8 +245,8 @@ class ivf_pq_group : public base_index_group<index_type> {
     }
     this->init_valid_array_names();
 
-    static const int32_t tile_size{
-        (int32_t)(tile_size_bytes / sizeof(typename index_type::feature_type) /
+    static const int32_t tile_size_ids{
+        (int32_t)(tile_size_bytes / sizeof(typename index_type::id_type) /
                   this->get_dimensions())};
     static const tiledb_filter_type_t default_compression{
         string_to_filter(storage_formats[version_]["default_attr_filters"])};
@@ -336,7 +336,7 @@ class ivf_pq_group : public base_index_group<index_type> {
         cached_ctx_,
         this->ids_uri(),
         default_domain,
-        tile_size,
+        tile_size_ids,
         default_compression);
     tiledb_helpers::add_to_group(
         write_group, this->ids_uri(), this->ids_array_name());

--- a/src/include/index/vamana_group.h
+++ b/src/include/index/vamana_group.h
@@ -198,9 +198,20 @@ class vamana_index_group : public base_index_group<index_type> {
     }
     this->init_valid_array_names();
 
-    static const int32_t tile_size{
-        (int32_t)(tile_size_bytes / sizeof(typename index_type::feature_type) /
-                  this->get_dimensions())};
+    static const int32_t tile_size{static_cast<int32_t>(
+        tile_size_bytes / sizeof(typename index_type::feature_type) /
+        this->get_dimensions())};
+    static const int32_t tile_size_ids{static_cast<int32_t>(
+        tile_size_bytes / sizeof(typename index_type::id_type) /
+        this->get_dimensions())};
+    static const int32_t tile_size_adjacency_row_index{static_cast<int32_t>(
+        tile_size_bytes /
+        sizeof(typename index_type::adjacency_row_index_type) /
+        this->get_dimensions())};
+    static const int32_t tile_size_adjacency_scores{static_cast<int32_t>(
+        tile_size_bytes / sizeof(typename index_type::adjacency_scores_type) /
+        this->get_dimensions())};
+
     static const tiledb_filter_type_t default_compression{
         string_to_filter(storage_formats[version_]["default_attr_filters"])};
 
@@ -270,7 +281,7 @@ class vamana_index_group : public base_index_group<index_type> {
         cached_ctx_,
         this->ids_uri(),
         default_domain,
-        tile_size,
+        tile_size_ids,
         default_compression);
     tiledb_helpers::add_to_group(
         write_group, this->ids_uri(), this->ids_array_name());
@@ -279,7 +290,7 @@ class vamana_index_group : public base_index_group<index_type> {
         cached_ctx_,
         adjacency_scores_uri(),
         default_domain,
-        tile_size,
+        tile_size_adjacency_scores,
         default_compression);
     tiledb_helpers::add_to_group(
         write_group, adjacency_scores_uri(), adjacency_scores_array_name());
@@ -288,7 +299,7 @@ class vamana_index_group : public base_index_group<index_type> {
         cached_ctx_,
         adjacency_ids_uri(),
         default_domain,
-        tile_size,
+        tile_size_ids,
         default_compression);
     tiledb_helpers::add_to_group(
         write_group, adjacency_ids_uri(), adjacency_ids_array_name());
@@ -297,7 +308,7 @@ class vamana_index_group : public base_index_group<index_type> {
         cached_ctx_,
         adjacency_row_index_uri(),
         default_domain,
-        tile_size,
+        tile_size_adjacency_row_index,
         default_compression);
     tiledb_helpers::add_to_group(
         write_group,


### PR DESCRIPTION
### What
Previously in FLAT and IVF FLAT indexes, we would set the IDs array `tile_size = TILE_SIZE_BYTES / np.dtype(vector_type).itemsize / dimensions`. This results in us having very large tile sizes if we are using `uint8` or `int8` feature vectors. To work around this, we change to calculate the tile for the IDs array (which is just a vector) based on the data type it stores, which today is hard-coded to `uint64`.

### Testing Python changes
I ran this code before and after making these changes:
```
def test_flat_index(tmp_path):
    uri = "/tmp/flat_index"
    if shutil.os.path.exists(uri):
        shutil.rmtree(uri)
    vector_type = np.dtype(np.uint8)
    index = flat_index.create(uri=uri, dimensions=3, vector_type=vector_type)

    update_vectors = np.empty([5], dtype=object)
    update_vectors[0] = np.array([0, 0, 0], dtype=vector_type)
    update_vectors[1] = np.array([1, 1, 1], dtype=vector_type)
    update_vectors[2] = np.array([2, 2, 2], dtype=vector_type)
    update_vectors[3] = np.array([3, 3, 3], dtype=vector_type)
    update_vectors[4] = np.array([4, 4, 4], dtype=vector_type)
    index.update_batch(vectors=update_vectors, external_ids=np.array([0, 1, 2, 3, 4]))
    query_and_check(index, np.array([[2, 2, 2]], dtype=np.float32), 3, {1, 2, 3})

    index = index.consolidate_updates()
```
Here we're using `uint8` vectors with 3 dimensions.

Before these changes our `shuffled_vector_ids` fragment was 253KB (this is because we had `np.dtype(vector_type = uint8).itemsize = 1`, and so our tile size was 42,666,666 bytes = 40.69 MB):

<img width="868" alt="Screenshot 2024-07-05 at 11 23 27 AM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/f2f0b682-7644-4e58-b6aa-f6b6df379875">

After these changes our `shuffled_vector_ids` fragment was 31KB (this is because we had `np.dtype(vector_type = uint64).itemsize = 8`, and so our tile size was 5,333,333 bytes = 5.0 MB):

<img width="868" alt="Screenshot 2024-07-05 at 11 22 24 AM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/9b75c199-223c-4d2a-a1f2-f57f636ba9a2">

I also tested on siftsmall (which has `float32` vectors with 128 dimensions):
```
def test_ingestion_fvec(tmp_path):
    vfs = tiledb.VFS()

    source_uri = siftsmall_inputs_file
    queries_uri = siftsmall_query_file
    gt_uri = siftsmall_groundtruth_file
    k = 100
    partitions = 100
    nqueries = 100
    nprobe = 20
    num_subspaces = 64
    queries = load_fvecs(queries_uri)
    gt_i, gt_d = get_groundtruth_ivec(gt_uri, k=k, nqueries=nqueries)

    for index_type, index_class in zip(INDEXES, INDEX_CLASSES):
        minimum_accuracy = (
            MINIMUM_ACCURACY_IVF_PQ if index_type == "IVF_PQ" else MINIMUM_ACCURACY
        )
        index_uri = f"/tmp/array_{index_type}"
        index = ingest(
            index_type=index_type,
            index_uri=index_uri,
            source_uri=source_uri,
            partitions=partitions,
            num_subspaces=num_subspaces,
        )
        continue
```
Before these changes our `shuffled_vector_ids` fragment was 12 KB with `np.dtype(vector_type).itemsize = 4, tile_size = 250,000 bytes = .23 MB`:

<img width="868" alt="Screenshot 2024-07-05 at 12 02 09 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/54b7ae17-b07d-4b21-b2cf-091ee4f7f438">

After these changes our `shuffled_vector_ids` fragment was also 12 KB, even though we have `np.dtype(vector_type).itemsize = 8, tile_size = 125,000 bytes = 0.119 MB`:

<img width="868" alt="Screenshot 2024-07-05 at 12 00 21 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/8e7a7b46-1351-4d77-9446-01cdb3c05c8a">

I will say that it seems that our tile size is too small when we have vectors with many dimensions, so perhaps there is actually a better approach than `big number / np.dtype(vector_type).itemsize / dimensions)`. So if you have suggestions, please do let me know. 

### Testing C++ changes
Here we build a Vamana index on SIFT (1 million 128 dimension float32 vectors):
```
def test_vamana_ingest():
    sift_base_uri = "/Users/parismorgan/Documents/tiledb/sift/sift_base.fvecs"
    data = load_fvecs(sift_base_uri)
    index_uri = f"/Users/parismorgan/Documents/tiledb/vamana/vamana_index_new"
    ingest(
            index_type="VAMANA",
            index_uri=index_uri,
            input_vectors=data,
            config=tiledb.cloud.Config().dict(),
     )
```
We have the same size with and without this change (the difference in the tile_size is only 2x (`float32` to `uint64`) versus 8x (`uint8` to `uint64`) and the dataset is larger so whatever the difference in data overflow beyond the last time looks to be negligible.

<img width="1506" alt="Screenshot 2024-07-05 at 1 45 46 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/8de857a3-1251-4c96-b74a-0541e56e9606">
