### PR TITLE
Close tdbMatrix and tdbMatrixWithIds Array's when we have nothing left to to read

### DIFF
--- a/src/include/detail/linalg/tdb_matrix.h
+++ b/src/include/detail/linalg/tdb_matrix.h
@@ -114,6 +114,10 @@ class tdbBlockedMatrix : public MatrixBase {
   // size_t pending_row_offset{0};
   // size_t pending_col_offset{0};
 
+  size_t get_elements_to_load() const {
+    return std::min(load_blocksize_, last_col_ - last_resident_col_);
+  }
+
  public:
   tdbBlockedMatrix(tdbBlockedMatrix&& rhs) = default;
 
@@ -324,11 +328,11 @@ class tdbBlockedMatrix : public MatrixBase {
     }
 
     size_t dimension = last_row_ - first_row_;
-    auto elements_to_load =
-        std::min(load_blocksize_, last_col_ - last_resident_col_);
+    auto elements_to_load = get_elements_to_load();
 
     // Return if we're at the end
     if (elements_to_load == 0 || dimension == 0) {
+      array_->close();
       return false;
     }
 
@@ -361,6 +365,10 @@ class tdbBlockedMatrix : public MatrixBase {
     // @todo Handle incomplete queries.
     if (tiledb::Query::Status::COMPLETE != query.query_status()) {
       throw std::runtime_error("Query status is not complete");
+    }
+
+    if (get_elements_to_load() == 0) {
+      array_->close();
     }
 
     num_loads_++;

--- a/src/include/detail/linalg/tdb_matrix_with_ids.h
+++ b/src/include/detail/linalg/tdb_matrix_with_ids.h
@@ -167,6 +167,7 @@ class tdbBlockedMatrixWithIds
   bool load() {
     scoped_timer _{tdb_func__ + " " + this->ids_uri_};
     if (!Base::load()) {
+      ids_array_->close();
       return false;
     }
 
@@ -212,6 +213,10 @@ class tdbBlockedMatrixWithIds
     // @todo Handle incomplete queries.
     if (tiledb::Query::Status::COMPLETE != query.query_status()) {
       throw std::runtime_error("Query status for IDs is not complete");
+    }
+
+    if (this->get_elements_to_load() == 0) {
+      ids_array_->close();
     }
 
     return true;

--- a/src/include/test/unit_tdb_matrix.cc
+++ b/src/include/test/unit_tdb_matrix.cc
@@ -59,7 +59,10 @@ TEMPLATE_TEST_CASE("constructors", "[tdb_matrix]", float, uint8_t) {
   write_matrix(ctx, X, tmp_matrix_uri);
 
   auto Y = tdbColMajorMatrix<TestType>(ctx, tmp_matrix_uri);
-  Y.load();
+  CHECK(Y.load() == true);
+  for (int i = 0; i < 5; ++i) {
+    CHECK(Y.load() == false);
+  }
 
   auto Z = tdbColMajorMatrix<TestType>(std::move(Y));
 

--- a/src/include/test/unit_tdb_matrix_with_ids.cc
+++ b/src/include/test/unit_tdb_matrix_with_ids.cc
@@ -63,7 +63,10 @@ TEMPLATE_TEST_CASE(
 
   auto Y = tdbColMajorMatrixWithIds<TestType, TestType>(
       ctx, tmp_matrix_uri, tmp_ids_uri);
-  Y.load();
+  CHECK(Y.load() == true);
+  for (int i = 0; i < 5; ++i) {
+    CHECK(Y.load() == false);
+  }
   CHECK(num_vectors(Y) == num_vectors(X));
   CHECK(dimensions(Y) == dimensions(X));
   CHECK(std::equal(


### PR DESCRIPTION
### What
When I tested with the new TileDB-Py `0.31.0` wheels (downloaded manually from this run: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/10096606074), I saw a new error when running Flat and IVF Flat:
```
>           Index.clear_history(uri=index_uri, timestamp=19)

apis/python/test/test_ingestion.py:720: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/homebrew/anaconda3/envs/TileDB-Vector-Search-2/lib/python3.9/site-packages/tiledb/vector_search/index.py:641: in clear_history
    tiledb.Array.delete_fragments(db_uri, 0, timestamp)
libtiledb.pyx:1337: in tiledb.libtiledb.Array.delete_fragments
    ???
libtiledb.pyx:337: in tiledb.libtiledb._raise_ctx_err
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   tiledb.cc.TileDBError: TileDB internal: [Array::set_array_closed] May not perform simultaneous open or close operations.
```
This happens from code like this:
```
def test_ingestion_timetravel(tmp_path):
    for index_type, index_class in zip(INDEXES, INDEX_CLASSES):
        index_uri = os.path.join(tmp_path, f"array_{index_type}")

        data = np.array([[1.0, 1.1, 1.2, 1.3], [2.0, 2.1, 2.2, 2.3]], dtype=np.float32)
        default_result_d = [[np.finfo(np.float32).max], [np.finfo(np.float32).max]]
        default_result_i = [[np.iinfo(np.uint64).max], [np.iinfo(np.uint64).max]]

        # We ingest at timestamp 10.
        index = ingest(
            index_type=index_type,
            index_uri=index_uri,
            input_vectors=data,
            index_timestamp=10,
            num_subspaces=2,
        )
        
        Index.clear_history(uri=index_uri, timestamp=19)
```
and is coming from `load_as_matrix()`:
```
flat_index.py
           self._db = load_as_matrix(
                self.db_uri,
                ctx=self.ctx,
                config=config,
                size=self.size,
                timestamp=self.base_array_timestamp,
            )
```
which does:
```
module.py
def load_as_matrix(
    ...    
    if dtype == np.float32:
        m = tdbColMajorMatrix_f32(ctx, path, 0, None, 0, size, 0, timestamp)
    ...
    m.load()
    return m
```
I fixed a similar bug for type-erased matrixes by having `tdbPartitionedMatrix` automatically close Array's when done reading (#448). So here we do the same thing for `tdbMatrix` and `tdbMatrixWithIds`.

### Testing
* Existing unit tests pass.
* Added new unit tests that we can call `load()` many times and nothing bad happens.
* With these changes `test_ingestion.py` now passes with TileDB-Py `0.31.0` wheels.