### PR TITLE
Add dump() methods to logging classes

### DIFF
--- a/src/include/test/unit_logging.cc
+++ b/src/include/test/unit_logging.cc
@@ -321,3 +321,15 @@ TEST_CASE("highly concurrent count test", "[logging][count_data]") {
   auto f = _count_data.get_entries_summed(timer_name);
   CHECK(f >= num_threads * num_iterations);
 }
+
+TEST_CASE("dump", "[logging]") {
+  _timing_data.insert_entry(
+      "a",
+      std::chrono::high_resolution_clock::now() -
+          std::chrono::high_resolution_clock::now());
+  _count_data.insert_entry("b", 1);
+  _memory_data.insert_entry("c", 2);
+  std::cout << _timing_data.dump();
+  std::cout << _count_data.dump();
+  std::cout << _memory_data.dump();
+}

--- a/src/include/utils/logging.h
+++ b/src/include/utils/logging.h
@@ -166,19 +166,12 @@ class timing_data_class {
    * Return a reference to the singleton instance.
    * @return The singleton instance.
    */
-  // static timing_data_class& get_instance() {
-  //   static timing_data_class instance;
-  //   return instance;
-  // }
-
   static timing_data_class& get_instance() {
-      static std::once_flag flag;
-      // This will leak, but it's okay - it's the Trusty Leaky Singleton pattern.
-      static timing_data_class* instance;
-      std::call_once(flag, []() {
-          instance = new timing_data_class();
-      });
-      return *instance;
+    static std::once_flag flag;
+    // This will leak, but it's okay - it's the Trusty Leaky Singleton pattern.
+    static timing_data_class* instance;
+    std::call_once(flag, []() { instance = new timing_data_class(); });
+    return *instance;
   }
 
   /**
@@ -393,33 +386,13 @@ class memory_data {
    * Get a reference to the singleton instance of the class.
    * @return Reference to the singleton instance of the class.
    */
-  // static memory_data& get_instance() {
-  //   // std::cout << "[memory_data@get_instance]" << std::endl;
-  //   static memory_data instance;
-  //   return instance;
-  // }
-
   static memory_data& get_instance() {
     static std::once_flag flag;
     // This will leak, but it's okay - it's the Trusty Leaky Singleton pattern.
     static memory_data* instance;
-    std::call_once(flag, []() {
-        instance = new memory_data();
-    });
+    std::call_once(flag, []() { instance = new memory_data(); });
     return *instance;
   }
-
-  // static memory_data& get_instance() {
-  //   std::cout << "[memory_data@get_instance]" << std::endl;
-  //     static std::once_flag flag;
-  //     static std::unique_ptr<memory_data> instance;
-  //     std::call_once(flag, []() {
-  //         instance.reset(new memory_data());
-  //     });
-  //     std::cout << "[memory_data@get_instance] instance: " << instance << std::endl;
-  //     return *instance;
-  // }
-
 
   /**
    * Insert a memory consumption entry into the multimap.
@@ -531,30 +504,13 @@ class count_data {
    * Get a reference to the singleton instance of the class.
    * @return Reference to the singleton instance of the class.
    */
-  // static count_data& get_instance() {
-  //   static count_data instance;
-  //   return instance;
-  // }
-
   static count_data& get_instance() {
-      std::cout << "[count_data@get_instance]" << std::endl;
-      static std::once_flag flag;
-      // This will leak, but it's okay - it's the Trusty Leaky Singleton pattern.
-      static count_data* instance;
-      std::call_once(flag, []() {
-          instance = new count_data();
-      });
-      return *instance;
+    static std::once_flag flag;
+    // This will leak, but it's okay - it's the Trusty Leaky Singleton pattern.
+    static count_data* instance;
+    std::call_once(flag, []() { instance = new count_data(); });
+    return *instance;
   }
-
-  // static count_data& get_instance() {
-  //     static std::once_flag flag;
-  //     static std::unique_ptr<count_data> instance;
-  //     std::call_once(flag, []() {
-  //         instance.reset(new count_data());
-  //     });
-  //     return *instance;
-  // }
 
   /**
    * Insert a count entry into the multimap.

--- a/src/include/utils/logging.h
+++ b/src/include/utils/logging.h
@@ -166,9 +166,19 @@ class timing_data_class {
    * Return a reference to the singleton instance.
    * @return The singleton instance.
    */
+  // static timing_data_class& get_instance() {
+  //   static timing_data_class instance;
+  //   return instance;
+  // }
+
   static timing_data_class& get_instance() {
-    static timing_data_class instance;
-    return instance;
+      static std::once_flag flag;
+      // This will leak, but it's okay - it's the Trusty Leaky Singleton pattern.
+      static timing_data_class* instance;
+      std::call_once(flag, []() {
+          instance = new timing_data_class();
+      });
+      return *instance;
   }
 
   /**
@@ -383,10 +393,33 @@ class memory_data {
    * Get a reference to the singleton instance of the class.
    * @return Reference to the singleton instance of the class.
    */
+  // static memory_data& get_instance() {
+  //   // std::cout << "[memory_data@get_instance]" << std::endl;
+  //   static memory_data instance;
+  //   return instance;
+  // }
+
   static memory_data& get_instance() {
-    static memory_data instance;
-    return instance;
+    static std::once_flag flag;
+    // This will leak, but it's okay - it's the Trusty Leaky Singleton pattern.
+    static memory_data* instance;
+    std::call_once(flag, []() {
+        instance = new memory_data();
+    });
+    return *instance;
   }
+
+  // static memory_data& get_instance() {
+  //   std::cout << "[memory_data@get_instance]" << std::endl;
+  //     static std::once_flag flag;
+  //     static std::unique_ptr<memory_data> instance;
+  //     std::call_once(flag, []() {
+  //         instance.reset(new memory_data());
+  //     });
+  //     std::cout << "[memory_data@get_instance] instance: " << instance << std::endl;
+  //     return *instance;
+  // }
+
 
   /**
    * Insert a memory consumption entry into the multimap.
@@ -498,10 +531,30 @@ class count_data {
    * Get a reference to the singleton instance of the class.
    * @return Reference to the singleton instance of the class.
    */
+  // static count_data& get_instance() {
+  //   static count_data instance;
+  //   return instance;
+  // }
+
   static count_data& get_instance() {
-    static count_data instance;
-    return instance;
+      std::cout << "[count_data@get_instance]" << std::endl;
+      static std::once_flag flag;
+      // This will leak, but it's okay - it's the Trusty Leaky Singleton pattern.
+      static count_data* instance;
+      std::call_once(flag, []() {
+          instance = new count_data();
+      });
+      return *instance;
   }
+
+  // static count_data& get_instance() {
+  //     static std::once_flag flag;
+  //     static std::unique_ptr<count_data> instance;
+  //     std::call_once(flag, []() {
+  //         instance.reset(new count_data());
+  //     });
+  //     return *instance;
+  // }
 
   /**
    * Insert a count entry into the multimap.


### PR DESCRIPTION
### What
Adds easy ways to print out timing / memory usage to a string.

### testing
Memory:
```
virtual bool tdbBlockedMatrix<float, Kokkos::layout_left, unsigned long, MatrixWithIds<float, unsigned char, Kokkos::layout_left>>::load() [T = float, LayoutPolicy = Kokkos::layout_left, I = unsigned long, MatrixBase = MatrixWithIds<float, unsigned char, Kokkos::layout_left>]: count: 1, sum: 390.62 KiB, avg: 390.62 KiB
virtual bool tdbBlockedMatrix<float, Kokkos::layout_left>::load() [T = float, LayoutPolicy = Kokkos::layout_left, I = unsigned long, MatrixBase = Matrix<float, Kokkos::layout_left>]: count: 5, sum: 1.91 MiB, avg: 390.62 KiB
virtual bool tdbBlockedMatrix<unsigned char, Kokkos::layout_left>::load() [T = unsigned char, LayoutPolicy = Kokkos::layout_left, I = unsigned long, MatrixBase = Matrix<unsigned char, Kokkos::layout_left>]: count: 3, sum: 292.97 KiB, avg: 97.66 KiB
virtual bool tdbBlockedMatrix<float, Kokkos::layout_left, unsigned long, MatrixWithIds<float, unsigned char, Kokkos::layout_left>>::load() [T = float, LayoutPolicy = Kokkos::layout_left, I = unsigned long, MatrixBase = MatrixWithIds<float, unsigned char, Kokkos::layout_left>]: count: 1, sum: 390.62 KiB, avg: 390.62 KiB
virtual bool tdbBlockedMatrix<float, Kokkos::layout_left>::load() [T = float, LayoutPolicy = Kokkos::layout_left, I = unsigned long, MatrixBase = Matrix<float, Kokkos::layout_left>]: count: 5, sum: 1.91 MiB, avg: 390.62 KiB
virtual bool tdbBlockedMatrix<unsigned char, Kokkos::layout_left>::load() [T = unsigned char, LayoutPolicy = Kokkos::layout_left, I = unsigned long, MatrixBase = Matrix<unsigned char, Kokkos::layout_left>]: count: 4, sum: 390.62 KiB, avg: 97.66 KiB
```

Timing - I used this to look at which of the Vamana greedy search algorithms was faster:
```
auto greedy_search_O1(auto &&, auto &&, typename std::decay_t<decltype(graph)>::id_type, auto &&, size_t, uint32_t, Distance &&, bool) [Distance = _l2_distance::sum_of_squares_distance, graph:auto = detail::graph::adj_list<float, int> &, db:auto = MatrixWithIds<float, unsigned long long, Kokkos::layout_left> &, query:auto = std::span<float>]: count: 2, sum: 147.88 µs, avg: 73.94 µs
greedy_search_O0: count: 1, sum: 160.71 µs, avg: 160.71 µs
greedy_search_O1: count: 1, sum: 88.17 µs, avg: 88.17 µs
greedy_search_O2: count: 1, sum: 159.25 µs, avg: 159.25 µs
```

Count:
```
highly_concurrent_count_test: count: 2000, sum: 2000, avg: 1
multithreaded_count_test1: count: 10, sum: 10, avg: 1
multithreaded_count_test2: count: 10, sum: 20, avg: 2
```