### PR TITLE
For type-erased Python indexes, 1) Don't consolidate parts and ids Arrays 2) Avoid extra Schema open in constructor

### DIFF
--- a/apis/python/src/tiledb/vector_search/ivf_pq_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_pq_index.py
@@ -58,6 +58,7 @@ class IVFPQIndex(index.Index):
             timestamp=timestamp,
             open_for_remote_query_execution=open_for_remote_query_execution,
         )
+        # TODO(SC-48710): Add support for `open_for_remote_query_execution`. We don't leave `self.index`` as `None` because we need to be able to call index.dimensions().
         self.index = vspy.IndexIVFPQ(self.ctx, uri, to_temporal_policy(timestamp))
         # TODO(paris): This is incorrect - should be fixed when we fix consolidation.
         self.db_uri = self.group[
@@ -67,19 +68,9 @@ class IVFPQIndex(index.Index):
             storage_formats[self.storage_version]["IDS_ARRAY_NAME"]
         ].uri
 
-        schema = tiledb.ArraySchema.load(self.db_uri, ctx=tiledb.Ctx(self.config))
         self.dimensions = self.index.dimensions()
-
         self.dtype = np.dtype(self.group.meta.get("dtype", None))
-        if self.dtype is None:
-            self.dtype = np.dtype(schema.attr("values").dtype)
-        else:
-            self.dtype = np.dtype(self.dtype)
-
-        if self.base_size == -1:
-            self.size = schema.domain.dim(1).domain[1] + 1
-        else:
-            self.size = self.base_size
+        self.size = self.base_size
 
     def get_dimensions(self):
         """

--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -77,19 +77,9 @@ class VamanaIndex(index.Index):
             storage_formats[self.storage_version]["IDS_ARRAY_NAME"]
         ].uri
 
-        schema = tiledb.ArraySchema.load(self.db_uri, ctx=tiledb.Ctx(self.config))
         self.dimensions = self.index.dimensions()
-
         self.dtype = np.dtype(self.group.meta.get("dtype", None))
-        if self.dtype is None:
-            self.dtype = np.dtype(schema.attr("values").dtype)
-        else:
-            self.dtype = np.dtype(self.dtype)
-
-        if self.base_size == -1:
-            self.size = schema.domain.dim(1).domain[1] + 1
-        else:
-            self.size = self.base_size
+        self.size = self.base_size
 
     def get_dimensions(self):
         """


### PR DESCRIPTION
### What
When we update the TileDB Core version, sometimes we only have the new C++ package, but not the Python package. This means that Python code (which is on a older Core version) should not open `Array`'s created in C++ (which is on a newer Core version). This is because there is no forward compatibility. This PR fixes a few places where the type-erased indexes were breaking this assumption and causing:
```
E   tiledb.cc.TileDBError: [TileDB::Array] Error: [TileDB::ArrayDirectory] Error: ArraySchema: Failed to deserialize; Array format version (22) is newer than the library format version (21)
```

1. We don't need to consolidate the `parts` (i.e. vectors) and `ids` `Array`'s. We do this because during distributed ingestion we end up with many fragments that are good to consolidate, but type-erased indexes do not do this.
2. Avoid extra Schema open in constructor. This code was copied from Flat and IVF Flat constructors, but is not needed for type-erased indexes because it was for backwards compatibility of Flat and IVF Flat.

### Testing
* Unit tests pass.
* We still don't fully fix the format version mismatch - there is still an issue in `consolidate_updates()`. But this gets us closer.