### PR TITLE
Remove use of `set_coords_filter_list` from dense array creation

### DIFF
--- a/src/include/detail/linalg/tdb_io.h
+++ b/src/include/detail/linalg/tdb_io.h
@@ -146,7 +146,6 @@ void create_empty_for_matrix(
   schema.set_domain(domain).set_order({{order, order}});
   schema.add_attribute(
       tiledb::Attribute::create<T>(ctx, "values", filter_list));
-  schema.set_coords_filter_list(filter_list);
 
   tiledb::Array::create(uri, schema);
 }
@@ -263,7 +262,6 @@ void create_empty_for_vector(
   schema.set_domain(domain).set_order({{TILEDB_COL_MAJOR, TILEDB_COL_MAJOR}});
   schema.add_attribute(
       tiledb::Attribute::create<feature_type>(ctx, "values", filter_list));
-  schema.set_coords_filter_list(filter_list);
 
   tiledb::Array::create(uri, schema);
 }


### PR DESCRIPTION
### What
Dense arrays don't store coordinates/dimensions, thus you can't filter/compression them. Remove use of `set_coords_filter_list` here.

### Testing
Tests pass.