### PR TITLE
Avoid creating one temp array for each ingestion work item

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -1672,6 +1672,7 @@ def ingest(
         verbose: bool = False,
         trace_id: Optional[str] = None,
     ):
+        import os
         import random
         import tempfile
 
@@ -1706,8 +1707,9 @@ def ingest(
             # Temporary solution until `ivf_index` library change gets released. We create a local disk
             # temporary array to hold the partial indices and write them to the respective range in the main array.
             # TODO(nikos) remove this when the `partition_start` parameter of `ivf_index` gets released.
-            partial_write_array_index_tmp_uri = (
-                f"{tempfile.gettempdir()}_{random.randint(0,MAX_INT32)}_{part_id}"
+            partial_write_array_index_tmp_uri = os.path.join(
+                tempfile.gettempdir(),
+                f"{random.randint(0,MAX_INT32)}_{part_id}",
             )
             index_array_rows_dim = tiledb.Dim(
                 name="rows",
@@ -1826,6 +1828,7 @@ def ingest(
         verbose: bool = False,
         trace_id: Optional[str] = None,
     ):
+        import os
         import random
         import tempfile
 
@@ -1846,8 +1849,8 @@ def ingest(
         # Temporary solution until `ivf_index` library change gets released. We create a local disk
         # temporary array to hold the partial indices and write them to the respective range in the main array.
         # TODO(nikos) remove this when the `partition_start` parameter of `ivf_index` gets released.
-        partial_write_array_index_tmp_uri = (
-            f"{tempfile.gettempdir()}_{random.randint(0,MAX_INT32)}_{partition_start}"
+        partial_write_array_index_tmp_uri = os.path.join(
+            tempfile.gettempdir(), f"{random.randint(0,MAX_INT32)}_{partition_start}"
         )
         index_array_rows_dim = tiledb.Dim(
             name="rows",

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -1721,7 +1721,7 @@ def ingest(
             index_attr = tiledb.Attr(
                 name="values",
                 dtype=np.dtype(np.uint64),
-                filters=DEFAULT_ATTR_FILTERS,
+                filters=tiledb.FilterList([tiledb.ZstdFilter()]),
             )
             index_schema = tiledb.ArraySchema(
                 domain=index_array_dom,
@@ -1862,7 +1862,7 @@ def ingest(
         index_attr = tiledb.Attr(
             name="values",
             dtype=np.dtype(np.uint64),
-            filters=DEFAULT_ATTR_FILTERS,
+            filters=tiledb.FilterList([tiledb.ZstdFilter()]),
         )
         index_schema = tiledb.ArraySchema(
             domain=index_array_dom,

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -1826,6 +1826,8 @@ def ingest(
         verbose: bool = False,
         trace_id: Optional[str] = None,
     ):
+        import random
+        import tempfile
         import tiledb.cloud
         from tiledb.vector_search.module import StdVector_u64
         from tiledb.vector_search.module import array_to_matrix
@@ -1883,7 +1885,7 @@ def ingest(
             deleted_ids=StdVector_u64(np.array([], np.uint64)),
             centroids_uri=centroids_uri,
             parts_uri=partial_write_array_parts_uri,
-            index_array_uri=partial_write_array_index_uri,
+            index_array_uri=partial_write_array_index_tmp_uri,
             id_uri=partial_write_array_ids_uri,
             start=write_offset,
             end=0,

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -1713,21 +1713,19 @@ def ingest(
             )
             index_array_rows_dim = tiledb.Dim(
                 name="rows",
-                domain=(0, partitions),
-                tile=partitions,
+                domain=(0, MAX_INT32),
+                tile=100000,
                 dtype=np.dtype(np.int32),
             )
             index_array_dom = tiledb.Domain(index_array_rows_dim)
             index_attr = tiledb.Attr(
                 name="values",
                 dtype=np.dtype(np.uint64),
-                filters=tiledb.FilterList([tiledb.ZstdFilter()]),
             )
             index_schema = tiledb.ArraySchema(
                 domain=index_array_dom,
                 sparse=False,
                 attrs=[index_attr],
-                capacity=partitions,
             )
             tiledb.Array.create(partial_write_array_index_tmp_uri, index_schema)
             partition_start = part_id * (partitions + 1)
@@ -1753,7 +1751,7 @@ def ingest(
                     id_uri=partial_write_array_ids_uri,
                     start=part,
                     end=part_end,
-                    partition_start=part_id * (partitions + 1),
+                    # partition_start=part_id * (partitions + 1),
                     nthreads=threads,
                     **(
                         {"timestamp": index_timestamp}
@@ -1796,7 +1794,7 @@ def ingest(
                     id_uri=partial_write_array_ids_uri,
                     start=part,
                     end=part_end,
-                    partition_start=part_id * (partitions + 1),
+                    # partition_start=part_id * (partitions + 1),
                     nthreads=threads,
                     **(
                         {"timestamp": index_timestamp}
@@ -1853,21 +1851,19 @@ def ingest(
         )
         index_array_rows_dim = tiledb.Dim(
             name="rows",
-            domain=(0, partitions),
-            tile=partitions,
+            domain=(0, MAX_INT32),
+            tile=100000,
             dtype=np.dtype(np.int32),
         )
         index_array_dom = tiledb.Domain(index_array_rows_dim)
         index_attr = tiledb.Attr(
             name="values",
             dtype=np.dtype(np.uint64),
-            filters=tiledb.FilterList([tiledb.ZstdFilter()]),
         )
         index_schema = tiledb.ArraySchema(
             domain=index_array_dom,
             sparse=False,
             attrs=[index_attr],
-            capacity=partitions,
         )
         tiledb.Array.create(partial_write_array_index_tmp_uri, index_schema)
 
@@ -1889,10 +1885,11 @@ def ingest(
             centroids_uri=centroids_uri,
             parts_uri=partial_write_array_parts_uri,
             index_array_uri=partial_write_array_index_tmp_uri,
+            # index_array_uri=partial_write_array_index_uri,
             id_uri=partial_write_array_ids_uri,
             start=write_offset,
             end=0,
-            partition_start=partition_start,
+            # partition_start=partition_start,
             nthreads=threads,
             **({"timestamp": index_timestamp} if index_timestamp is not None else {}),
             config=config,

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -733,7 +733,7 @@ def ingest(
                     config=config,
                     storage_version=storage_version,
                 )
-            partial_write_array_index_uri = create_partial_write_array_group(
+            create_partial_write_array_group(
                 temp_data_group=temp_data_group,
                 vector_type=vector_type,
                 dimensions=dimensions,
@@ -1715,7 +1715,7 @@ def ingest(
                     id_uri=partial_write_array_ids_uri,
                     start=part,
                     end=part_end,
-                    partition_start=part_id * (partitions+1),
+                    partition_start=part_id * (partitions + 1),
                     nthreads=threads,
                     **(
                         {"timestamp": index_timestamp}
@@ -1757,7 +1757,7 @@ def ingest(
                     id_uri=partial_write_array_ids_uri,
                     start=part,
                     end=part_end,
-                    partition_start=part_id * (partitions+1),
+                    partition_start=part_id * (partitions + 1),
                     nthreads=threads,
                     **(
                         {"timestamp": index_timestamp}
@@ -1835,13 +1835,11 @@ def ingest(
             partial_index_array_uri = partial_write_array_group[INDEX_ARRAY_NAME].uri
             partition_sizes = np.zeros(partitions)
 
-            total_partitions = work_items * (partitions+1)
+            total_partitions = work_items * (partitions + 1)
             with tiledb.open(
                 partial_index_array_uri, mode="r", timestamp=index_timestamp
             ) as partial_index_array:
-                partial_indexes = partial_index_array[ : total_partitions][
-                    "values"
-                ]
+                partial_indexes = partial_index_array[:total_partitions]["values"]
 
             indexes = np.zeros(partitions + 1).astype(np.uint64)
             i = 0
@@ -1903,13 +1901,11 @@ def ingest(
             for i in range(partitions):
                 partition_slices.append([])
 
-            total_partitions = work_items * (partitions+1)
+            total_partitions = work_items * (partitions + 1)
             with tiledb.open(
                 partial_index_array_uri, mode="r", timestamp=index_timestamp
             ) as partial_index_array:
-                partial_indexes = partial_index_array[: total_partitions][
-                    "values"
-                ]
+                partial_indexes = partial_index_array[:total_partitions]["values"]
             i = 0
             prev_index = 0
             for work_item_id in range(work_items):
@@ -2457,9 +2453,11 @@ def ingest(
                 ingest_node.depends_on(centroids_node)
                 ingest_nodes.append(ingest_node)
                 task_id += 1
-            
+
             if updates_uri is not None:
-                partition_start=task_id * input_vectors_work_items_per_worker * (partitions+1)
+                partition_start = (
+                    task_id * input_vectors_work_items_per_worker * (partitions + 1)
+                )
                 ingest_additions_node = submit(
                     ingest_additions_udf,
                     index_group_uri=index_group_uri,
@@ -2479,7 +2477,7 @@ def ingest(
                 ingest_additions_node.depends_on(centroids_node)
                 ingest_nodes.append(ingest_additions_node)
 
-            work_items=len(ingest_nodes)*input_vectors_work_items_per_worker
+            work_items = len(ingest_nodes) * input_vectors_work_items_per_worker
             compute_indexes_node = submit(
                 compute_partition_indexes_udf,
                 index_group_uri=index_group_uri,

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -1727,7 +1727,6 @@ def ingest(
                 attrs=[index_attr],
                 capacity=partitions,
             )
-            logger.debug(index_schema)
             tiledb.Array.create(partial_write_array_index_tmp_uri, index_schema)
             partition_start = part_id * (partitions + 1)
 

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -1753,8 +1753,7 @@ def ingest(
                     id_uri=partial_write_array_ids_uri,
                     start=part,
                     end=part_end,
-                    partition_start=0,
-                    # partition_start=part_id * (partitions + 1),
+                    partition_start=part_id * (partitions + 1),
                     nthreads=threads,
                     **(
                         {"timestamp": index_timestamp}
@@ -1797,8 +1796,7 @@ def ingest(
                     id_uri=partial_write_array_ids_uri,
                     start=part,
                     end=part_end,
-                    partition_start=0,
-                    # partition_start=part_id * (partitions + 1),
+                    partition_start=part_id * (partitions + 1),
                     nthreads=threads,
                     **(
                         {"timestamp": index_timestamp}
@@ -1821,6 +1819,7 @@ def ingest(
         index_group_uri: str,
         updates_uri: str,
         vector_type: np.dtype,
+        partitions: int,
         write_offset: int,
         partition_start: int,
         threads: int,
@@ -1893,8 +1892,7 @@ def ingest(
             id_uri=partial_write_array_ids_uri,
             start=write_offset,
             end=0,
-            # partition_start=partition_start,
-            partition_start=0,
+            partition_start=partition_start,
             nthreads=threads,
             **({"timestamp": index_timestamp} if index_timestamp is not None else {}),
             config=config,
@@ -2557,6 +2555,7 @@ def ingest(
                     index_group_uri=index_group_uri,
                     updates_uri=updates_uri,
                     vector_type=vector_type,
+                    partitions=partitions,
                     write_offset=size,
                     partition_start=partition_start,
                     threads=threads,

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -635,7 +635,7 @@ def ingest(
             tiledb.Array.create(partial_write_array_index_uri, index_schema)
             add_to_group(
                 temp_data_group,
-                partial_write_array_ids_uri,
+                partial_write_array_index_uri,
                 INDEX_ARRAY_NAME,
             )
 

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -1828,6 +1828,7 @@ def ingest(
     ):
         import random
         import tempfile
+
         import tiledb.cloud
         from tiledb.vector_search.module import StdVector_u64
         from tiledb.vector_search.module import array_to_matrix

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -623,7 +623,7 @@ def ingest(
             index_attr = tiledb.Attr(
                 name="values",
                 dtype=np.dtype(np.uint64),
-                filters=storage_formats[storage_version]["DEFAULT_ATTR_FILTERS"],
+                filters=filters,
             )
             index_schema = tiledb.ArraySchema(
                 domain=index_array_dom,

--- a/apis/python/src/tiledb/vector_search/module.cc
+++ b/apis/python/src/tiledb/vector_search/module.cc
@@ -327,8 +327,7 @@ static void declare_ivf_index(py::module& m, const std::string& suffix) {
             start_pos,
             end_pos,
             nthreads,
-            timestamp,
-            partition_start);
+            timestamp);
       },
       py::keep_alive<1, 2>());
 }
@@ -364,8 +363,7 @@ static void declare_ivf_index_tdb(py::module& m, const std::string& suffix) {
             start_pos,
             end_pos,
             nthreads,
-            timestamp,
-            partition_start);
+            timestamp);
       },
       py::keep_alive<1, 2>());
 }

--- a/apis/python/src/tiledb/vector_search/module.cc
+++ b/apis/python/src/tiledb/vector_search/module.cc
@@ -327,7 +327,8 @@ static void declare_ivf_index(py::module& m, const std::string& suffix) {
             start_pos,
             end_pos,
             nthreads,
-            timestamp);
+            timestamp,
+            partition_start);
       },
       py::keep_alive<1, 2>());
 }
@@ -363,7 +364,8 @@ static void declare_ivf_index_tdb(py::module& m, const std::string& suffix) {
             start_pos,
             end_pos,
             nthreads,
-            timestamp);
+            timestamp,
+            partition_start);
       },
       py::keep_alive<1, 2>());
 }

--- a/apis/python/src/tiledb/vector_search/module.cc
+++ b/apis/python/src/tiledb/vector_search/module.cc
@@ -313,7 +313,8 @@ static void declare_ivf_index(py::module& m, const std::string& suffix) {
          size_t start_pos,
          size_t end_pos,
          size_t nthreads,
-         uint64_t timestamp) -> int {
+         uint64_t timestamp,
+         size_t partition_start) -> int {
         return detail::ivf::ivf_index<T, uint64_t, float>(
             ctx,
             input_vectors,
@@ -326,7 +327,8 @@ static void declare_ivf_index(py::module& m, const std::string& suffix) {
             start_pos,
             end_pos,
             nthreads,
-            timestamp);
+            timestamp,
+            partition_start);
       },
       py::keep_alive<1, 2>());
 }
@@ -348,7 +350,8 @@ static void declare_ivf_index_tdb(py::module& m, const std::string& suffix) {
          size_t start_pos,
          size_t end_pos,
          size_t nthreads,
-         uint64_t timestamp) -> int {
+         uint64_t timestamp,
+         size_t partition_start) -> int {
         return detail::ivf::ivf_index<T, uint64_t, float>(
             ctx,
             input_vectors_uri,
@@ -361,7 +364,8 @@ static void declare_ivf_index_tdb(py::module& m, const std::string& suffix) {
             start_pos,
             end_pos,
             nthreads,
-            timestamp);
+            timestamp,
+            partition_start);
       },
       py::keep_alive<1, 2>());
 }

--- a/apis/python/src/tiledb/vector_search/module.py
+++ b/apis/python/src/tiledb/vector_search/module.py
@@ -175,6 +175,7 @@ def ivf_index_tdb(
     id_uri: str,
     start: int = 0,
     end: int = 0,
+    partition_start: int = 0,
     nthreads: int = 0,
     timestamp: int = 0,
     config: Dict = None,
@@ -198,6 +199,7 @@ def ivf_index_tdb(
             end,
             nthreads,
             timestamp,
+            partition_start,
         ]
     )
 
@@ -222,6 +224,7 @@ def ivf_index(
     id_uri: str,
     start: int = 0,
     end: int = 0,
+    partition_start: int = 0,
     nthreads: int = 0,
     timestamp: int = 0,
     config: Dict = None,
@@ -245,6 +248,7 @@ def ivf_index(
             end,
             nthreads,
             timestamp,
+            partition_start,
         ]
     )
 

--- a/src/include/detail/ivf/index.h
+++ b/src/include/detail/ivf/index.h
@@ -67,7 +67,8 @@ int ivf_index(
     size_t start_pos,
     size_t end_pos,
     size_t nthreads,
-    uint64_t timestamp) {
+    uint64_t timestamp,
+    size_t partition_start = 0) {
   if (nthreads == 0) {
     nthreads = std::thread::hardware_concurrency();
   }
@@ -190,7 +191,8 @@ int ivf_index(
           temporal_policy);
     }
     if (index_uri != "") {
-      write_vector(ctx, indices, index_uri, 0, false, temporal_policy);
+      write_vector(
+          ctx, indices, index_uri, partition_start, false, temporal_policy);
     }
     if (id_uri != "") {
       write_vector(
@@ -218,7 +220,8 @@ int ivf_index(
     size_t start_pos = 0,
     size_t end_pos = 0,
     size_t nthreads = 0,
-    uint64_t timestamp = 0) {
+    uint64_t timestamp = 0,
+    size_t partition_start = 0) {
   TemporalPolicy temporal_policy = (timestamp == 0) ?
                                        TemporalPolicy() :
                                        TemporalPolicy(TimeTravel, timestamp);
@@ -253,7 +256,8 @@ int ivf_index(
       start_pos,
       end_pos,
       nthreads,
-      timestamp);
+      timestamp,
+      partition_start);
 }
 
 /**
@@ -272,7 +276,8 @@ int ivf_index(
     size_t start_pos = 0,
     size_t end_pos = 0,
     size_t nthreads = 0,
-    uint64_t timestamp = 0) {
+    uint64_t timestamp = 0,
+    size_t partition_start = 0) {
   // Read all rows from column `start_pos` -> `end_pos`. Set no upper_bound.
   auto input_vectors = tdbColMajorMatrix<FeatureType>(
       ctx,
@@ -296,7 +301,8 @@ int ivf_index(
       start_pos,
       end_pos,
       nthreads,
-      timestamp);
+      timestamp,
+      partition_start);
 }
 
 /*
@@ -317,7 +323,8 @@ int ivf_index(
     size_t start_pos = 0,
     size_t end_pos = 0,
     size_t nthreads = 0,
-    uint64_t timestamp = 0) {
+    uint64_t timestamp = 0,
+    size_t partition_start = 0) {
   std::vector<IdsType> external_ids;
   if (external_ids_uri.empty()) {
     external_ids = std::vector<IdsType>(input_vectors.num_cols());
@@ -338,7 +345,8 @@ int ivf_index(
       start_pos,
       end_pos,
       nthreads,
-      timestamp);
+      timestamp,
+      partition_start);
 }
 
 }  // namespace detail::ivf


### PR DESCRIPTION
This avoids the creation of one temp array per work item to hold the partition indices. Instead we use one array to hold the indices of all work items.

This reduces the start up cost of ingestion especially for `tiledb://` uris as we don't have to create and register many arrays.

To avoid doing a rolling release of first releasing the lib change and then using it in ingestion, I applied a temporary solution of writing the indices in a temporary local array and then copying to the main array after the library call. This will be removed after the next cloud release.