### PR TITLE
`tdbPartitionedMatrix` will automatically close Array's when done reading

### DIFF
--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -717,9 +717,6 @@ def test_ingestion_timetravel(tmp_path):
                 second_num_edges = num_edges_history[1]
 
         # Clear all history at timestamp 19.
-        # With type-erased indexes, we cannot call clear_history() while the index is open because they
-        # open up a TileDB Array during query(). Deleting fragments while the array is open is not allowed.
-        index = None
         Index.clear_history(uri=index_uri, timestamp=19)
 
         with tiledb.Group(index_uri, "r") as group:
@@ -1118,12 +1115,10 @@ def test_ingestion_with_updates_and_timetravel(tmp_path):
                 second_num_edges = num_edges_history[1]
 
         # Clear history before the latest ingestion
-        latest_ingestion_timestamp = index.latest_ingestion_timestamp
         assert index.latest_ingestion_timestamp == 102
-        # With type-erased indexes, we cannot call clear_history() while the index is open because they
-        # open up a TileDB Array during query(). Deleting fragments while the array is open is not allowed.
-        index = None
-        Index.clear_history(uri=index_uri, timestamp=latest_ingestion_timestamp - 1)
+        Index.clear_history(
+            uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1
+        )
 
         with tiledb.Group(index_uri, "r") as group:
             assert metadata_to_list(group, "ingestion_timestamps") == [102]
@@ -1166,12 +1161,8 @@ def test_ingestion_with_updates_and_timetravel(tmp_path):
         assert accuracy(result, gt_i, updated_ids=updated_ids) == 1.0
 
         # Clear all history
-        latest_ingestion_timestamp = index.latest_ingestion_timestamp
         assert index.latest_ingestion_timestamp == 102
-        # With type-erased indexes, we cannot call clear_history() while the index is open because they
-        # open up a TileDB Array during query(). Deleting fragments while the array is open is not allowed.
-        index = None
-        Index.clear_history(uri=index_uri, timestamp=latest_ingestion_timestamp)
+        Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp)
         index = index_class(uri=index_uri, timestamp=1)
         _, result = index.query(queries, k=k, nprobe=partitions)
         assert accuracy(result, gt_i, updated_ids=updated_ids) == 0.0
@@ -1768,11 +1759,7 @@ def test_ivf_flat_ingestion_with_training_source_uri_tdb(tmp_path):
     )
 
     # Clear the index history, load, update, and query.
-    # With type-erased indexes, we cannot call clear_history() while the index is open because they
-    # open up a TileDB Array during query(). Deleting fragments while the array is open is not allowed.
-    latest_ingestion_timestamp = index.latest_ingestion_timestamp
-    index = None
-    Index.clear_history(uri=index_uri, timestamp=latest_ingestion_timestamp - 1)
+    Index.clear_history(uri=index_uri, timestamp=index.latest_ingestion_timestamp - 1)
 
     index = IVFFlatIndex(uri=index_uri)
 

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -520,7 +520,9 @@ class tdbPartitionedMatrix
     // it is, we'll have an error to investigate, rather than just returning
     // false incorrectly.
     if (closed_) {
-      throw std::runtime_error("[tdb_partioned_matrix@load] Array is closed");
+      throw std::runtime_error(
+          "[tdb_partioned_matrix@load] Arrays are closed - this should not "
+          "happen.");
     }
 
     // 2. Load the vectors and IDs.

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -600,8 +600,6 @@ class tdbPartitionedMatrix
     this->num_vectors_ = num_resident_cols_;
     this->num_parts_ = num_resident_parts;
 
-    debug_tdb_partitioned_matrix("", 100);
-
     if (last_resident_part_ == total_num_parts_ &&
         last_resident_col_ == total_max_cols_) {
       // We have loaded all the data we can, let's close our Array's.

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -339,7 +339,6 @@ class tdbPartitionedMatrix
     num_array_cols_ =
         (array_cols.template domain<col_domain_type>().second -
          array_cols.template domain<col_domain_type>().first + 1);
-      std::cout << "num_array_cols_: " << num_array_cols_ << std::endl;
 #endif
 
     if ((matrix_order_ == TILEDB_ROW_MAJOR && cell_order == TILEDB_COL_MAJOR) ||

--- a/src/include/index/ivf_pq_index.h
+++ b/src/include/index/ivf_pq_index.h
@@ -912,6 +912,8 @@ class ivf_pq_index {
     auto infinite_parts =
         std::vector<indices_type>(::num_vectors(pq_ivf_centroids_));
     std::iota(begin(infinite_parts), end(infinite_parts), 0);
+    std::cout << "[ivf_pq_index@read_index_infinite] "
+              << "partitioned_pq_vectors_" << std::endl;
     partitioned_pq_vectors_ = std::make_unique<tdb_pq_storage_type>(
         group_->cached_ctx(),
         group_->pq_ivf_vectors_uri(),
@@ -922,7 +924,11 @@ class ivf_pq_index {
         0,
         temporal_policy_);
 
+    std::cout << "[ivf_pq_index@read_index_infinite] "
+              << "partitioned_pq_vectors_->load()" << std::endl;
     partitioned_pq_vectors_->load();
+    std::cout << "[ivf_pq_index@read_index_infinite] "
+              << "partitioned_pq_vectors_->load() done" << std::endl;
 
     if (::num_vectors(*partitioned_pq_vectors_) !=
         size(partitioned_pq_vectors_->ids())) {

--- a/src/include/index/ivf_pq_index.h
+++ b/src/include/index/ivf_pq_index.h
@@ -912,8 +912,6 @@ class ivf_pq_index {
     auto infinite_parts =
         std::vector<indices_type>(::num_vectors(pq_ivf_centroids_));
     std::iota(begin(infinite_parts), end(infinite_parts), 0);
-    std::cout << "[ivf_pq_index@read_index_infinite] "
-              << "partitioned_pq_vectors_" << std::endl;
     partitioned_pq_vectors_ = std::make_unique<tdb_pq_storage_type>(
         group_->cached_ctx(),
         group_->pq_ivf_vectors_uri(),
@@ -924,11 +922,7 @@ class ivf_pq_index {
         0,
         temporal_policy_);
 
-    std::cout << "[ivf_pq_index@read_index_infinite] "
-              << "partitioned_pq_vectors_->load()" << std::endl;
     partitioned_pq_vectors_->load();
-    std::cout << "[ivf_pq_index@read_index_infinite] "
-              << "partitioned_pq_vectors_->load() done" << std::endl;
 
     if (::num_vectors(*partitioned_pq_vectors_) !=
         size(partitioned_pq_vectors_->ids())) {

--- a/src/include/test/unit_api_ivf_pq_index.cc
+++ b/src/include/test/unit_api_ivf_pq_index.cc
@@ -587,13 +587,9 @@ TEST_CASE("clear history with an open index", "[api_ivf_pq_index]") {
 
   auto&& [scores_vector_array, ids_vector_array] =
       index.query(QueryType::InfiniteRAM, training_vector_array, 1, 1);
-  auto&& [scores_vector_array_finite, ids_vector_array_finite] =
-      index.query(QueryType::FiniteRAM, training_vector_array, 1, 1);
 
   auto second_index = IndexIVFPQ(ctx, index_uri);
-  auto&& [scores_vector_array_2, ids_vector_array_2] =
-      second_index.query(QueryType::InfiniteRAM, training_vector_array, 1, 1);
-  auto&& [scores_vector_array_finite_2, ids_vector_array_finite_2] =
+  auto&& [scores_vector_array_finite, ids_vector_array_finite] =
       second_index.query(QueryType::FiniteRAM, training_vector_array, 1, 1);
 
   // Here we check that we can clear_history() even with a index in memory. This

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -472,7 +472,7 @@ TEST_CASE("storage_version", "[api_vamana_index]") {
 }
 
 TEST_CASE("clear history with an open index", "[api_ivf_pq_index]") {
-    auto ctx = tiledb::Context{};
+  auto ctx = tiledb::Context{};
   using feature_type_type = uint8_t;
   using id_type_type = uint32_t;
   using adjacency_row_index_type_type = uint64_t;
@@ -489,11 +489,11 @@ TEST_CASE("clear history with an open index", "[api_ivf_pq_index]") {
     vfs.remove_dir(index_uri);
   }
 
-auto index = IndexVamana(std::make_optional<IndexOptions>(
-    {{"feature_type", feature_type},
-        {"id_type", id_type},
-        {"l_build", std::to_string(l_build)},
-        {"r_max_degree", std::to_string(r_max_degree)}}));
+  auto index = IndexVamana(std::make_optional<IndexOptions>(
+      {{"feature_type", feature_type},
+       {"id_type", id_type},
+       {"l_build", std::to_string(l_build)},
+       {"r_max_degree", std::to_string(r_max_degree)}}));
 
   auto training = ColMajorMatrixWithIds<feature_type_type, id_type_type>{
       {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}, {1, 2, 3, 4}};

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -471,6 +471,51 @@ TEST_CASE("storage_version", "[api_vamana_index]") {
   }
 }
 
+TEST_CASE("clear history with an open index", "[api_ivf_pq_index]") {
+    auto ctx = tiledb::Context{};
+  using feature_type_type = uint8_t;
+  using id_type_type = uint32_t;
+  using adjacency_row_index_type_type = uint64_t;
+  auto feature_type = "uint8";
+  auto id_type = "uint32";
+  size_t dimensions = 3;
+  size_t l_build = 100;
+  size_t r_max_degree = 64;
+
+  std::string index_uri =
+      (std::filesystem::temp_directory_path() / "api_vamana_index").string();
+  tiledb::VFS vfs(ctx);
+  if (vfs.is_dir(index_uri)) {
+    vfs.remove_dir(index_uri);
+  }
+
+auto index = IndexVamana(std::make_optional<IndexOptions>(
+    {{"feature_type", feature_type},
+        {"id_type", id_type},
+        {"l_build", std::to_string(l_build)},
+        {"r_max_degree", std::to_string(r_max_degree)}}));
+
+  auto training = ColMajorMatrixWithIds<feature_type_type, id_type_type>{
+      {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}, {1, 2, 3, 4}};
+  auto training_vector_array = FeatureVectorArray(training);
+  index.train(training_vector_array);
+  index.add(training_vector_array);
+  index.write_index(ctx, index_uri, TemporalPolicy(TimeTravel, 99));
+
+  auto&& [scores_vector_array, ids_vector_array] =
+      index.query(training_vector_array, 1, 1);
+
+  auto second_index = IndexVamana(ctx, index_uri);
+  auto&& [scores_vector_array_2, ids_vector_array_2] =
+      second_index.query(training_vector_array, 1, 1);
+
+  // Here we check that we can clear_history() even with a index in memory. This
+  // makes sure that every Array which IndexVamana opens has been closed,
+  // otherwise clear_history() will throw when it tries to call
+  // delete_fragments() on the index Array's.
+  IndexVamana::clear_history(ctx, index_uri, 99);
+}
+
 TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   using feature_type_type = uint8_t;

--- a/src/include/test/unit_tdb_partitioned_matrix.cc
+++ b/src/include/test/unit_tdb_partitioned_matrix.cc
@@ -183,6 +183,9 @@ TEST_CASE("can load correctly", "[tdb_partitioned_matrix]") {
         std::vector<part_index_type>{}.begin()));
     CHECK(std::equal(
         matrix.indices().begin(), matrix.indices().end(), indices.begin()));
+
+    CHECK_FALSE(matrix.load());
+    CHECK_FALSE(matrix.load());
   }
 }
 
@@ -311,6 +314,8 @@ TEST_CASE("test different combinations", "[tdb_partitioned_matrix]") {
           CHECK(
               tdb_partitioned_matrix.num_partitions() ==
               expected_num_partitions);
+
+          CHECK_FALSE(tdb_partitioned_matrix.load());
         }
       }
     }
@@ -388,4 +393,51 @@ TEST_CASE(
     CHECK(matrix.num_partitions() > 0);
     CHECK(_cpo::dimensions(matrix) == dimensions);
   }
+
+  CHECK_FALSE(matrix.load());
+}
+
+TEST_CASE("single vector and single partition", "[tdb_partitioned_matrix]") {
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
+
+  using feature_type = int;
+  using id_type = int;
+  using part_index_type = int;
+
+  std::string partitioned_vectors_uri =
+      (std::filesystem::temp_directory_path() /
+       "single_vector_partitioned_vectors")
+          .string();
+  std::string ids_uri =
+      (std::filesystem::temp_directory_path() / "single_vector_ids").string();
+  // Setup data.
+  {
+    if (vfs.is_dir(partitioned_vectors_uri)) {
+      vfs.remove_dir(partitioned_vectors_uri);
+    }
+    if (vfs.is_dir(ids_uri)) {
+      vfs.remove_dir(ids_uri);
+    }
+
+    auto partitioned_vectors = ColMajorMatrix<feature_type>{{1}};
+    write_matrix(ctx, partitioned_vectors, partitioned_vectors_uri);
+    std::vector<id_type> ids = {1};
+    write_vector(ctx, ids, ids_uri);
+  }
+
+  std::vector<part_index_type> indices = {0, 1};
+  std::vector<part_index_type> relevant_parts = {0};
+
+  auto matrix =
+      tdbColMajorPartitionedMatrix<feature_type, id_type, part_index_type>(
+          ctx, partitioned_vectors_uri, indices, ids_uri, relevant_parts, 0);
+  matrix.load();
+
+  CHECK(matrix.num_vectors() == 1);
+  CHECK(matrix.num_partitions() == 1);
+  CHECK(matrix.data()[0] == 1);
+  CHECK(matrix.ids()[0] == 1);
+  CHECK(matrix.indices() == indices);
+  CHECK_FALSE(matrix.load());
 }


### PR DESCRIPTION
### What
Today `tdbPartitionedMatrix` will leave `std::unique_ptr<tiledb::Array> partitioned_vectors_array_` and `std::unique_ptr<tiledb::Array> partitioned_ids_array_` open until the destructor. This was causing issues in #447 because we have a static function on our indexes which will try to call `tiledb::Array::delete_fragments()` on these `Array`'s, but that will throw if the `Array`'s are already open somewhere, which they are in `tdbPartitionedMatrix`.

### Testing
* Existing unit tests pass.
* Undos changes to Python which were added in #447 to work around this issue.
* Adds new `clear history with an open index` unit tests to Vamana and IVFPQ which make sure you can query and then call `clear_history()`. Note that Vamana doesn't need the changes in this PR to pass that tests, but IVFPQ fails without it.
* Adds checks for `tdb_partioned_matrix.load() = false` in several places that didn't have it.