### PR TITLE
Add more testing for Vamana helpers, add option to skip top_k to improve ingestion speed

### DIFF
--- a/src/include/detail/graph/adj_list.h
+++ b/src/include/detail/graph/adj_list.h
@@ -178,6 +178,20 @@ class adj_list : public std::vector<std::list<std::tuple<SC, ID>>> {
   constexpr auto num_edges() const {
     return num_edges_;
   }
+
+  std::string dump(const std::string& msg = "adj_list") const {
+    std::string s;
+    s += msg + " (vertices: " + std::to_string(num_vertices()) +
+         ", edges: " + std::to_string(num_edges()) + ")\n";
+    for (size_t i = 0; i < num_vertices(); ++i) {
+      s += "  " + std::to_string(i) + ": ";
+      for (const auto& [val, dst] : out_edges(i)) {
+        s += std::to_string(dst) + "(" + std::to_string(val) + ") ";
+      }
+      s += "\n";
+    }
+    return s;
+  }
 };
 
 template <class T, std::integral I>

--- a/src/include/detail/graph/best_first.h
+++ b/src/include/detail/graph/best_first.h
@@ -413,8 +413,6 @@ auto best_first_O3(
     // Extract vertex with minimum score from frontier
     auto [_, p_star] = frontier.front();
 
-    auto debug_p_star = p_star;
-
     auto p_star_iter = vertex_state_map.find(p_star);
     if (p_star_iter == vertex_state_map.end()) {
       throw std::runtime_error(
@@ -470,7 +468,6 @@ auto best_first_O3(
           continue;
         }
       }
-      auto debug_neighbor_state = neighbor_state_iter->second;
 
       score_type heuristic = distance(db[neighbor_id], query);
 
@@ -541,9 +538,6 @@ auto best_first_O4(
     uint32_t Lmax,
     bool skip_top_k = false,
     Distance&& distance = Distance{}) {
-  scoped_timer __{"[best_first_O4][1] outer"};
-  debug_vector(query, "query");
-
   using id_type = typename std::decay_t<Graph>::id_type;
   using score_type = float;
 
@@ -565,7 +559,7 @@ auto best_first_O4(
   // Will be returned from this function
   std::unordered_set<id_type> visited;
 
-  //  scoped_timer __{tdb_func__};
+  scoped_timer __{tdb_func__};
 
   score_type heuristic = distance(db[source], query);
   pq.insert(heuristic, source);
@@ -573,17 +567,11 @@ auto best_first_O4(
 
   id_type p_star = source;
   set_enfrontiered(vertex_state_property_map[p_star]);
-  // debug_vector(vertex_state_property_map, "vertex_state_property_map A");
   do {
-    scoped_timer _2{"[best_first_O4][2] do loop"};
-    // std::cout << "[best_first_O4] p_star: " << p_star << std::endl;
     visited.insert(p_star);
-    // debug_unordered_set(visited, "[best_first_O4] visited");
     set_visited(vertex_state_property_map[p_star]);
 
-    scoped_timer _2a{"[best_first_O4][2a] do loop"};
     for (auto&& [_, neighbor_id] : graph[p_star]) {
-      scoped_timer _3{"[best_first_O4][3a] for graph loop"};
       auto neighbor_state = vertex_state_property_map[neighbor_id];
       if (!is_unvisited(neighbor_state)) {
         continue;
@@ -596,10 +584,6 @@ auto best_first_O4(
             std::to_string(::num_vectors(db)) + ")");
       }
       score_type heuristic = distance(db[neighbor_id], query);
-      // std::cout << "[best_first_O4] neighbor_id: " << neighbor_id <<
-      // std::endl; debug_vector(db[neighbor_id], "[best_first_O4] neighbor_id
-      // vector"); std::cout << "[best_first_O4] distance from neighbor to
-      // query: " << heuristic << std::endl;
 
       auto [inserted, evicted, evicted_score, evicted_id] =
           // pq.template evict_insert<unique_id>(heuristic, neighbor_id);
@@ -617,13 +601,8 @@ auto best_first_O4(
         set_evicted(vertex_state_property_map[neighbor_id]);
         clear_enpqd(vertex_state_property_map[neighbor_id]);
       }
-      // std::cout << "[best_first_O4] -- " << std::endl;
     }
-    // debug_vector(vertex_state_property_map, "vertex_state_property_map B");
-    scoped_timer _2b{"[best_first_O4][2b] do loop"};
     clear_enfrontiered(vertex_state_property_map[p_star]);
-    // debug_vector(vertex_state_property_map, "vertex_state_property_map C");
-    //    std::cout << "p_star " << p_star << std::endl;
     if (!is_visited(vertex_state_property_map[p_star])) {
       throw std::runtime_error(
           "[best_first@best_first_O4] p_star is not visited");
@@ -635,12 +614,10 @@ auto best_first_O4(
       throw std::runtime_error(
           "[best_first@best_first_O4] p_star is enfrontiered");
     }
-    scoped_timer _2c{"[best_first_O4][2c] do loop"};
     p_star = std::numeric_limits<id_type>::max();
     auto p_min_score = std::numeric_limits<score_type>::max();
 
     for (auto&& [pq_score, pq_id] : pq) {
-      scoped_timer _3{"[best_first_O4][3b] for graph loop 2"};
       if (pq_score < p_min_score) {
         auto pq_state = vertex_state_property_map[pq_id];
 
@@ -658,11 +635,9 @@ auto best_first_O4(
         }
       }
     }
-    std::cout << "[best_first_O4] --------------------- " << std::endl;
     // set_finished(vertex_state_property_map[p_star]);
   } while (p_star != std::numeric_limits<id_type>::max());
 
-  scoped_timer _4{"[best_first_O4][4] final part"};
   if (skip_top_k) {
     auto top_k = std::vector<id_type>(0);
     auto top_k_scores = std::vector<score_type>(0);
@@ -673,7 +648,6 @@ auto best_first_O4(
   auto top_k = std::vector<id_type>(k_nn);
   auto top_k_scores = std::vector<score_type>(k_nn);
   get_top_k_with_scores_from_heap(pq, top_k, top_k_scores);
-  // debug_vector(vertex_state_property_map, "vertex_state_property_map final");
   return std::make_tuple(
       std::move(top_k_scores), std::move(top_k), std::move(visited));
 }
@@ -747,7 +721,6 @@ auto best_first_O5(
           continue;
         }
       }
-      auto debug_neighbor_state = neighbor_state_iter->second;
 
       score_type heuristic = distance(db[neighbor_id], query);
 

--- a/src/include/detail/graph/best_first.h
+++ b/src/include/detail/graph/best_first.h
@@ -51,7 +51,7 @@ template <
     feature_vector_array A,
     feature_vector V,
     class Distance = sum_of_squares_distance>
-auto best_first_O0(
+std::unordered_set<typename std::decay_t<Graph>::id_type> best_first_O0(
     const Graph& graph,
     const A& db,
     typename std::decay_t<Graph>::id_type source,
@@ -91,7 +91,7 @@ template <
     feature_vector_array A,
     feature_vector V,
     class Distance = sum_of_squares_distance>
-auto best_first_O1(
+std::unordered_set<typename std::decay_t<Graph>::id_type> best_first_O1(
     const Graph& graph,
     const A& db,
     typename std::decay_t<Graph>::id_type source,

--- a/src/include/detail/graph/best_first.h
+++ b/src/include/detail/graph/best_first.h
@@ -567,6 +567,7 @@ auto best_first_O4(
 
   id_type p_star = source;
   set_enfrontiered(vertex_state_property_map[p_star]);
+
   do {
     visited.insert(p_star);
     set_visited(vertex_state_property_map[p_star]);
@@ -614,6 +615,7 @@ auto best_first_O4(
       throw std::runtime_error(
           "[best_first@best_first_O4] p_star is enfrontiered");
     }
+
     p_star = std::numeric_limits<id_type>::max();
     auto p_min_score = std::numeric_limits<score_type>::max();
 
@@ -635,6 +637,7 @@ auto best_first_O4(
         }
       }
     }
+
     // set_finished(vertex_state_property_map[p_star]);
   } while (p_star != std::numeric_limits<id_type>::max());
 

--- a/src/include/detail/graph/best_first.h
+++ b/src/include/detail/graph/best_first.h
@@ -539,6 +539,7 @@ auto best_first_O4(
     const V& query,
     size_t k_nn,
     uint32_t Lmax,
+    bool skip_top_k = false,
     Distance&& distance = Distance{}) {
   scoped_timer __{"[best_first_O4][1] outer"};
   debug_vector(query, "query");
@@ -564,7 +565,7 @@ auto best_first_O4(
   // Will be returned from this function
   std::unordered_set<id_type> visited;
 
-  scoped_timer __{tdb_func__};
+  //  scoped_timer __{tdb_func__};
 
   score_type heuristic = distance(db[source], query);
   pq.insert(heuristic, source);
@@ -662,10 +663,17 @@ auto best_first_O4(
   } while (p_star != std::numeric_limits<id_type>::max());
 
   scoped_timer _4{"[best_first_O4][4] final part"};
+  if (skip_top_k) {
+    auto top_k = std::vector<id_type>(0);
+    auto top_k_scores = std::vector<score_type>(0);
+    return std::make_tuple(
+        std::move(top_k_scores), std::move(top_k), std::move(visited));
+  }
+
   auto top_k = std::vector<id_type>(k_nn);
   auto top_k_scores = std::vector<score_type>(k_nn);
-  // debug_vector(vertex_state_property_map, "vertex_state_property_map final");
   get_top_k_with_scores_from_heap(pq, top_k, top_k_scores);
+  // debug_vector(vertex_state_property_map, "vertex_state_property_map final");
   return std::make_tuple(
       std::move(top_k_scores), std::move(top_k), std::move(visited));
 }

--- a/src/include/detail/graph/greedy_search.h
+++ b/src/include/detail/graph/greedy_search.h
@@ -56,7 +56,7 @@ static inline bool noisy_robust_prune = false;
  * @brief Developmental code for performance analysis / optimization of
  * greedy search. "O1" is the OG.
  */
-template </* SearchPath SP, */ class Distance = sum_of_squares_distance>
+template <class Distance = sum_of_squares_distance>
 auto greedy_search_O2(
     auto&& graph,
     auto&& db,
@@ -163,7 +163,7 @@ auto greedy_search_O2(
  * @param distance distance functor
  * @return top_k_scores, top_k, visited vertices
  */
-template </* SearchPath SP, */ class Distance = sum_of_squares_distance>
+template <class Distance = sum_of_squares_distance>
 auto greedy_search_O0(
     auto&& graph,
     auto&& db,
@@ -280,10 +280,9 @@ auto greedy_search_O0(
  *
  * @todo -- add a `SearchPath `template parameter to determine whether to
  * return the top k results of the search or just the path taken.
- * @todo -- remove printf debugging code
  * @todo -- would it be more efficient somehow to process multiple queries?
  */
-template </* SearchPath SP, */ class Distance = sum_of_squares_distance>
+template <class Distance = sum_of_squares_distance>
 auto greedy_search_O1(
     auto&& graph,
     auto&& db,
@@ -415,8 +414,6 @@ auto greedy_search_O1(
     q2.clear();
   }
 
-  // auto top_k = Vector<id_type>(k_nn);
-  // auto top_k_scores = Vector<score_type>(k_nn);
   auto top_k = std::vector<id_type>(k_nn);
   auto top_k_scores = std::vector<score_type>(k_nn);
 
@@ -436,7 +433,7 @@ auto greedy_search_O1(
       std::move(top_k_scores), std::move(top_k), std::move(visited_vertices));
 }
 
-template </* SearchPath SP, */ class Distance = sum_of_squares_distance>
+template <class Distance = sum_of_squares_distance>
 auto greedy_search(
     auto&& graph,
     auto&& db,

--- a/src/include/detail/linalg/set.h
+++ b/src/include/detail/linalg/set.h
@@ -32,6 +32,8 @@
 #ifndef TILEDB_SET_H
 #define TILEDB_SET_H
 
+#include <unordered_set>
+
 template <typename T>
 void debug_unordered_set(
     const std::unordered_set<T>& s,

--- a/src/include/detail/linalg/set.h
+++ b/src/include/detail/linalg/set.h
@@ -33,30 +33,33 @@
 #define TILEDB_SET_H
 
 template <typename T>
-void debug_unordered_set(const std::unordered_set<T>& s, const std::string& msg = "", size_t max_size = 10) {
-    if (s.empty()) {
-        std::cout << msg << ": (empty)\n";
-        return;
+void debug_unordered_set(
+    const std::unordered_set<T>& s,
+    const std::string& msg = "",
+    size_t max_size = 10) {
+  if (s.empty()) {
+    std::cout << msg << ": (empty)\n";
+    return;
+  }
+
+  size_t end = std::min(max_size, s.size());
+  if (!msg.empty()) {
+    std::cout << msg << ": ";
+  }
+  std::cout << "[";
+  size_t i = 0;
+  for (const auto& val : s) {
+    std::cout << val;
+    if (i >= end) {
+      std::cout << "...";
+      break;
     }
-    
-    size_t end = std::min(max_size, s.size());
-    if (!msg.empty()) {
-        std::cout << msg << ": ";
+    if (i != end - 1) {
+      std::cout << ", ";
     }
-    std::cout << "[";
-    size_t i = 0;
-    for (const auto& val: s) {
-        std::cout << val;
-        if (i >= end) {
-            std::cout << "...";
-            break;
-        }
-        if (i != end -  1) {
-            std::cout << ", ";
-        }
-        i++;
-    }
-    std::cout << "]\n";
+    i++;
+  }
+  std::cout << "]\n";
 }
 
 #endif  // TILEDB_SET_H

--- a/src/include/detail/linalg/set.h
+++ b/src/include/detail/linalg/set.h
@@ -1,0 +1,62 @@
+/**
+ * @file set.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ */
+
+#ifndef TILEDB_SET_H
+#define TILEDB_SET_H
+
+template <typename T>
+void debug_unordered_set(const std::unordered_set<T>& s, const std::string& msg = "", size_t max_size = 10) {
+    if (s.empty()) {
+        std::cout << msg << ": (empty)\n";
+        return;
+    }
+    
+    size_t end = std::min(max_size, s.size());
+    if (!msg.empty()) {
+        std::cout << msg << ": ";
+    }
+    std::cout << "[";
+    size_t i = 0;
+    for (const auto& val: s) {
+        std::cout << val;
+        if (i >= end) {
+            std::cout << "...";
+            break;
+        }
+        if (i != end -  1) {
+            std::cout << ", ";
+        }
+        i++;
+    }
+    std::cout << "]\n";
+}
+
+#endif  // TILEDB_SET_H

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -354,16 +354,15 @@ class vamana_index {
       for (size_t p = 0; p < num_vectors_; ++p) {
         ++counter;
 
-        // Do not need top_k or top_k scores here -- use path_only enum
-        auto&& [top_k_scores, top_k, visited] =
-            ::best_first_O4 /*greedy_search*/ (
-                graph_,
-                feature_vectors_,
-                medoid_,
-                feature_vectors_[p],
-                1,
-                l_build_,
-                distance);
+        auto&& [_, __, visited] = ::best_first_O4 /*greedy_search*/ (
+            graph_,
+            feature_vectors_,
+            medoid_,
+            feature_vectors_[p],
+            1,
+            l_build_,
+            true,
+            distance);
         total_visited += visited.size();
 
         robust_prune(

--- a/src/include/test/CMakeLists.txt
+++ b/src/include/test/CMakeLists.txt
@@ -62,6 +62,8 @@ endmacro (kmeans_add_test)
 
 kmeans_add_exe(time_scoring)
 
+kmeans_add_test(unit_best_first)
+
 kmeans_add_test(unit_vamana_index)
 
 kmeans_add_test(unit_vamana_group)

--- a/src/include/test/unit_best_first.cc
+++ b/src/include/test/unit_best_first.cc
@@ -1,0 +1,127 @@
+/**
+ * @file unit_best_first.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ *
+ */
+
+#include <catch2/catch_all.hpp>
+#include "cpos.h"
+#include "detail/flat/qv.h"
+#include "detail/graph/adj_list.h"
+#include "detail/graph/diskann.h"
+#include "detail/graph/nn-descent.h"
+#include "detail/graph/nn-graph.h"
+#include "detail/graph/best_first.h"
+#include "detail/linalg/tdb_io.h"
+#include "index/vamana_index.h"
+#include "test/utils/array_defs.h"
+#include "test/utils/gen_graphs.h"
+#include "test/utils/test_utils.h"
+#include "test/utils/tiny_graphs.h"
+#include "utils/logging.h"
+#include "utils/utils.h"
+#include <filesystem>
+#include <tiledb/tiledb>
+
+namespace fs = std::filesystem;
+
+TEST_CASE("best first", "[best_first]") {
+  size_t num_vertices = 5;
+  detail::graph::adj_list<size_t, size_t> graph(num_vertices);
+  for (size_t src = 0; src < num_vertices; ++src) {
+    for (size_t dst = 0; dst < num_vertices; ++dst) {
+      size_t score = static_cast<size_t>(std::pow(static_cast<int>(src) - static_cast<int>(dst), 2));
+      graph.add_edge(src, dst, score);
+    }
+  }
+  CHECK(detail::graph::num_vertices(graph) == num_vertices);
+  CHECK(graph.num_vertices() == num_vertices);
+  std::vector<std::tuple<size_t, size_t>> expected = {{0, 0}, {1, 1}, {4, 2}, {9, 3}, {16, 4}};
+  CHECK(std::equal(expected.begin(), expected.end(), graph.out_edges(0).begin()));
+
+  auto feature_vectors = ColMajorMatrixWithIds<float, size_t>{{
+    {1.f, 1.f, 1.f}, {2.f, 2.f, 2.f}, {3.f, 3.f, 3.f}, {4.f, 4.f, 4.f}, {5.f, 5.f, 5.f}}, 
+    {1, 2, 3, 4, 5}
+  };
+
+
+  size_t k_nn = 1;
+  size_t source = 0;
+  {
+    auto visited = best_first_O0(
+                  graph,
+                  feature_vectors,
+                  source,
+                  feature_vectors[0]);
+    CHECK(visited == std::unordered_set<size_t>{0, 1, 2, 3, 4});
+  }
+
+  {
+    auto visited = best_first_O1(
+                  graph,
+                  feature_vectors,
+                  source,
+                  feature_vectors[0]);
+    CHECK(visited == std::unordered_set<size_t>{0, 1, 2, 3, 4});
+  }
+
+  // NOTE: Here is where you would expect to also test best_first_O2 and best_first_O3, but they do  not compile. We'll leave them for now, but eventually we should either remove them or get them building.
+
+  // Test best_first_O4 when used normally.
+  for (size_t l_max = 1; l_max < 6; ++l_max) {
+    auto&& [top_k_scores, top_k, visited] = best_first_O4(
+                  graph,
+                  feature_vectors,
+                  source,
+                  feature_vectors[0],
+                  k_nn,
+                  l_max);
+    
+    if (l_max == 1) {
+      CHECK(visited == std::unordered_set<size_t>{0});
+    }
+    if (l_max == 2) {
+      CHECK(visited == std::unordered_set<size_t>{0, 1});
+    }
+    if (l_max == 3) {
+      CHECK(visited == std::unordered_set<size_t>{0, 1, 2});
+    }
+    if (l_max == 4) {
+      CHECK(visited == std::unordered_set<size_t>{0, 1, 2, 3});
+    }
+    if (l_max == 5) {
+      CHECK(visited == std::unordered_set<size_t>{0, 1, 2, 3, 4});
+    }
+    CHECK(top_k_scores[0] == 0);
+    CHECK(top_k[0] == 0);
+  }
+
+  // Test best_first_O4 when with skip_top_k = True.
+
+}

--- a/src/include/test/unit_best_first.cc
+++ b/src/include/test/unit_best_first.cc
@@ -32,31 +32,17 @@
 
 #include <catch2/catch_all.hpp>
 #include <filesystem>
-#include <tiledb/tiledb>
-#include "cpos.h"
-#include "detail/flat/qv.h"
 #include "detail/graph/adj_list.h"
 #include "detail/graph/best_first.h"
-#include "detail/graph/diskann.h"
-#include "detail/graph/nn-descent.h"
-#include "detail/graph/nn-graph.h"
-#include "detail/linalg/tdb_io.h"
-#include "index/vamana_index.h"
-#include "test/utils/array_defs.h"
 #include "test/utils/gen_graphs.h"
-#include "test/utils/test_utils.h"
 #include "test/utils/tiny_graphs.h"
-#include "utils/logging.h"
-#include "utils/utils.h"
-
-namespace fs = std::filesystem;
 
 TEST_CASE("best first", "[best_first]") {
   size_t num_vertices = 5;
   detail::graph::adj_list<size_t, size_t> graph(num_vertices);
   for (size_t src = 0; src < num_vertices; ++src) {
     for (size_t dst = 0; dst < num_vertices; ++dst) {
-      size_t score = static_cast<size_t>(
+      auto score = static_cast<size_t>(
           std::pow(static_cast<int>(src) - static_cast<int>(dst), 2));
       graph.add_edge(src, dst, score);
     }
@@ -121,7 +107,7 @@ TEST_CASE("best first", "[best_first]") {
     }
     CHECK(visited == expected_visited);
     // In this case we do not compute top_k and so these are empty.
-    CHECK(top_k_scores.size() == 0);
-    CHECK(top_k.size() == 0);
+    CHECK(top_k_scores.empty());
+    CHECK(top_k.empty());
   }
 }

--- a/src/include/test/unit_best_first.cc
+++ b/src/include/test/unit_best_first.cc
@@ -96,6 +96,21 @@ TEST_CASE("best first", "[best_first]") {
     CHECK(top_k[0] == 0);
   }
 
+  for (size_t l_max = 1; l_max < 6; ++l_max) {
+    auto&& [top_k_scores, top_k, visited] = best_first_O5(
+        graph, feature_vectors, source, feature_vectors[0], k_nn, l_max);
+
+    std::unordered_set<size_t> expected_visited;
+    for (size_t i = 0; i < l_max; ++i) {
+      expected_visited.insert(i);
+    }
+    CHECK(visited == expected_visited);
+    CHECK(top_k_scores.size() == k_nn);
+    CHECK(top_k.size() == k_nn);
+    CHECK(top_k_scores[0] == 0);
+    CHECK(top_k[0] == 0);
+  }
+
   // Test best_first_O4 when with skip_top_k=true.
   for (size_t l_max = 1; l_max < 6; ++l_max) {
     auto&& [top_k_scores, top_k, visited] = best_first_O4(

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -357,10 +357,20 @@ TEST_CASE("small greedy search", "[vamana]") {
       CHECK(top_k_scores[i] == expected_scores[i]);
     }
   }
-  set_noisy(noisy);
   {
     auto&& [top_k_scores, top_k, visited] =
         greedy_search_O1(graph, x, med, x[query_id], k, L);
+    CHECK(size(top_k) == k);
+    CHECK(size(top_k_scores) == k);
+    CHECK(size(visited) == size(expected));
+    for (size_t i = 0; i < k; ++i) {
+      CHECK(top_k[i] == expected[i]);
+      CHECK(top_k_scores[i] == expected_scores[i]);
+    }
+  }
+  {
+    auto&& [top_k_scores, top_k, visited] =
+        greedy_search_O2(graph, x, med, x[query_id], k, L);
     CHECK(size(top_k) == k);
     CHECK(size(top_k_scores) == k);
     CHECK(size(visited) == size(expected));
@@ -874,24 +884,35 @@ TEST_CASE("fmnist compare greedy search", "[vamana]") {
       greedy_search_O0(g, db, 0UL, query, k_nn, L);
   auto&& [top_k_scores_O1, top_k_O1, V_O1] =
       greedy_search_O1(g, db, 0UL, query, k_nn, L);
+  auto&& [top_k_scores_O2, top_k_O2, V_O2] =
+      greedy_search_O2(g, db, 0UL, query, k_nn, L);
 
   CHECK(top_k_scores_O0 == top_k_scores_O1);
   CHECK(top_k_O0 == top_k_O1);
   CHECK(V_O0 == V_O1);
 
+  CHECK(top_k_scores_O0 == top_k_scores_O2);
+  CHECK(top_k_O0 == top_k_O2);
+  CHECK(V_O0 == V_O2);
+
   auto top_n_O0 = ColMajorMatrix<size_t>(k_nn, 1);
   auto top_n_O1 = ColMajorMatrix<size_t>(k_nn, 1);
+  auto top_n_O2 = ColMajorMatrix<size_t>(k_nn, 1);
   for (size_t i = 0; i < k_nn; ++i) {
     top_n_O0(i, 0) = top_k_O0[i];
     top_n_O1(i, 0) = top_k_O1[i];
+    top_n_O2(i, 0) = top_k_O2[i];
   }
   auto num_intersected_O0 = count_intersections(top_n_O0, qv_top_k, k_nn);
   auto num_intersected_O1 = count_intersections(top_n_O1, qv_top_k, k_nn);
-  CHECK(num_intersected_O0 == num_intersected_O1);
+  auto num_intersected_O2 = count_intersections(top_n_O2, qv_top_k, k_nn);
+  CHECK(num_intersected_O0 == num_intersected_O2);
   if (debug) {
     std::cout << "num intersected_O0: " << num_intersected_O0 << " / " << L
               << std::endl;
     std::cout << "num intersected_O1: " << num_intersected_O1 << " / " << L
+              << std::endl;
+    std::cout << "num intersected_O2: " << num_intersected_O2 << " / " << L
               << std::endl;
   }
 }

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -906,6 +906,7 @@ TEST_CASE("fmnist compare greedy search", "[vamana]") {
   auto num_intersected_O0 = count_intersections(top_n_O0, qv_top_k, k_nn);
   auto num_intersected_O1 = count_intersections(top_n_O1, qv_top_k, k_nn);
   auto num_intersected_O2 = count_intersections(top_n_O2, qv_top_k, k_nn);
+  CHECK(num_intersected_O0 == num_intersected_O1);
   CHECK(num_intersected_O0 == num_intersected_O2);
   if (debug) {
     std::cout << "num intersected_O0: " << num_intersected_O0 << " / " << L


### PR DESCRIPTION
### What
Here we do two main things:
1. Add more testing for Vamana helper functions
2. Add an option to `best_first_O4()` to skip computing top_k ids and distances. This is useful in Vamana ingestion where they are unused.

### Performance
The accuracy numbers are the same and ingestion is sometimes faster, but sometimes not, so likely just variability in my local machine is causing the change.

**Charts**
Before

![ingestion_time_vs_accuracy](https://github.com/user-attachments/assets/efc4c8ed-6487-46d7-a644-a7b7a623e640)

After

![ingestion_time_vs_accuracy](https://github.com/user-attachments/assets/263dcd9d-f752-4091-9a21-0efff002f211)

**Raw numbers**
Before
```
VAMANA_l_build=40_r_max_degree=10
  Ingestion (count: 1):
    Average Time: 181.4188 seconds
  Query (count: 5):
    Average Time: 2.4649 seconds
    Average Accuracy: 0.7436

VAMANA_l_build=40_r_max_degree=15
  Ingestion (count: 1):
    Average Time: 260.3602 seconds
  Query (count: 5):
    Average Time: 1.9147 seconds
    Average Accuracy: 0.8676

VAMANA_l_build=40_r_max_degree=20
  Ingestion (count: 1):
    Average Time: 341.2821 seconds
  Query (count: 5):
    Average Time: 2.0450 seconds
    Average Accuracy: 0.9201

VAMANA_l_build=40_r_max_degree=25
  Ingestion (count: 1):
    Average Time: 419.1305 seconds
  Query (count: 5):
    Average Time: 1.9463 seconds
    Average Accuracy: 0.9439

VAMANA_l_build=40_r_max_degree=30
  Ingestion (count: 1):
    Average Time: 456.7194 seconds
  Query (count: 5):
    Average Time: 2.0422 seconds
    Average Accuracy: 0.9562

VAMANA_l_build=40_r_max_degree=35
  Ingestion (count: 1):
    Average Time: 480.5166 seconds
  Query (count: 5):
    Average Time: 2.0756 seconds
    Average Accuracy: 0.9624

VAMANA_l_build=40_r_max_degree=40
  Ingestion (count: 1):
    Average Time: 503.7234 seconds
  Query (count: 5):
    Average Time: 2.1702 seconds
    Average Accuracy: 0.9662
```

After
```
VAMANA_l_build=40_r_max_degree=10
  Ingestion (count: 1):
    Average Time: 157.6301 seconds
  Query (count: 5):
    Average Time: 1.7090 seconds
    Average Accuracy: 0.7436

VAMANA_l_build=40_r_max_degree=15
  Ingestion (count: 1):
    Average Time: 239.2754 seconds
  Query (count: 5):
    Average Time: 1.9881 seconds
    Average Accuracy: 0.8676

VAMANA_l_build=40_r_max_degree=20
  Ingestion (count: 1):
    Average Time: 330.6436 seconds
  Query (count: 5):
    Average Time: 2.3247 seconds
    Average Accuracy: 0.9201

VAMANA_l_build=40_r_max_degree=25
  Ingestion (count: 1):
    Average Time: 410.9352 seconds
  Query (count: 5):
    Average Time: 2.1819 seconds
    Average Accuracy: 0.9439

VAMANA_l_build=40_r_max_degree=30
  Ingestion (count: 1):
    Average Time: 463.5973 seconds
  Query (count: 5):
    Average Time: 2.4142 seconds
    Average Accuracy: 0.9562

VAMANA_l_build=40_r_max_degree=35
  Ingestion (count: 1):
    Average Time: 500.3645 seconds
  Query (count: 5):
    Average Time: 2.4888 seconds
    Average Accuracy: 0.9624

VAMANA_l_build=40_r_max_degree=40
  Ingestion (count: 1):
    Average Time: 521.9184 seconds
  Query (count: 5):
    Average Time: 2.6005 seconds
    Average Accuracy: 0.9662
```

### Testing
Tests pass.

### Benchmarking
I also tested `best_first_O4` vs `best_first_O5` (with `std::cout << _timing_data.dump();`), and `best_first_O4` (which we use) seems to be faster:
```
auto best_first_O4 count: 5, sum: 20.04 µs, avg: 4.01 µs
auto best_first_O5: count: 5, sum: 40.71 µs, avg: 8.14 µs
```