### PR TITLE
Add ids to Python `FeatureVectorArray`

### DIFF
--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -214,13 +214,13 @@ void init_type_erased_module(py::module_& m) {
 
         auto dtype_str = vector.dtype().str();
         tiledb_datatype_t datatype = string_to_datatype(dtype_str);
-
-        if (!check_datatype_format(datatype_to_format(datatype), info.format)) {
+        auto datatype_format = datatype_to_format(datatype);
+        if (!check_datatype_format(datatype_format, info.format)) {
           throw std::runtime_error(
               "[type_erased_module@FeatureVector] Incompatible format: "
               "expected array of " +
-              datatype_to_string(datatype) + " (" +
-              datatype_to_format(datatype) + "), but was " + info.format + ".");
+              dtype_str + " (" + datatype_format + "), but was " + info.format +
+              ".");
         }
 
         size_t sz = datatype_to_size(datatype);
@@ -289,14 +289,13 @@ void init_type_erased_module(py::module_& m) {
 
             auto dtype_str = vectors.dtype().str();
             tiledb_datatype_t datatype = string_to_datatype(dtype_str);
-            if (!check_datatype_format(
-                    datatype_to_format(datatype), info.format)) {
+            auto datatype_format = datatype_to_format(datatype);
+            if (!check_datatype_format(datatype_format, info.format)) {
               throw std::runtime_error(
                   "[type_erased_module@FeatureVectorArray] Incompatible format "
                   "- expected array of " +
-                  datatype_to_string(datatype) + " (" +
-                  datatype_to_format(datatype) + "), but was " + info.format +
-                  ".");
+                  dtype_str + " (" + datatype_format + "), but was " +
+                  info.format + ".");
             }
 
             // The ids vector buffer info.
@@ -313,14 +312,14 @@ void init_type_erased_module(py::module_& m) {
             if (ids.size() != 0) {
               ids_dtype_str = ids.dtype().str();
               ids_datatype = string_to_datatype(ids_dtype_str);
+              auto ids_datatype_format = datatype_to_format(ids_datatype);
               if (!check_datatype_format(
-                      datatype_to_format(ids_datatype), ids_info.format)) {
+                      ids_datatype_format, ids_info.format)) {
                 throw std::runtime_error(
                     "[type_erased_module@FeatureVectorArray] Incompatible ids "
                     "format - expected array of " +
-                    datatype_to_string(datatype) + " (" +
-                    datatype_to_format(datatype) + "), but was " + info.format +
-                    ".");
+                    ids_dtype_str + " (" + ids_datatype_format + "), but was " +
+                    ids_info.format + ".");
               }
             }
 

--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -219,8 +219,8 @@ void init_type_erased_module(py::module_& m) {
           throw std::runtime_error(
               "[type_erased_module@FeatureVector] Incompatible format: "
               "expected array of " +
-              dtype_str + " (" + datatype_format + "), but was " + info.format +
-              ".");
+              datatype_to_string(datatype) + " (" + datatype_format +
+              "), but was " + info.format + ".");
         }
 
         size_t sz = datatype_to_size(datatype);
@@ -294,8 +294,8 @@ void init_type_erased_module(py::module_& m) {
               throw std::runtime_error(
                   "[type_erased_module@FeatureVectorArray] Incompatible format "
                   "- expected array of " +
-                  dtype_str + " (" + datatype_format + "), but was " +
-                  info.format + ".");
+                  datatype_to_string(datatype) + " (" + datatype_format +
+                  "), but was " + info.format + ".");
             }
 
             // The ids vector buffer info.
@@ -318,8 +318,9 @@ void init_type_erased_module(py::module_& m) {
                 throw std::runtime_error(
                     "[type_erased_module@FeatureVectorArray] Incompatible ids "
                     "format - expected array of " +
-                    ids_dtype_str + " (" + ids_datatype_format + "), but was " +
-                    ids_info.format + ".");
+                    datatype_to_string(ids_datatype) + " (" +
+                    ids_datatype_format + "), but was " + ids_info.format +
+                    ".");
               }
             }
 

--- a/apis/python/test/test_type_erased_module.py
+++ b/apis/python/test/test_type_erased_module.py
@@ -28,6 +28,30 @@ def test_feature_vector_to_numpy():
     assert b.dtype == np.uint64
 
 
+def test_numpy_to_feature_vector_data_types():
+    for dtype in [
+        np.float32,
+        np.int8,
+        np.uint8,
+        np.int32,
+        np.uint32,
+        np.uint64,
+    ]:
+        if np.issubdtype(dtype, np.integer):
+            max_val = np.iinfo(dtype).max
+        elif np.issubdtype(dtype, np.floating):
+            max_val = np.finfo(dtype).max
+        else:
+            raise TypeError(f"Unsupported data type {dtype}")
+
+        vector = np.array([max_val], dtype=dtype)
+        feature_vector = vspy.FeatureVector(vector)
+        assert feature_vector.feature_type_string() == np.dtype(dtype).name
+        assert np.array_equal(
+            vector, np.array(feature_vector)
+        ), f"Arrays were not equal for dtype: {dtype}"
+
+
 def test_numpy_to_feature_vector_array_simple():
     a = np.array(np.random.rand(10000), dtype=np.float32)
     b = vspy.FeatureVector(a)
@@ -115,6 +139,8 @@ def test_numpy_to_feature_vector_array_data_types():
             vectors = np.array([[max_val]], dtype=dtype)
             ids = np.array([max_val_ids], dtype=dtype_ids)
             feature_vector_array = vspy.FeatureVectorArray(vectors, ids)
+            assert feature_vector_array.feature_type_string() == np.dtype(dtype).name
+            assert feature_vector_array.ids_type_string() == np.dtype(dtype_ids).name
             assert np.array_equal(
                 vectors, np.array(feature_vector_array)
             ), f"Arrays were not equal for dtype: {dtype}, dtype_ids: {dtype_ids}"

--- a/apis/python/test/test_type_erased_module.py
+++ b/apis/python/test/test_type_erased_module.py
@@ -226,7 +226,6 @@ def test_numpy_to_feature_vector_array():
 
 
 def test_numpy_to_feature_vector_array_with_ids():
-    print()
     a = np.array(np.random.rand(10000, 128), dtype=np.float32)
     ids = np.arange(10000, dtype=np.uint64)
     b = vspy.FeatureVectorArray(a, ids)


### PR DESCRIPTION
### What
Adds an optional `ids` argument to the Python `FeatureVectorArray`. Now you can do:
```
vectors = np.array([[max_val]], dtype=dtype)
ids = np.array([max_val_ids], dtype=dtype_ids)
feature_vector_array = vspy.FeatureVectorArray(vectors, ids)
```
And also just:
```
feature_vector_array = vspy.FeatureVectorArray(vectors, ids)
```

### Testing
* Adds a unit test
* In # I am able to update the index using the `ids` passed in here.