### PR TITLE
Set random sampling as the default sampling method for ingestion

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -54,7 +54,7 @@ def ingest(
     num_subspaces: int = -1,
     l_build: int = -1,
     r_max_degree: int = -1,
-    training_sampling_policy: TrainingSamplingPolicy = TrainingSamplingPolicy.FIRST_N,
+    training_sampling_policy: TrainingSamplingPolicy = TrainingSamplingPolicy.RANDOM,
     copy_centroids_uri: Optional[str] = None,
     training_sample_size: int = -1,
     training_input_vectors: Optional[np.ndarray] = None,


### PR DESCRIPTION
Using `FIRST_N` sampling can lead to quality problems for users that are not aware of it and try to experiment with TileDB vector search. 

`FIRST_N` can give some ingestion performance boost but it is better for a user to configure this specifically rather than facing hidden quality issues.