### PR TITLE
Update to TileDB Core 2.24.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 dependencies = [
     "tiledb-cloud>=0.11",
-    "tiledb>=0.30.1",
+    "tiledb>=0.30.2",
     "typing-extensions", # for tiledb-cloud indirect, x-ref https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/428
     "scikit-learn",
     "numpy<2.0.0",

--- a/src/cmake/Modules/FindTileDB_EP.cmake
+++ b/src/cmake/Modules/FindTileDB_EP.cmake
@@ -52,15 +52,18 @@ else()
     include(DownloadPrebuiltTileDB)
 
     # Try to download prebuilt artifacts unless the user specifies to build from source
+    # To update these:
+    # - Find the TileDB release, i.e. https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.1.
+    # - Copy the release hash from the `releases.csv.sha256` file in the release.
     if(DOWNLOAD_TILEDB_PREBUILT)
         fetch_prebuilt_tiledb(
-                VERSION 2.24.1
-                RELLIST_HASH SHA256=76d4deebd42afd059729fac7f13b172e1187ab43b8e3d2404f0328a47221a231
+                VERSION 2.24.2
+                RELLIST_HASH SHA256=ecc2ba2ce4041884a273707b80caf24db55a9b2f8b649b518e90940211f9f1ca
         )
     else() # Build from source
         fetch_source_tiledb(
-                VERSION 2.24.1
-                RELLIST_HASH SHA256=76d4deebd42afd059729fac7f13b172e1187ab43b8e3d2404f0328a47221a231
+                VERSION 2.24.2
+                RELLIST_HASH SHA256=ecc2ba2ce4041884a273707b80caf24db55a9b2f8b649b518e90940211f9f1ca
         )
     endif()
 


### PR DESCRIPTION
### What
Update to TileDB Core 2.24.2. Based on [this message](https://tiledb.slack.com/archives/C05R1S5AZGC/p1720205264765659).

### Testing
Tests pass.