### PR TITLE
Add `Optional` to Python code that was missing it

### DIFF
--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -216,7 +216,7 @@ class Index:
         self,
         queries: np.ndarray,
         k: int,
-        driver_mode: Mode = None,
+        driver_mode: Optional[Mode] = None,
         driver_resources: Optional[str] = None,
         driver_access_credentials_name: Optional[str] = None,
         **kwargs,
@@ -266,13 +266,13 @@ class Index:
                 f"Expected queries to have dtype np.float32, but it had dtype {queries.dtype}"
             )
 
-        if driver_mode == Mode.LOCAL:
-            # @todo: Fix bug with driver_mode=Mode.LOCAL and remove this check.
-            raise TypeError(
-                "Cannot pass driver_mode=Mode.LOCAL to query() - use driver_mode=None to query locally."
-            )
-
         if driver_mode is not None:
+            if driver_mode == Mode.LOCAL:
+                # @todo: Fix bug with driver_mode=Mode.LOCAL and remove this check.
+                raise TypeError(
+                    "Cannot pass driver_mode=Mode.LOCAL to query() - use driver_mode=None to query locally."
+                )
+
             return self._query_with_driver(
                 queries,
                 k,

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -39,14 +39,14 @@ def ingest(
     index_type: str,
     index_uri: str,
     *,
-    input_vectors: np.ndarray = None,
-    source_uri: str = None,
-    source_type: str = None,
-    external_ids: np.array = None,
-    external_ids_uri: str = "",
-    external_ids_type: str = None,
-    updates_uri: str = None,
-    index_timestamp: int = None,
+    input_vectors: Optional[np.ndarray] = None,
+    source_uri: Optional[str] = None,
+    source_type: Optional[str] = None,
+    external_ids: Optional[np.array] = None,
+    external_ids_uri: Optional[str] = "",
+    external_ids_type: Optional[str] = None,
+    updates_uri: Optional[str] = None,
+    index_timestamp: Optional[int] = None,
     config: Optional[Mapping[str, Any]] = None,
     namespace: Optional[str] = None,
     size: int = -1,
@@ -55,11 +55,11 @@ def ingest(
     l_build: int = -1,
     r_max_degree: int = -1,
     training_sampling_policy: TrainingSamplingPolicy = TrainingSamplingPolicy.FIRST_N,
-    copy_centroids_uri: str = None,
+    copy_centroids_uri: Optional[str] = None,
     training_sample_size: int = -1,
-    training_input_vectors: np.ndarray = None,
-    training_source_uri: str = None,
-    training_source_type: str = None,
+    training_input_vectors: Optional[np.ndarray] = None,
+    training_source_uri: Optional[str] = None,
+    training_source_type: Optional[str] = None,
     workers: int = -1,
     input_vectors_per_work_item: int = -1,
     max_tasks_per_stage: int = -1,
@@ -397,7 +397,7 @@ def ingest(
             return "TILEDB_ARRAY"
 
     def read_source_metadata(
-        source_uri: str, source_type: str = None
+        source_uri: str, source_type: Optional[str] = None
     ) -> Tuple[int, int, np.dtype]:
         if source_type == "TILEDB_ARRAY":
             schema = tiledb.ArraySchema.load(source_uri)


### PR DESCRIPTION
### What
Here we add `Optional` to Python code that was missing it. I noticed this b/c VSCode was greying out a code section b/c it was missing somewhere:

<img width="753" alt="Screenshot 2024-07-11 at 3 38 38 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/4ea4b78e-d4dc-4021-b9b6-0f36d393fb57">


Adding this removed the greying out b/c VSCode understood it was optional:

<img width="1043" alt="Screenshot 2024-07-11 at 3 38 52 PM" src="https://github.com/TileDB-Inc/TileDB-Vector-Search/assets/1396242/6072b33c-8a74-4e79-80dc-1b83895d81f3">

### Testing
Tests pass.
