### PR TITLE
Enable more benchmarks in ann-benchmarks script

### DIFF
--- a/src/benchmarks/ann-benchmarks.py
+++ b/src/benchmarks/ann-benchmarks.py
@@ -19,31 +19,25 @@ import boto3
 import paramiko
 
 installations = ["tiledb"]
-algorithms = [
-    "tiledb-ivf-flat",
-    "tiledb-ivf-pq",
-    "tiledb-flat",
-    # NOTE(paris): Commented out until Vamana disk space usage is optimized.
-    # "tiledb-vamana"
-]
+algorithms = ["tiledb-ivf-flat", "tiledb-ivf-pq", "tiledb-flat", "tiledb-vamana"]
 
 also_benchmark_others = True
 if also_benchmark_others:
     # TODO(paris): Some of these are failing so commented out. Investigate and re-enable.
     installations += [
-        # "flann",
-        # "faiss",
-        # "hnswlib",
+        "flann",
+        "faiss",
+        "hnswlib",
         # "weaviate"
         # "milvus",
-        "pgvector"
+        "pgvector",
     ]
     algorithms += [
-        # "flann",
-        # "faiss-ivf",
+        "flann",
+        "faiss-ivf",
         # "faiss-lsh",
-        # "faiss-ivfpqfs",
-        # "hnswlib",
+        "faiss-ivfpqfs",
+        "hnswlib",
         # "weaviate",
         # "milvus-flat",
         # "milvus-ivfflat",


### PR DESCRIPTION
### What
More benchmarks are working now, including Vamana b/c of the fix to enable compression of TileDB Arrays, so enable them.

### Testing
We now end up with:

![sift-128-euclidean_10_euclidean-batch](https://github.com/user-attachments/assets/6b8561e7-beaa-4c21-877c-ccb2a4b561ed)
