### PR TITLE
Save kmeans settings to IVF PQ metadata

### DIFF
--- a/src/include/api/ivf_pq_index.h
+++ b/src/include/api/ivf_pq_index.h
@@ -106,6 +106,8 @@ class IndexIVFPQ {
           max_iterations_ = std::stol(value);
         } else if (key == "convergence_tolerance") {
           convergence_tolerance_ = std::stof(value);
+        } else if (key == "reassign_ratio") {
+          reassign_ratio_ = std::stof(value);
         } else if (key == "feature_type") {
           feature_datatype_ = string_to_datatype(value);
         } else if (key == "id_type") {
@@ -150,6 +152,7 @@ class IndexIVFPQ {
     num_subspaces_ = index_->num_subspaces();
     max_iterations_ = index_->max_iterations();
     convergence_tolerance_ = index_->convergence_tolerance();
+    reassign_ratio_ = index_->reassign_ratio();
 
     if (dimensions_ != 0 && dimensions_ != index_->dimensions()) {
       throw std::runtime_error(
@@ -190,6 +193,7 @@ class IndexIVFPQ {
         num_subspaces_,
         max_iterations_,
         convergence_tolerance_,
+        reassign_ratio_,
         index_ ? std::make_optional<TemporalPolicy>(index_->temporal_policy()) :
                  std::nullopt);
 
@@ -295,6 +299,10 @@ class IndexIVFPQ {
     return convergence_tolerance_;
   }
 
+  constexpr auto reassign_ratio() const {
+    return reassign_ratio_;
+  }
+
   constexpr auto feature_type() const {
     return feature_datatype_;
   }
@@ -380,6 +388,7 @@ class IndexIVFPQ {
     [[nodiscard]] virtual uint64_t num_subspaces() const = 0;
     [[nodiscard]] virtual uint64_t max_iterations() const = 0;
     [[nodiscard]] virtual float convergence_tolerance() const = 0;
+    [[nodiscard]] virtual float reassign_ratio() const = 0;
   };
 
   /**
@@ -396,13 +405,15 @@ class IndexIVFPQ {
         size_t n_list,
         size_t num_subspaces,
         size_t max_iterations,
-        size_t convergence_tolerance,
+        float convergence_tolerance,
+        float reassign_ratio,
         std::optional<TemporalPolicy> temporal_policy)
         : impl_index_(
               n_list,
               num_subspaces,
               max_iterations,
               convergence_tolerance,
+              reassign_ratio,
               temporal_policy) {
     }
 
@@ -532,6 +543,10 @@ class IndexIVFPQ {
       return impl_index_.convergence_tolerance();
     }
 
+    float reassign_ratio() const override {
+      return impl_index_.reassign_ratio();
+    }
+
    private:
     /**
      * @brief Instance of the concrete class.
@@ -540,7 +555,7 @@ class IndexIVFPQ {
   };
 
   // clang-format off
-  using constructor_function = std::function<std::unique_ptr<index_base>(size_t, size_t, size_t, float, std::optional<TemporalPolicy>)>;
+  using constructor_function = std::function<std::unique_ptr<index_base>(size_t, size_t, size_t, float, float, std::optional<TemporalPolicy>)>;
   using table_type = std::map<std::tuple<tiledb_datatype_t, tiledb_datatype_t, tiledb_datatype_t>, constructor_function>;
   static const table_type dispatch_table;
 
@@ -558,6 +573,7 @@ class IndexIVFPQ {
   size_t num_subspaces_{16};
   size_t max_iterations_{2};
   float convergence_tolerance_{0.000025f};
+  float reassign_ratio_{0.075f};
   tiledb_datatype_t feature_datatype_{TILEDB_ANY};
   tiledb_datatype_t id_datatype_{TILEDB_ANY};
   tiledb_datatype_t partitioning_index_datatype_{TILEDB_ANY};
@@ -566,18 +582,18 @@ class IndexIVFPQ {
 
 // clang-format off
 const IndexIVFPQ::table_type IndexIVFPQ::dispatch_table = {
-  {{TILEDB_INT8,    TILEDB_UINT32, TILEDB_UINT32}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<int8_t,  uint32_t, uint32_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, temporal_policy); }},
-  {{TILEDB_UINT8,   TILEDB_UINT32, TILEDB_UINT32}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<uint8_t, uint32_t, uint32_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, temporal_policy); }},
-  {{TILEDB_FLOAT32, TILEDB_UINT32, TILEDB_UINT32}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<float,   uint32_t, uint32_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, temporal_policy); }},
-  {{TILEDB_INT8,    TILEDB_UINT32, TILEDB_UINT64}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<int8_t,  uint32_t, uint64_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, temporal_policy); }},
-  {{TILEDB_UINT8,   TILEDB_UINT32, TILEDB_UINT64}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<uint8_t, uint32_t, uint64_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, temporal_policy); }},
-  {{TILEDB_FLOAT32, TILEDB_UINT32, TILEDB_UINT64}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<float,   uint32_t, uint64_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, temporal_policy); }},
-  {{TILEDB_INT8,    TILEDB_UINT64, TILEDB_UINT32}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<int8_t,  uint64_t, uint32_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, temporal_policy); }},
-  {{TILEDB_UINT8,   TILEDB_UINT64, TILEDB_UINT32}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<uint8_t, uint64_t, uint32_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, temporal_policy); }},
-  {{TILEDB_FLOAT32, TILEDB_UINT64, TILEDB_UINT32}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<float,   uint64_t, uint32_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, temporal_policy); }},
-  {{TILEDB_INT8,    TILEDB_UINT64, TILEDB_UINT64}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<int8_t,  uint64_t, uint64_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, temporal_policy); }},
-  {{TILEDB_UINT8,   TILEDB_UINT64, TILEDB_UINT64}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<uint8_t, uint64_t, uint64_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, temporal_policy); }},
-  {{TILEDB_FLOAT32, TILEDB_UINT64, TILEDB_UINT64}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<float,   uint64_t, uint64_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, temporal_policy); }},
+  {{TILEDB_INT8,    TILEDB_UINT32, TILEDB_UINT32}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, float reassign_ratio, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<int8_t,  uint32_t, uint32_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, reassign_ratio, temporal_policy); }},
+  {{TILEDB_UINT8,   TILEDB_UINT32, TILEDB_UINT32}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, float reassign_ratio, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<uint8_t, uint32_t, uint32_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, reassign_ratio, temporal_policy); }},
+  {{TILEDB_FLOAT32, TILEDB_UINT32, TILEDB_UINT32}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, float reassign_ratio, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<float,   uint32_t, uint32_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, reassign_ratio, temporal_policy); }},
+  {{TILEDB_INT8,    TILEDB_UINT32, TILEDB_UINT64}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, float reassign_ratio, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<int8_t,  uint32_t, uint64_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, reassign_ratio, temporal_policy); }},
+  {{TILEDB_UINT8,   TILEDB_UINT32, TILEDB_UINT64}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, float reassign_ratio, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<uint8_t, uint32_t, uint64_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, reassign_ratio, temporal_policy); }},
+  {{TILEDB_FLOAT32, TILEDB_UINT32, TILEDB_UINT64}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, float reassign_ratio, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<float,   uint32_t, uint64_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, reassign_ratio, temporal_policy); }},
+  {{TILEDB_INT8,    TILEDB_UINT64, TILEDB_UINT32}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, float reassign_ratio, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<int8_t,  uint64_t, uint32_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, reassign_ratio, temporal_policy); }},
+  {{TILEDB_UINT8,   TILEDB_UINT64, TILEDB_UINT32}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, float reassign_ratio, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<uint8_t, uint64_t, uint32_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, reassign_ratio, temporal_policy); }},
+  {{TILEDB_FLOAT32, TILEDB_UINT64, TILEDB_UINT32}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, float reassign_ratio, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<float,   uint64_t, uint32_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, reassign_ratio, temporal_policy); }},
+  {{TILEDB_INT8,    TILEDB_UINT64, TILEDB_UINT64}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, float reassign_ratio, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<int8_t,  uint64_t, uint64_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, reassign_ratio, temporal_policy); }},
+  {{TILEDB_UINT8,   TILEDB_UINT64, TILEDB_UINT64}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, float reassign_ratio, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<uint8_t, uint64_t, uint64_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, reassign_ratio, temporal_policy); }},
+  {{TILEDB_FLOAT32, TILEDB_UINT64, TILEDB_UINT64}, [](size_t nlist, size_t num_subspaces, size_t max_iterations, float convergence_tolerance, float reassign_ratio, std::optional<TemporalPolicy> temporal_policy) { return std::make_unique<index_impl<ivf_pq_index<float,   uint64_t, uint64_t>>>(nlist, num_subspaces, max_iterations, convergence_tolerance, reassign_ratio, temporal_policy); }},
 };
 
 const IndexIVFPQ::uri_table_type IndexIVFPQ::uri_dispatch_table = {

--- a/src/include/index/ivf_pq_group.h
+++ b/src/include/index/ivf_pq_group.h
@@ -89,6 +89,8 @@ class ivf_pq_group : public base_index_group<index_type> {
       size_t num_subspaces = 0)
       : Base(ctx, uri, rw, temporal_policy, version, dimensions) {
     if (rw == TILEDB_WRITE && !this->exists()) {
+      // num_clusters and num_subspaces must be set before we call
+      // create_default_impl().
       if (num_clusters == 0) {
         throw std::invalid_argument(
             "num_clusters must be specified when creating a new group.");
@@ -221,8 +223,7 @@ class ivf_pq_group : public base_index_group<index_type> {
   }
 
   /*****************************************************************************
-   * Getters and setters for PQ related metadata: num_subspaces, sub_dimension,
-   * bits_per_subspace, num_clusters
+   * Getters and setters for PQ related metadata
    ****************************************************************************/
   auto get_num_subspaces() const {
     return metadata_.num_subspaces_;
@@ -250,6 +251,27 @@ class ivf_pq_group : public base_index_group<index_type> {
   }
   auto set_num_clusters(size_t num_clusters) {
     metadata_.num_clusters_ = num_clusters;
+  }
+
+  auto get_max_iterations() const {
+    return metadata_.max_iterations_;
+  }
+  auto set_max_iterations(uint64_t max_iterations) {
+    metadata_.max_iterations_ = max_iterations;
+  }
+
+  auto get_convergence_tolerance() const {
+    return metadata_.convergence_tolerance_;
+  }
+  auto set_convergence_tolerance(float convergence_tolerance) {
+    metadata_.convergence_tolerance_ = convergence_tolerance;
+  }
+
+  auto get_reassign_ratio() const {
+    return metadata_.reassign_ratio_;
+  }
+  auto set_reassign_ratio(float reassign_ratio) {
+    metadata_.reassign_ratio_ = reassign_ratio;
   }
 
   /*****************************************************************************

--- a/src/include/index/ivf_pq_index.h
+++ b/src/include/index/ivf_pq_index.h
@@ -1026,8 +1026,6 @@ class ivf_pq_index {
     write_group.set_convergence_tolerance(convergence_tolerance_);
     write_group.set_reassign_ratio(reassign_ratio_);
 
-    write_group.dump();
-
     if (num_subspaces_ * sub_dimensions_ != dimensions_) {
       throw std::runtime_error(
           "[ivf_pq_index@write_index] num_subspaces_ * sub_dimensions_ != "

--- a/src/include/index/ivf_pq_metadata.h
+++ b/src/include/index/ivf_pq_metadata.h
@@ -48,10 +48,11 @@
  *   - sub_dimensions
  *   - bits_per_subspace
  *   - num_clusters
+ *   - max_iterations
+ *   - convergence_tolerance
+ *   - reassign_ratio
  *
  *   Execution specific
- *   - tol
- *   - max_iter
  *   - num_threads
  *
  *
@@ -82,6 +83,9 @@ class ivf_pq_metadata : public base_index_metadata<ivf_pq_metadata> {
   uint32_t sub_dimensions_{0};
   uint32_t bits_per_subspace_{0};
   uint32_t num_clusters_{0};
+  uint64_t max_iterations_{0};
+  float convergence_tolerance_{0.f};
+  float reassign_ratio_{0.f};
 
  protected:
   IndexKind index_kind_{IndexKind::IVFPQ};
@@ -99,6 +103,9 @@ class ivf_pq_metadata : public base_index_metadata<ivf_pq_metadata> {
       {"sub_dimensions", &sub_dimensions_, TILEDB_UINT32, true},
       {"bits_per_subspace", &bits_per_subspace_, TILEDB_UINT32, true},
       {"num_clusters", &num_clusters_, TILEDB_UINT32, true},
+      {"max_iterations", &max_iterations_, TILEDB_UINT64, true},
+      {"convergence_tolerance", &convergence_tolerance_, TILEDB_FLOAT32, true},
+      {"reassign_ratio", &reassign_ratio_, TILEDB_FLOAT32, true},
   };
 
   void clear_history_impl(uint64_t timestamp) {

--- a/src/include/test/unit_ivf_flat_index.cc
+++ b/src/include/test/unit_ivf_flat_index.cc
@@ -374,8 +374,12 @@ TEST_CASE("Build index and query in place, infinite", "[ivf_index]") {
 
   auto init = siftsmall_test_init<index>(ctx, nlist);
 
-  auto&& [nprobe, k_nn, nthreads, max_iter, tolerance] = std::tie(
-      init.nprobe, init.k_nn, init.nthreads, init.max_iter, init.tolerance);
+  auto&& [nprobe, k_nn, nthreads, max_iterations, tolerance] = std::tie(
+      init.nprobe,
+      init.k_nn,
+      init.nthreads,
+      init.max_iterations,
+      init.convergence_tolerance);
   auto&& [idx, training_set, query_set, groundtruth_set] = std::tie(
       init.idx, init.training_set, init.query_set, init.groundtruth_set);
 
@@ -416,8 +420,12 @@ TEST_CASE("Build index, write, read and query, infinite", "[ivf_index]") {
 
   auto init = siftsmall_test_init<index>(ctx, nlist);
 
-  auto&& [nprobe, k_nn, nthreads, max_iter, tolerance] = std::tie(
-      init.nprobe, init.k_nn, init.nthreads, init.max_iter, init.tolerance);
+  auto&& [nprobe, k_nn, nthreads, max_iterations, tolerance] = std::tie(
+      init.nprobe,
+      init.k_nn,
+      init.nthreads,
+      init.max_iterations,
+      init.convergence_tolerance);
   auto&& [_, training_set, query_set, groundtruth_set] = std::tie(
       init.idx, init.training_set, init.query_set, init.groundtruth_set);
   auto idx = init.get_write_read_idx();
@@ -459,8 +467,12 @@ TEST_CASE("Build index, write, read and query, finite", "[ivf_index]") {
 
   auto init = siftsmall_test_init<index>(ctx, nlist);
 
-  auto&& [nprobe, k_nn, nthreads, max_iter, tolerance] = std::tie(
-      init.nprobe, init.k_nn, init.nthreads, init.max_iter, init.tolerance);
+  auto&& [nprobe, k_nn, nthreads, max_iterations, tolerance] = std::tie(
+      init.nprobe,
+      init.k_nn,
+      init.nthreads,
+      init.max_iterations,
+      init.convergence_tolerance);
   auto&& [_, training_set, query_set, groundtruth_set] = std::tie(
       init.idx, init.training_set, init.query_set, init.groundtruth_set);
   auto idx = init.get_write_read_idx();
@@ -498,8 +510,12 @@ TEST_CASE(
 
   auto init = siftsmall_test_init<index>(ctx, nlist);
 
-  auto&& [nprobe, k_nn, nthreads, max_iter, tolerance] = std::tie(
-      init.nprobe, init.k_nn, init.nthreads, init.max_iter, init.tolerance);
+  auto&& [nprobe, k_nn, nthreads, max_iterations, tolerance] = std::tie(
+      init.nprobe,
+      init.k_nn,
+      init.nthreads,
+      init.max_iterations,
+      init.convergence_tolerance);
   auto&& [_, training_set, query_set, groundtruth_set] = std::tie(
       init.idx, init.training_set, init.query_set, init.groundtruth_set);
   auto idx = init.get_write_read_idx();

--- a/src/include/test/unit_ivf_pq_index.cc
+++ b/src/include/test/unit_ivf_pq_index.cc
@@ -297,7 +297,7 @@ TEST_CASE("ivf_index write and read", "[ivf_pq_index]") {
   size_t dimension = 128;
   size_t nlist = 100;
   size_t num_subspaces = 16;
-  size_t max_iters = 4;
+  size_t max_iterationss = 4;
   size_t nprobe = 10;
   size_t k_nn = 10;
   size_t nthreads = 1;
@@ -316,7 +316,7 @@ TEST_CASE("ivf_index write and read", "[ivf_pq_index]") {
   std::vector<siftsmall_ids_type> ids(num_vectors(training_set));
   std::iota(begin(ids), end(ids), 0);
   auto idx = ivf_pq_index<float, uint32_t, uint32_t>(
-      nlist, num_subspaces, max_iters, nthreads);
+      nlist, num_subspaces, max_iterationss, nthreads);
   idx.train_ivf(training_set, kmeans_init::kmeanspp);
   idx.add(training_set, ids);
   idx.write_index(ctx, ivf_index_uri);
@@ -484,8 +484,13 @@ TEST_CASE("Build index and query in place, infinite", "[ivf_pq_index]") {
 
   auto init = siftsmall_test_init<index>(ctx, nlist, 16);
 
-  auto&& [nprobe, k_nn, nthreads, max_iter, tolerance] = std::tie(
-      init.nprobe, init.k_nn, init.nthreads, init.max_iter, init.tolerance);
+  auto&& [nprobe, k_nn, nthreads, max_iterations, convergence_tolerance] =
+      std::tie(
+          init.nprobe,
+          init.k_nn,
+          init.nthreads,
+          init.max_iterations,
+          init.convergence_tolerance);
   auto&& [_, training_set, query_set, groundtruth_set] = std::tie(
       init.idx, init.training_set, init.query_set, init.groundtruth_set);
   auto idx = init.get_write_read_idx();
@@ -642,16 +647,25 @@ TEST_CASE("query simple", "[ivf_pq_index]") {
   size_t dimensions = 4;
   size_t nlist = 1;
   size_t num_subspaces = 2;
-  size_t max_iter = 1;
-  float tol = 0.000025;
+  size_t max_iterations = 1;
+  float convergence_tolerance = 0.000025f;
+  float reassign_ratio = 0.09f;
   std::optional<TemporalPolicy> temporal_policy = std::nullopt;
   size_t num_clusters = 4;
   using feature_type = float;
   using id_type = uint32_t;
   auto index = ivf_pq_index<feature_type, id_type>(
-      nlist, num_subspaces, max_iter, tol, temporal_policy, num_clusters);
+      nlist,
+      num_subspaces,
+      max_iterations,
+      convergence_tolerance,
+      reassign_ratio,
+      temporal_policy,
+      num_clusters);
   auto ivf_index_uri =
       (std::filesystem::temp_directory_path() / "ivf_index").string();
+
+  CHECK(index.nlist() == nlist);
 
   // We can train, add, query, and then write the index.
   {
@@ -715,8 +729,8 @@ TEST_CASE("ivf_pq_index query index written twice", "[ivf_pq_index]") {
   size_t dimensions = 3;
   size_t n_list = 1;
   size_t num_subspaces = 1;
-  float convergence_tolerance = 0.00003f;
-  size_t max_iterations = 3;
+  float convergence_convergence_toleranceerance = 0.00003f;
+  size_t max_iterationsations = 3;
 
   // Write the empty index.
   {

--- a/src/include/test/unit_ivf_pq_metadata.cc
+++ b/src/include/test/unit_ivf_pq_metadata.cc
@@ -74,6 +74,12 @@ TEST_CASE("load metadata from index", "[ivf_pq_metadata]") {
       {"sub_dimensions", 8},
       {"bits_per_subspace", 8},
       {"num_clusters", 256},
+      {"max_iterations", 2},
+  };
+
+  std::vector<std::tuple<std::string, float>> expected_arithmetic_float{
+      {"convergence_tolerance", 0.000025f},
+      {"reassign_ratio", 0.075f},
   };
 
   {
@@ -97,7 +103,11 @@ TEST_CASE("load metadata from index", "[ivf_pq_metadata]") {
         {"base_sizes", "[0]"},
         {"partition_history", "[0]"},
     };
-    validate_metadata(read_group, expected_str, expected_arithmetic);
+    validate_metadata(
+        read_group,
+        expected_str,
+        expected_arithmetic,
+        expected_arithmetic_float);
 
     auto x = ivf_pq_metadata();
     x.load_metadata(read_group);

--- a/src/include/test/utils/query_common.h
+++ b/src/include/test/utils/query_common.h
@@ -140,8 +140,8 @@ struct siftsmall_test_init_defaults {
 
   size_t k_nn = 10;
   size_t nthreads = 0;
-  size_t max_iter = 10;
-  float tolerance = 1e-4;
+  size_t max_iterations = 10;
+  float convergence_tolerance = 1e-4;
 };
 
 template <class IndexType>
@@ -172,11 +172,12 @@ struct siftsmall_test_init : public siftsmall_test_init_defaults {
     if constexpr (std::is_same_v<
                       IndexType,
                       ivf_flat_index<feature_type, id_type, px_type>>) {
-      idx = IndexType(nlist, max_iter, tolerance);
+      idx = IndexType(nlist, max_iterations, convergence_tolerance);
     } else if constexpr (std::is_same_v<
                              IndexType,
                              ivf_pq_index<feature_type, id_type, px_type>>) {
-      idx = IndexType(nlist, num_subspaces, max_iter, tolerance);
+      idx = IndexType(
+          nlist, num_subspaces, max_iterations, convergence_tolerance);
     } else {
       std::cout << "Unsupported index type" << std::endl;
     }


### PR DESCRIPTION
### What
Previously we did not save kmeans settings to IVF PQ metadata. This would mean that if in the future we want to expose these to Python, we wouldn't be able to rely on all indexes having these set in metadata. So here we set them to make it easier to change them in the future.

### Testing
* Existing tests pass.
* Added new checks that these values are saved and loaded correctly.