### PR TITLE
Optimize distance computations for IVFPQ

### DIFF
--- a/src/include/index/ivf_pq_index.h
+++ b/src/include/index/ivf_pq_index.h
@@ -1246,16 +1246,17 @@ class ivf_pq_index {
     auto&& [active_partitions, active_queries] =
         detail::ivf::partition_ivf_flat_index<indices_type>(
             flat_ivf_centroids_, query_vectors, nprobe, num_threads_);
+
+    auto query_vectors_encoded =
+        std::move(*pq_encode<Q, pq_ivf_centroid_storage_type>(query_vectors));
     return detail::ivf::query_infinite_ram(
         *partitioned_pq_vectors_,
         active_partitions,
-        query_vectors,
+        query_vectors_encoded,
         active_queries,
         k_nn,
         num_threads_,
-        make_pq_distance_asymmetric<
-            std::span<typename Q::value_type>,
-            decltype(pq_storage_type{}[0])>());
+        make_pq_distance_symmetric());
   }
 
   /**

--- a/src/include/index/ivf_pq_index.h
+++ b/src/include/index/ivf_pq_index.h
@@ -574,28 +574,41 @@ class ivf_pq_index {
     };
     return pq_distance{this};
   }
-
+  /**
+   * @brief Computes the distance between a query and and a pq_encoded_vector
+   * given the distance table of the query to the pq_centroids
+   * query_to_pq_centroid_distance_table.
+   *
+   * @param query_to_pq_centroid_distance_table Distance table of the query
+   * vector to the pq_centroids.
+   * @param pq_encoded_vector PQ encoded database vector.
+   *
+   */
   template <feature_vector U, feature_vector V>
-  float sub_distance_query_centroid_distances(const U& a, const V& b) const {
+  float sub_distance_query_to_pq_centroid_distance_tables(
+      const U& query_to_pq_centroid_distance_table,
+      const V& pq_encoded_vector) const {
     float pq_distance = 0.0;
     size_t sub_id = 0;
     for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
-      auto j = b[subspace];
-      pq_distance += a[sub_id + j];
+      auto j = pq_encoded_vector[subspace];
+      pq_distance += query_to_pq_centroid_distance_table[sub_id + j];
       sub_id += num_clusters_;
     }
     return pq_distance;
   }
 
-  template <typename queries_feature_type, typename index_feature_type>
-  auto make_pq_distance_query_centroid_distances() const {
-    using A = queries_feature_type;
+  template <
+      typename query_to_pq_centroid_distance_tables_type,
+      typename index_feature_type>
+  auto make_pq_distance_query_to_pq_centroid_distance_tables() const {
+    using A = query_to_pq_centroid_distance_tables_type;
     using B = index_feature_type;
 
     struct pq_distance {
       const ivf_pq_index* outer_;
       inline float operator()(const A& a, const B& b) {
-        return outer_->sub_distance_query_centroid_distances(a, b);
+        return outer_->sub_distance_query_to_pq_centroid_distance_tables(a, b);
       }
     };
     return pq_distance{this};
@@ -839,17 +852,33 @@ class ivf_pq_index {
     return pq_vectors;
   }
 
+  /**
+   * @brief Builds distance tables between each query and pq centroid.
+   *
+   * For each query, we iterate through each of it's subspaces, and for
+   * each subspace we will compute the distance from the vector's subspace to
+   * each of the (num_clusters_) pq_centroids. This results in a distance table
+   * per query that is used during the actual distance computation between the
+   * query and the encoded database vectors. This should be combined with
+   * sub_distance_query_to_pq_centroid_distance_tables.
+   *
+   *
+   * @param query_vectors Array of query vectors to compute centroid distance
+   * tables for.
+   * @param distance Distance function.
+   *
+   */
   template <
       feature_vector_array U,
       class Matrix,
       class Distance = uncached_sub_sum_of_squares_distance>
-  auto pq_query_centroid_distances(
-      const U& training_set, Distance distance = Distance{}) const {
+  auto generate_query_to_pq_centroid_distance_tables(
+      const U& query_vectors, Distance distance = Distance{}) const {
     auto pq_vectors = std::make_unique<Matrix>(
-        num_subspaces_ * num_clusters_, num_vectors(training_set));
+        num_subspaces_ * num_clusters_, num_vectors(query_vectors));
     auto& pqv = *pq_vectors;
     auto local_distance = Distance{};
-    for (size_t i = 0; i < num_vectors(training_set); ++i) {
+    for (size_t i = 0; i < num_vectors(query_vectors); ++i) {
       auto sub_begin = 0;
       auto sub_id = 0;
       for (size_t subspace = 0; subspace < num_subspaces_; ++subspace) {
@@ -857,7 +886,7 @@ class ivf_pq_index {
         for (size_t centroid_id = 0; centroid_id < num_clusters_;
              ++centroid_id) {
           float pq_distance = local_distance(
-              training_set[i],
+              query_vectors[i],
               cluster_centroids_[centroid_id],
               sub_begin,
               sub_end);
@@ -1303,16 +1332,18 @@ class ivf_pq_index {
     auto&& [active_partitions, active_queries] =
         detail::ivf::partition_ivf_flat_index<indices_type>(
             flat_ivf_centroids_, query_vectors, nprobe, num_threads_);
-    auto query_centroid_distances = std::move(
-        *pq_query_centroid_distances<Q, ColMajorMatrix<float>>(query_vectors));
+    auto query_to_pq_centroid_distance_tables =
+        std::move(*generate_query_to_pq_centroid_distance_tables<
+                  Q,
+                  ColMajorMatrix<float>>(query_vectors));
     return detail::ivf::query_infinite_ram(
         *partitioned_pq_vectors_,
         active_partitions,
-        query_centroid_distances,
+        query_to_pq_centroid_distance_tables,
         active_queries,
         k_nn,
         num_threads_,
-        make_pq_distance_query_centroid_distances<
+        make_pq_distance_query_to_pq_centroid_distance_tables<
             std::span<float>,
             decltype(pq_storage_type{}[0])>());
   }
@@ -1358,16 +1389,19 @@ class ivf_pq_index {
     }
     auto&& [active_partitions, active_queries] =
         read_index_finite(query_vectors, nprobe, upper_bound);
-
+    auto query_to_pq_centroid_distance_tables =
+        std::move(*generate_query_to_pq_centroid_distance_tables<
+                  Q,
+                  ColMajorMatrix<float>>(query_vectors));
     return detail::ivf::query_finite_ram(
         *partitioned_pq_vectors_,
-        query_vectors,
+        query_to_pq_centroid_distance_tables,
         active_queries,
         k_nn,
         upper_bound,
         num_threads_,
-        make_pq_distance_asymmetric<
-            std::span<typename Q::value_type>,
+        make_pq_distance_query_to_pq_centroid_distance_tables<
+            std::span<float>,
             decltype(pq_storage_type{}[0])>());
   }
 

--- a/src/include/test/unit_ivf_pq_index.cc
+++ b/src/include/test/unit_ivf_pq_index.cc
@@ -482,7 +482,7 @@ TEST_CASE("Build index and query in place, infinite", "[ivf_pq_index]") {
   using s = siftsmall_test_init_defaults;
   using index = ivf_pq_index<s::feature_type, s::id_type, s::px_type>;
 
-  auto init = siftsmall_test_init<index>(ctx, nlist, 32);
+  auto init = siftsmall_test_init<index>(ctx, nlist, 16);
 
   auto&& [nprobe, k_nn, nthreads, max_iterations, convergence_tolerance] =
       std::tie(

--- a/src/include/test/unit_ivf_pq_index.cc
+++ b/src/include/test/unit_ivf_pq_index.cc
@@ -482,7 +482,7 @@ TEST_CASE("Build index and query in place, infinite", "[ivf_pq_index]") {
   using s = siftsmall_test_init_defaults;
   using index = ivf_pq_index<s::feature_type, s::id_type, s::px_type>;
 
-  auto init = siftsmall_test_init<index>(ctx, nlist, 16);
+  auto init = siftsmall_test_init<index>(ctx, nlist, 32);
 
   auto&& [nprobe, k_nn, nthreads, max_iterations, convergence_tolerance] =
       std::tie(


### PR DESCRIPTION
Implemented a new query to quantized vectors distance implementation that is:
- Computing distance tables between each query and each pq_centroid
- Uses the query distance tables during query-vector distance computations

Tested the performance of all methods using SIFT-1M:
- asymmetric(previous default)
![query_time_vs_accuracy](https://github.com/user-attachments/assets/f750b222-783e-437e-9c53-1d28d6db7318)
- symmetric: 
  - ~1,3x speedup, accuracy reduction
![query_time_vs_accuracy](https://github.com/user-attachments/assets/89c0dbf4-08a8-4392-b7f2-d298ed9c2a4d)
- new distance based on query to pq_centroid distance tables: 
  - more than 2x speedup, no accuracy reduction 
![query_time_vs_accuracy](https://github.com/user-attachments/assets/9a6db919-e3cf-46ba-8618-d7e2d3c3d26b)

When comparing latency for a larger dataset of 60M vectors of 200 dimensions, the original latency was ~100s and after this it is 9s.