### PR TITLE
Add out-of-core query() support to IVF PQ

### DIFF
--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -188,7 +188,7 @@ class IVFFlatIndex(index.Index):
         nprobe: int = 1,
         nthreads: int = -1,
         use_nuv_implementation: bool = False,
-        mode: Mode = None,
+        mode: Optional[Mode] = None,
         resource_class: Optional[str] = None,
         resources: Optional[Mapping[str, Any]] = None,
         num_partitions: int = -1,

--- a/apis/python/src/tiledb/vector_search/ivf_pq_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_pq_index.py
@@ -117,11 +117,15 @@ class IVFPQIndex(index.Index):
         if not queries.flags.f_contiguous:
             queries = queries.copy(order="F")
         queries_feature_vector_array = vspy.FeatureVectorArray(queries)
-        
+
         if self.memory_budget == -1:
-            distances, ids = self.index.query_infinite_ram(queries_feature_vector_array, k, nprobe)
+            distances, ids = self.index.query_infinite_ram(
+                queries_feature_vector_array, k, nprobe
+            )
         else:
-            distances, ids = self.index.query_finite_ram(queries_feature_vector_array, k, nprobe, self.memory_budget)
+            distances, ids = self.index.query_finite_ram(
+                queries_feature_vector_array, k, nprobe, self.memory_budget
+            )
 
         return np.array(distances, copy=False), np.array(ids, copy=False)
 

--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -494,19 +494,31 @@ void init_type_erased_module(py::module_& m) {
           },
           py::arg("vectors"))
       .def(
-          "query",
+          "query_infinite_ram",
           [](IndexIVFPQ& index,
-             QueryType queryType,
              const FeatureVectorArray& vectors,
              size_t top_k,
              size_t nprobe) {
-            auto r = index.query(queryType, vectors, top_k, nprobe);
+            auto r = index.query(QueryType::InfiniteRAM, vectors, top_k, nprobe);
             return make_python_pair(std::move(r));
           },
-          py::arg("queryType"),
           py::arg("vectors"),
           py::arg("top_k"),
           py::arg("nprobe"))
+      .def(
+          "query_finite_ram",
+          [](IndexIVFPQ& index,
+             const FeatureVectorArray& vectors,
+             size_t top_k,
+             size_t nprobe,
+             size_t memory_budget) {
+            auto r = index.query(QueryType::FiniteRAM, vectors, top_k, nprobe, memory_budget);
+            return make_python_pair(std::move(r));
+          },
+          py::arg("vectors"),
+          py::arg("top_k"),
+          py::arg("nprobe"),
+          py::arg("memory_budget"))
       .def(
           "write_index",
           [](IndexIVFPQ& index,

--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -499,7 +499,8 @@ void init_type_erased_module(py::module_& m) {
              const FeatureVectorArray& vectors,
              size_t top_k,
              size_t nprobe) {
-            auto r = index.query(QueryType::InfiniteRAM, vectors, top_k, nprobe);
+            auto r =
+                index.query(QueryType::InfiniteRAM, vectors, top_k, nprobe);
             return make_python_pair(std::move(r));
           },
           py::arg("vectors"),
@@ -512,7 +513,8 @@ void init_type_erased_module(py::module_& m) {
              size_t top_k,
              size_t nprobe,
              size_t memory_budget) {
-            auto r = index.query(QueryType::FiniteRAM, vectors, top_k, nprobe, memory_budget);
+            auto r = index.query(
+                QueryType::FiniteRAM, vectors, top_k, nprobe, memory_budget);
             return make_python_pair(std::move(r));
           },
           py::arg("vectors"),

--- a/apis/python/test/common.py
+++ b/apis/python/test/common.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import tiledb
 from tiledb.cloud import groups
+from tiledb.vector_search import _tiledbvspy as vspy
 from tiledb.vector_search.flat_index import FlatIndex
 from tiledb.vector_search.ivf_flat_index import IVFFlatIndex
 from tiledb.vector_search.ivf_pq_index import IVFPQIndex
@@ -333,6 +334,12 @@ def check_equals(result_d, result_i, expected_result_d, expected_result_i):
     assert np.array_equal(
         result_d, expected_result_d
     ), f"result_d: {result_d} != expected_result_d: {expected_result_d}"
+
+
+def recall(ids, groundtruth_set, k_nn):
+    intersections = vspy.count_intersections(ids, groundtruth_set, k_nn)
+    total_possible_intersections = np.double(ids.num_vectors()) * np.double(k_nn)
+    return intersections / total_possible_intersections
 
 
 def random_name(name: str) -> str:

--- a/apis/python/test/test_type_erased_module.py
+++ b/apis/python/test/test_type_erased_module.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 from array_paths import *
+from common import *
 
 from tiledb.vector_search import _tiledbvspy as vspy
 from tiledb.vector_search.utils import load_fvecs
@@ -498,15 +499,22 @@ def test_construct_IndexIVFPQ_with_empty_vector(tmp_path):
     a.train(training_set)
     a.add(training_set)
 
-    s, t = a.query(vspy.QueryType.InfiniteRAM, query_set, k_nn, nprobe)
+    _, ids = a.query_infinite_ram(query_set, k_nn, nprobe)
+    assert recall(ids, groundtruth_set, k_nn) >= 0.89
 
-    intersections = vspy.count_intersections(t, groundtruth_set, k_nn)
-    nt = np.double(t.num_vectors()) * np.double(k_nn)
-    recall = intersections / nt
-    assert recall > 0.89
+    index_uri = os.path.join(tmp_path, "array")
+    a.write_index(ctx, index_uri)
+
+    b = vspy.IndexIVFPQ(ctx, index_uri)
+
+    _, ids = b.query_infinite_ram(query_set, k_nn, nprobe)
+    assert recall(ids, groundtruth_set, k_nn) >= 0.89
+
+    _, ids = b.query_finite_ram(query_set, k_nn, nprobe, 500)
+    assert recall(ids, groundtruth_set, k_nn) >= 0.89
 
 
-def test_inplace_build_query_IndexIVFPQ():
+def test_inplace_build_query_IndexIVFPQ(tmp_path):
     nprobe = 100
     k_nn = 10
 
@@ -526,14 +534,20 @@ def test_inplace_build_query_IndexIVFPQ():
 
     a.train(training_set)
     a.add(training_set)
-    s, t = a.query(vspy.QueryType.InfiniteRAM, query_set, k_nn, nprobe)
 
-    intersections = vspy.count_intersections(t, groundtruth_set, k_nn)
+    _, ids = a.query_infinite_ram(query_set, k_nn, nprobe)
+    assert recall(ids, groundtruth_set, k_nn) >= 0.895
 
-    nt = np.double(t.num_vectors()) * np.double(k_nn)
-    recall = intersections / nt
+    index_uri = os.path.join(tmp_path, "array")
+    a.write_index(ctx, index_uri)
 
-    assert recall >= 0.895
+    b = vspy.IndexIVFPQ(ctx, index_uri)
+
+    _, ids = b.query_infinite_ram(query_set, k_nn, nprobe)
+    assert recall(ids, groundtruth_set, k_nn) >= 0.895
+
+    _, ids = b.query_finite_ram(query_set, k_nn, nprobe, 500)
+    assert recall(ids, groundtruth_set, k_nn) >= 0.895
 
 
 def test_construct_IndexIVFFlat():

--- a/src/include/api/ivf_pq_index.h
+++ b/src/include/api/ivf_pq_index.h
@@ -243,12 +243,13 @@ class IndexIVFPQ {
       QueryType queryType,
       const QueryVectorArray& vectors,
       size_t top_k,
-      size_t nprobe) {
+      size_t nprobe,
+      size_t upper_bound = 0) {
     if (!index_) {
       throw std::runtime_error(
-          "Cannot query_infinite_ram() because there is no index.");
+          "Cannot query() because there is no index.");
     }
-    return index_->query(queryType, vectors, top_k, nprobe);
+    return index_->query(queryType, vectors, top_k, nprobe, upper_bound);
   }
 
   void write_index(
@@ -389,7 +390,8 @@ class IndexIVFPQ {
         QueryType queryType,
         const QueryVectorArray& vectors,
         size_t top_k,
-        size_t nprobe) = 0;
+        size_t nprobe,
+        size_t upper_bound) = 0;
 
     virtual void write_index(
         const tiledb::Context& ctx,
@@ -498,7 +500,8 @@ class IndexIVFPQ {
         QueryType queryType,
         const QueryVectorArray& vectors,
         size_t top_k,
-        size_t nprobe) override {
+        size_t nprobe,
+        size_t upper_bound) override {
       // @todo using index_type = size_t;
       auto dtype = vectors.feature_type();
 
@@ -509,7 +512,7 @@ class IndexIVFPQ {
               (float*)vectors.data(),
               extents(vectors)[0],
               extents(vectors)[1]};  // @todo ??
-          auto [s, t] = impl_index_.query(queryType, qspan, top_k, nprobe);
+          auto [s, t] = impl_index_.query(queryType, qspan, top_k, nprobe, upper_bound);
           auto x = FeatureVectorArray{std::move(s)};
           auto y = FeatureVectorArray{std::move(t)};
           return {std::move(x), std::move(y)};
@@ -519,7 +522,7 @@ class IndexIVFPQ {
               (uint8_t*)vectors.data(),
               extents(vectors)[0],
               extents(vectors)[1]};  // @todo ??
-          auto [s, t] = impl_index_.query(queryType, qspan, top_k, nprobe);
+          auto [s, t] = impl_index_.query(queryType, qspan, top_k, nprobe, upper_bound);
           auto x = FeatureVectorArray{std::move(s)};
           auto y = FeatureVectorArray{std::move(t)};
           return {std::move(x), std::move(y)};

--- a/src/include/api/ivf_pq_index.h
+++ b/src/include/api/ivf_pq_index.h
@@ -246,8 +246,7 @@ class IndexIVFPQ {
       size_t nprobe,
       size_t upper_bound = 0) {
     if (!index_) {
-      throw std::runtime_error(
-          "Cannot query() because there is no index.");
+      throw std::runtime_error("Cannot query() because there is no index.");
     }
     return index_->query(queryType, vectors, top_k, nprobe, upper_bound);
   }
@@ -512,7 +511,8 @@ class IndexIVFPQ {
               (float*)vectors.data(),
               extents(vectors)[0],
               extents(vectors)[1]};  // @todo ??
-          auto [s, t] = impl_index_.query(queryType, qspan, top_k, nprobe, upper_bound);
+          auto [s, t] =
+              impl_index_.query(queryType, qspan, top_k, nprobe, upper_bound);
           auto x = FeatureVectorArray{std::move(s)};
           auto y = FeatureVectorArray{std::move(t)};
           return {std::move(x), std::move(y)};
@@ -522,7 +522,8 @@ class IndexIVFPQ {
               (uint8_t*)vectors.data(),
               extents(vectors)[0],
               extents(vectors)[1]};  // @todo ??
-          auto [s, t] = impl_index_.query(queryType, qspan, top_k, nprobe, upper_bound);
+          auto [s, t] =
+              impl_index_.query(queryType, qspan, top_k, nprobe, upper_bound);
           auto x = FeatureVectorArray{std::move(s)};
           auto y = FeatureVectorArray{std::move(t)};
           return {std::move(x), std::move(y)};

--- a/src/include/detail/linalg/partitioned_matrix.h
+++ b/src/include/detail/linalg/partitioned_matrix.h
@@ -194,18 +194,15 @@ class PartitionedMatrix : public Matrix<T, LayoutPolicy, I> {
     part_index_[0] = 0;
   }
 
-  constexpr auto& num_vectors() {
+  size_t num_vectors() const {
     return num_vectors_;
   }
 
-  constexpr auto& num_vectors() const {
+  virtual unsigned long total_num_vectors() const {
     return num_vectors_;
   }
 
-  constexpr auto& num_partitions() const {
-    return num_parts_;
-  }
-  constexpr auto& num_partitions() {
+  constexpr size_t num_partitions() const {
     return num_parts_;
   }
 

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -621,7 +621,8 @@ class tdbPartitionedMatrix
     close();
   }
 
-  void debug_tdb_partitioned_matrix(const std::string& msg, size_t max_size = 10) {
+  void debug_tdb_partitioned_matrix(
+      const std::string& msg, size_t max_size = 10) {
     debug_partitioned_matrix(*this, msg, max_size);
     debug_vector(master_indices_, "# master_indices_", max_size);
     debug_vector(relevant_parts_, "# relevant_parts_", max_size);

--- a/src/include/detail/linalg/tdb_partitioned_matrix.h
+++ b/src/include/detail/linalg/tdb_partitioned_matrix.h
@@ -609,6 +609,10 @@ class tdbPartitionedMatrix
     return true;
   }
 
+  unsigned long total_num_vectors() const override {
+    return total_max_cols_;
+  }
+
   /**
    * Destructor.  Closes arrays if they are open.
    */
@@ -617,7 +621,7 @@ class tdbPartitionedMatrix
     close();
   }
 
-  void debug_tdb_partitioned_matrix(const std::string& msg, size_t max_size) {
+  void debug_tdb_partitioned_matrix(const std::string& msg, size_t max_size = 10) {
     debug_partitioned_matrix(*this, msg, max_size);
     debug_vector(master_indices_, "# master_indices_", max_size);
     debug_vector(relevant_parts_, "# relevant_parts_", max_size);

--- a/src/include/index/ivf_pq_index.h
+++ b/src/include/index/ivf_pq_index.h
@@ -341,6 +341,7 @@ class ivf_pq_index {
       : temporal_policy_{temporal_policy.has_value() ? *temporal_policy : TemporalPolicy()}
       , group_{std::make_unique<ivf_pq_group<ivf_pq_index>>(
             ctx, uri, TILEDB_READ, temporal_policy_)} {
+    std::cout << "ivf_pq_index::ivf_pq_index(uri) -- uri: " << uri << std::endl;
     /**
      * Read the centroids. How the partitioned_pq_vectors_ are read in will be
      * determined by the type of query we are doing. But they will be read
@@ -1041,15 +1042,32 @@ class ivf_pq_index {
   template <feature_vector_array Q>
   auto read_index_finite(
       const Q& query_vectors, size_t nprobe, size_t upper_bound) {
-    if (partitioned_pq_vectors_ &&
-        (::num_vectors(*partitioned_pq_vectors_) != 0 ||
-         ::num_vectors(partitioned_pq_vectors_->ids()) != 0)) {
-      throw std::runtime_error("Index already loaded");
+    if (!group_) {
+      throw std::runtime_error("[ivf_pq_index@read_index_finite] group_ is not initialized. This happens if you do not load an index by URI. Please close the index and re-open it by URI.");
     }
+    // if (partitioned_pq_vectors_ &&
+    //     (::num_vectors(*partitioned_pq_vectors_) != 0 ||
+    //      ::num_vectors(partitioned_pq_vectors_->ids()) != 0)) {
+    //   throw std::runtime_error("Index already loaded");
+    // }
 
     auto&& [active_partitions, active_queries] =
         detail::ivf::partition_ivf_flat_index<indices_type>(
             flat_ivf_centroids_, query_vectors, nprobe, num_threads_);
+
+
+    // if (!group_) {
+    //   std::cout << "[ivf_pq_index@read_index_finite] Finite RAM query will only work when you load an index by URI. Please close the index and re-open it by URI." << std::endl;
+    //   partitioned_pq_vectors_ = std::make_unique<ColMajorPartitionedMatrix<pq_code_type, partitioned_ids_type, indices_type>>(dimensions_, 0, 1);
+    //   return std::make_tuple(
+    //     std::move(active_partitions), std::move(active_queries));
+    // }
+
+    std::cout << "group_: " << group_ << std::endl;
+
+    // return std::make_tuple(
+    //     std::move(active_partitions), std::move(active_queries));
+    // std::cout << "group_->get_num_partitions() + 1: " << group_->get_num_partitions() + 1 << std::endl;
 
     partitioned_pq_vectors_ = std::make_unique<tdb_pq_storage_type>(
         group_->cached_ctx(),
@@ -1089,6 +1107,10 @@ class ivf_pq_index {
       const std::string& group_uri,
       std::optional<TemporalPolicy> temporal_policy = std::nullopt,
       const std::string& storage_version = "") {
+    if (!partitioned_pq_vectors_) {
+      throw std::runtime_error(
+          "[ivf_pq_index@write_index] partitioned_pq_vectors_ is not initialized. This happens if you train the index, query with finite RAM, and then try to write. Make sure to write before the query.");
+    }
     if (temporal_policy.has_value()) {
       temporal_policy_ = *temporal_policy;
     }
@@ -1285,12 +1307,12 @@ class ivf_pq_index {
 
   template <feature_vector_array Q>
   auto query(
-      QueryType queryType, const Q& query_vectors, size_t k_nn, size_t nprobe) {
+      QueryType queryType, const Q& query_vectors, size_t k_nn, size_t nprobe, size_t upper_bound = 0) {
     switch (queryType) {
       case QueryType::InfiniteRAM:
         return query_infinite_ram(query_vectors, k_nn, nprobe);
       case QueryType::FiniteRAM:
-        return query_finite_ram(query_vectors, k_nn, nprobe);
+        return query_finite_ram(query_vectors, k_nn, nprobe, upper_bound);
       default:
         throw std::runtime_error("Invalid query type");
     }
@@ -1317,13 +1339,19 @@ class ivf_pq_index {
    */
   template <feature_vector_array Q>
   auto query_infinite_ram(const Q& query_vectors, size_t k_nn, size_t nprobe) {
+    std::cout << "[ivf_pq_index@query_infinite_ram]" << std::endl;
     if (::num_vectors(flat_ivf_centroids_) < nprobe) {
       nprobe = ::num_vectors(flat_ivf_centroids_);
     }
-    if (!partitioned_pq_vectors_ ||
-        ::num_vectors(*partitioned_pq_vectors_) == 0) {
+    // std::cout << "::num_vectors(flat_ivf_centroids_)" << ::num_vectors(flat_ivf_centroids_) << std::endl;
+    // std::cout << "::num_vectors(*partitioned_pq_vectors_" << ::num_vectors(*partitioned_pq_vectors_) << std::endl;
+    // std::cout << "partitioned_pq_vectors_->num_vectors()" << partitioned_pq_vectors_->num_vectors() << std::endl;
+    // std::cout << "partitioned_pq_vectors_->total_num_vectors()" << partitioned_pq_vectors_->total_num_vectors() << std::endl;
+    if (!partitioned_pq_vectors_ || partitioned_pq_vectors_->num_vectors() == 0 || partitioned_pq_vectors_->num_vectors() != partitioned_pq_vectors_->total_num_vectors()) {
+      std::cout << "[ivf_pq_index@query_infinite_ram] Will call read_index_infinite()" << std::endl;
       read_index_infinite();
     }
+    debug_partitioned_matrix(*partitioned_pq_vectors_, "[ivf_pq_index@query_infinite_ram] partitioned_pq_vectors_");
     auto&& [active_partitions, active_queries] =
         detail::ivf::partition_ivf_flat_index<indices_type>(
             flat_ivf_centroids_, query_vectors, nprobe, num_threads_);
@@ -1373,21 +1401,39 @@ class ivf_pq_index {
       size_t k_nn,
       size_t nprobe,
       size_t upper_bound = 0) {
-    if (partitioned_pq_vectors_ &&
-        ::num_vectors(*partitioned_pq_vectors_) != 0) {
-      throw std::runtime_error(
-          "Vectors are already loaded. Cannot load twice. "
-          "Cannot do finite query on in-memory index.");
+    std::cout << "[ivf_pq_index@query_finite_ram]" << std::endl;
+    // if (partitioned_pq_vectors_ && ::num_vectors(*partitioned_pq_vectors_) != 0) {
+    //   throw std::runtime_error(
+    //       "Vectors are already loaded. Cannot load twice. "
+    //       "Cannot do finite query on in-memory index.");
+    // }
+    std::cout << "[ivf_pq_index@query_finite_ram] group_: " << group_ << std::endl;
+    if (!group_) {
+      throw std::runtime_error("[ivf_pq_index@query_finite_ram] Query with finite RAM can only be run if you're loading the index by URI. Please open it by URI and try again. If you just wrote the index, open it up again by URI.");
+    }
+    std::cout << "[ivf_pq_index@query_finite_ram] partitioned_pq_vectors_: " << partitioned_pq_vectors_ << std::endl;
+    if (partitioned_pq_vectors_) {
+      // We did an infinite query before this. Reset the data we loaded.
+      partitioned_pq_vectors_.reset();
     }
     if (::num_vectors(flat_ivf_centroids_) < nprobe) {
       nprobe = ::num_vectors(flat_ivf_centroids_);
     }
+
     auto&& [active_partitions, active_queries] =
         read_index_finite(query_vectors, nprobe, upper_bound);
+    debug_partitioned_matrix(*partitioned_pq_vectors_, "[ivf_pq_index@query_finite_ram] partitioned_pq_vectors_");
+    // std::cout << "partitioned_pq_vectors_" << partitioned_pq_vectors_ << std::endl;
+
     auto query_to_pq_centroid_distance_tables =
         std::move(*generate_query_to_pq_centroid_distance_tables<
                   Q,
                   ColMajorMatrix<float>>(query_vectors));
+    // debug_partitioned_matrix(*partitioned_pq_vectors_, "partitioned_pq_vectors_");
+    // ColMajorMatrix<uint64_t> top_k(k_nn, num_vectors(query_vectors));
+    // ColMajorMatrix<float> top_scores(k_nn, num_vectors(query_vectors));
+    // return std::make_tuple(std::move(top_scores), std::move(top_k));
+
     return detail::ivf::query_finite_ram(
         *partitioned_pq_vectors_,
         query_to_pq_centroid_distance_tables,
@@ -1398,6 +1444,21 @@ class ivf_pq_index {
         make_pq_distance_query_to_pq_centroid_distance_tables<
             std::span<float>,
             decltype(pq_storage_type{}[0])>());
+          
+    // auto &&[scores, ids] = detail::ivf::query_finite_ram(
+    //     *partitioned_pq_vectors_,
+    //     query_to_pq_centroid_distance_tables,
+    //     active_queries,
+    //     k_nn,
+    //     upper_bound,
+    //     num_threads_,
+    //     make_pq_distance_query_to_pq_centroid_distance_tables<
+    //         std::span<float>,
+    //         decltype(pq_storage_type{}[0])>());
+    
+    // partitioned_pq_vectors_.reset();
+    
+    // return std::make_tuple(std::move(scores), std::move(ids));
   }
 
   /***************************************************************************

--- a/src/include/index/ivf_pq_index.h
+++ b/src/include/index/ivf_pq_index.h
@@ -1042,7 +1042,10 @@ class ivf_pq_index {
   auto read_index_finite(
       const Q& query_vectors, size_t nprobe, size_t upper_bound) {
     if (!group_) {
-      throw std::runtime_error("[ivf_pq_index@read_index_finite] group_ is not initialized. This happens if you do not load an index by URI. Please close the index and re-open it by URI.");
+      throw std::runtime_error(
+          "[ivf_pq_index@read_index_finite] group_ is not initialized. This "
+          "happens if you do not load an index by URI. Please close the index "
+          "and re-open it by URI.");
     }
 
     auto&& [active_partitions, active_queries] =
@@ -1089,7 +1092,9 @@ class ivf_pq_index {
       const std::string& storage_version = "") {
     if (!partitioned_pq_vectors_) {
       throw std::runtime_error(
-          "[ivf_pq_index@write_index] partitioned_pq_vectors_ is not initialized. This happens if you train the index, query with finite RAM, and then try to write. Make sure to write before the query.");
+          "[ivf_pq_index@write_index] partitioned_pq_vectors_ is not "
+          "initialized. This happens if you train the index, query with finite "
+          "RAM, and then try to write. Make sure to write before the query.");
     }
     if (temporal_policy.has_value()) {
       temporal_policy_ = *temporal_policy;
@@ -1287,7 +1292,11 @@ class ivf_pq_index {
 
   template <feature_vector_array Q>
   auto query(
-      QueryType queryType, const Q& query_vectors, size_t k_nn, size_t nprobe, size_t upper_bound = 0) {
+      QueryType queryType,
+      const Q& query_vectors,
+      size_t k_nn,
+      size_t nprobe,
+      size_t upper_bound = 0) {
     switch (queryType) {
       case QueryType::InfiniteRAM:
         return query_infinite_ram(query_vectors, k_nn, nprobe);
@@ -1322,7 +1331,10 @@ class ivf_pq_index {
     if (::num_vectors(flat_ivf_centroids_) < nprobe) {
       nprobe = ::num_vectors(flat_ivf_centroids_);
     }
-    if (!partitioned_pq_vectors_ || partitioned_pq_vectors_->num_vectors() == 0 || partitioned_pq_vectors_->num_vectors() != partitioned_pq_vectors_->total_num_vectors()) {
+    if (!partitioned_pq_vectors_ ||
+        partitioned_pq_vectors_->num_vectors() == 0 ||
+        partitioned_pq_vectors_->num_vectors() !=
+            partitioned_pq_vectors_->total_num_vectors()) {
       read_index_infinite();
     }
 
@@ -1376,7 +1388,10 @@ class ivf_pq_index {
       size_t nprobe,
       size_t upper_bound = 0) {
     if (!group_) {
-      throw std::runtime_error("[ivf_pq_index@query_finite_ram] Query with finite RAM can only be run if you're loading the index by URI. Please open it by URI and try again. If you just wrote the index, open it up again by URI.");
+      throw std::runtime_error(
+          "[ivf_pq_index@query_finite_ram] Query with finite RAM can only be "
+          "run if you're loading the index by URI. Please open it by URI and "
+          "try again. If you just wrote the index, open it up again by URI.");
     }
     if (partitioned_pq_vectors_) {
       // We did an infinite query before this. Reset so we can load again..

--- a/src/include/index/ivf_pq_index.h
+++ b/src/include/index/ivf_pq_index.h
@@ -1394,21 +1394,18 @@ class ivf_pq_index {
           "try again. If you just wrote the index, open it up again by URI.");
     }
     if (partitioned_pq_vectors_) {
-      // We did an infinite query before this. Reset so we can load again..
+      // We did an infinite query before this. Reset so we can load again.
       partitioned_pq_vectors_.reset();
     }
     if (::num_vectors(flat_ivf_centroids_) < nprobe) {
       nprobe = ::num_vectors(flat_ivf_centroids_);
     }
-
     auto&& [active_partitions, active_queries] =
         read_index_finite(query_vectors, nprobe, upper_bound);
-
     auto query_to_pq_centroid_distance_tables =
         std::move(*generate_query_to_pq_centroid_distance_tables<
                   Q,
                   ColMajorMatrix<float>>(query_vectors));
-
     return detail::ivf::query_finite_ram(
         *partitioned_pq_vectors_,
         query_to_pq_centroid_distance_tables,

--- a/src/include/test/unit_api_ivf_pq_index.cc
+++ b/src/include/test/unit_api_ivf_pq_index.cc
@@ -307,8 +307,8 @@ TEST_CASE(
     size_t top_k = 1;
     size_t nprobe = 1;
 
-    auto queries = ColMajorMatrix<feature_type_type>{{
-        {8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}};
+    auto queries = ColMajorMatrix<feature_type_type>{
+        {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}};
     for (auto upper_bound : {3, 4, 5, 100, 0}) {
       auto&& [scores_vector_array, ids_vector_array] = index.query(
           QueryType::FiniteRAM,
@@ -792,8 +792,8 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
     // Check that we can do finite and infinite queries and then train + write
     // the index.
     {
-      auto queries = ColMajorMatrix<feature_type_type>{{
-          {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}};
+      auto queries = ColMajorMatrix<feature_type_type>{
+          {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}};
       auto&& [scores_vector_array, ids_vector_array] = index.query(
           QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
       check_single_vector_equals(

--- a/src/include/test/unit_api_ivf_pq_index.cc
+++ b/src/include/test/unit_api_ivf_pq_index.cc
@@ -226,7 +226,8 @@ TEST_CASE("create empty index and then train and query", "[api_ivf_pq_index]") {
         {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
-    check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {0, 1, 2, 3});
+    check_single_vector_equals(
+        scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {0, 1, 2, 3});
   }
 }
 
@@ -294,10 +295,11 @@ TEST_CASE(
 
     auto queries = ColMajorMatrix<feature_type_type>{
         {8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
-    
+
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
-    check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {10, 11, 12, 13});
+    check_single_vector_equals(
+        scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {10, 11, 12, 13});
   }
 
   {
@@ -305,13 +307,32 @@ TEST_CASE(
     size_t top_k = 1;
     size_t nprobe = 1;
 
-    auto queries = ColMajorMatrix<feature_type_type>{{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
-    for (auto upper_bound: {3, 4, 5, 100, 0}) {
-      auto&& [scores_vector_array, ids_vector_array] = index.query(QueryType::FiniteRAM, FeatureVectorArray(queries), top_k, nprobe, upper_bound);
-      check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {10, 11, 12, 13});
+    auto queries = ColMajorMatrix<feature_type_type>{
+        {8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
+    for (auto upper_bound : {3, 4, 5, 100, 0}) {
+      auto&& [scores_vector_array, ids_vector_array] = index.query(
+          QueryType::FiniteRAM,
+          FeatureVectorArray(queries),
+          top_k,
+          nprobe,
+          upper_bound);
+      check_single_vector_equals(
+          scores_vector_array,
+          ids_vector_array,
+          {0, 0, 0, 0},
+          {10, 11, 12, 13});
 
-      auto&& [scores_vector_array_infinite, ids_vector_array_infinite] = index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), top_k, nprobe);
-      check_single_vector_equals(scores_vector_array_infinite, ids_vector_array_infinite, {0, 0, 0, 0}, {10, 11, 12, 13});
+      auto&& [scores_vector_array_infinite, ids_vector_array_infinite] =
+          index.query(
+              QueryType::InfiniteRAM,
+              FeatureVectorArray(queries),
+              top_k,
+              nprobe);
+      check_single_vector_equals(
+          scores_vector_array_infinite,
+          ids_vector_array_infinite,
+          {0, 0, 0, 0},
+          {10, 11, 12, 13});
     }
   }
 }
@@ -374,26 +395,27 @@ TEST_CASE(
     auto recall = intersections / static_cast<double>(num_ids * k_nn);
     CHECK(recall > 0.7);
   }
-  
+
   {
     auto index = IndexIVFPQ(ctx, index_uri);
     size_t nprobe = 5;
 
     auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
     auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
-    for (auto upper_bound: {400, 1000, 0}) {
-      auto&& [_, ids] = index.query(QueryType::InfiniteRAM, query_set, k_nn, nprobe);
+    for (auto upper_bound : {400, 1000, 0}) {
+      auto&& [_, ids] =
+          index.query(QueryType::InfiniteRAM, query_set, k_nn, nprobe);
       auto intersections = count_intersections(ids, groundtruth_set, k_nn);
       auto num_ids = num_vectors(ids);
       auto recall = intersections / static_cast<double>(num_ids * k_nn);
       CHECK(recall > 0.7);
 
-      auto&& [__, ids_finite] = index.query(QueryType::FiniteRAM, query_set, k_nn, nprobe, upper_bound);
+      auto&& [__, ids_finite] = index.query(
+          QueryType::FiniteRAM, query_set, k_nn, nprobe, upper_bound);
       intersections = count_intersections(ids_finite, groundtruth_set, k_nn);
       num_ids = num_vectors(ids_finite);
       recall = intersections / static_cast<double>(num_ids * k_nn);
       CHECK(recall > 0.7);
-
     }
   }
 }
@@ -497,10 +519,14 @@ TEST_CASE("read index and query", "[api_ivf_pq_index]") {
   auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
   auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
 
-  auto&& [scores_1, ids_1] = a.query(QueryType::InfiniteRAM, query_set, k_nn, 5);
-  auto&& [scores_2, ids_2] = b.query(QueryType::InfiniteRAM, query_set, k_nn, 5);
-  auto&& [scores_3, ids_3] = b.query(QueryType::FiniteRAM, query_set, k_nn, 5, 500);
-  auto&& [scores_4, ids_4] = b.query(QueryType::FiniteRAM, query_set, k_nn, 5, 0);
+  auto&& [scores_1, ids_1] =
+      a.query(QueryType::InfiniteRAM, query_set, k_nn, 5);
+  auto&& [scores_2, ids_2] =
+      b.query(QueryType::InfiniteRAM, query_set, k_nn, 5);
+  auto&& [scores_3, ids_3] =
+      b.query(QueryType::FiniteRAM, query_set, k_nn, 5, 500);
+  auto&& [scores_4, ids_4] =
+      b.query(QueryType::FiniteRAM, query_set, k_nn, 5, 0);
 
   auto intersections_1 = count_intersections(ids_1, groundtruth_set, k_nn);
   auto intersections_2 = count_intersections(ids_2, groundtruth_set, k_nn);
@@ -509,7 +535,8 @@ TEST_CASE("read index and query", "[api_ivf_pq_index]") {
   CHECK(num_vectors(ids_1) == num_vectors(ids_2));
   CHECK(num_vectors(ids_1) == num_vectors(ids_3));
   CHECK(num_vectors(ids_1) == num_vectors(ids_4));
-  auto recall = intersections_1 / static_cast<double>(num_vectors(ids_1) * k_nn);
+  auto recall =
+      intersections_1 / static_cast<double>(num_vectors(ids_1) * k_nn);
   CHECK(recall > 0.7);
 }
 
@@ -734,7 +761,8 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
         {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
-    check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {1, 2, 3, 4});
+    check_single_vector_equals(
+        scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {1, 2, 3, 4});
 
     auto typed_index = ivf_pq_index<
         feature_type_type,
@@ -759,14 +787,24 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
     // we'll load it at timestamp 99).
     auto index = IndexIVFPQ(ctx, index_uri);
 
-    // Check that we can do finite and infinite queries and then train + write the index.
+    // Check that we can do finite and infinite queries and then train + write
+    // the index.
     {
-      auto queries = ColMajorMatrix<feature_type_type>{{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
-      auto&& [scores_vector_array, ids_vector_array] = index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
-      check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {1, 2, 3, 4});
+      auto queries = ColMajorMatrix<feature_type_type>{
+          {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
+      auto&& [scores_vector_array, ids_vector_array] = index.query(
+          QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
+      check_single_vector_equals(
+          scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {1, 2, 3, 4});
 
-      auto&& [scores_vector_array_finite, ids_vector_array_finite] = index.query(QueryType::FiniteRAM, FeatureVectorArray(queries), 1, 1, 4);
-      check_single_vector_equals(scores_vector_array_finite, ids_vector_array_finite, {0, 0, 0, 0}, {1, 2, 3, 4});
+      auto&& [scores_vector_array_finite, ids_vector_array_finite] =
+          index.query(
+              QueryType::FiniteRAM, FeatureVectorArray(queries), 1, 1, 4);
+      check_single_vector_equals(
+          scores_vector_array_finite,
+          ids_vector_array_finite,
+          {0, 0, 0, 0},
+          {1, 2, 3, 4});
     }
 
     CHECK(index.temporal_policy().timestamp_start() == 0);
@@ -801,7 +839,11 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
         {11, 11, 11}, {22, 22, 22}, {33, 33, 33}, {44, 44, 44}, {55, 55, 55}};
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
-    check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0, 0}, {11, 22, 33, 44, 55});
+    check_single_vector_equals(
+        scores_vector_array,
+        ids_vector_array,
+        {0, 0, 0, 0, 0},
+        {11, 22, 33, 44, 55});
 
     auto typed_index = ivf_pq_index<
         feature_type_type,
@@ -850,10 +892,15 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
         {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
     auto&& [scores_vector_array_finite, ids_vector_array_finite] =
         index.query(QueryType::FiniteRAM, FeatureVectorArray(queries), 1, 1);
-    check_single_vector_equals(scores_vector_array_finite, ids_vector_array_finite, {0, 0, 0, 0}, {1, 2, 3, 4});
+    check_single_vector_equals(
+        scores_vector_array_finite,
+        ids_vector_array_finite,
+        {0, 0, 0, 0},
+        {1, 2, 3, 4});
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
-    check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {1, 2, 3, 4});
+    check_single_vector_equals(
+        scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {1, 2, 3, 4});
 
     auto typed_index = ivf_pq_index<
         feature_type_type,
@@ -901,10 +948,20 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
     CHECK(index.reassign_ratio() == reassign_ratio);
 
     auto queries = ColMajorMatrix<feature_type_type>{{1, 1, 1}};
-    auto&& [scores_vector_array, ids_vector_array] = index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
-    check_single_vector_equals(scores_vector_array, ids_vector_array, {std::numeric_limits<float>::max()}, {std::numeric_limits<uint32_t>::max()});
-    auto&& [scores_vector_array_finite, ids_vector_array_finite] = index.query(QueryType::FiniteRAM, FeatureVectorArray(queries), 1, 1, 4);
-    check_single_vector_equals(scores_vector_array_finite, ids_vector_array_finite, {std::numeric_limits<float>::max()}, {std::numeric_limits<uint32_t>::max()});
+    auto&& [scores_vector_array, ids_vector_array] =
+        index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
+    check_single_vector_equals(
+        scores_vector_array,
+        ids_vector_array,
+        {std::numeric_limits<float>::max()},
+        {std::numeric_limits<uint32_t>::max()});
+    auto&& [scores_vector_array_finite, ids_vector_array_finite] =
+        index.query(QueryType::FiniteRAM, FeatureVectorArray(queries), 1, 1, 4);
+    check_single_vector_equals(
+        scores_vector_array_finite,
+        ids_vector_array_finite,
+        {std::numeric_limits<float>::max()},
+        {std::numeric_limits<uint32_t>::max()});
 
     auto typed_index = ivf_pq_index<
         feature_type_type,
@@ -960,10 +1017,20 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
 
     auto default_score = std::numeric_limits<float>::max();
     auto default_id = std::numeric_limits<uint32_t>::max();
-    auto&& [scores_vector_array_finite, ids_vector_array_finite] = index.query(QueryType::FiniteRAM, FeatureVectorArray(queries), 1, 1, 0);
-    check_single_vector_equals(scores_vector_array_finite, ids_vector_array_finite, {default_score, default_score, default_score, default_score}, {default_id, default_id, default_id, default_id});
-    auto&& [scores_vector_array, ids_vector_array] = index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
-    check_single_vector_equals(scores_vector_array, ids_vector_array, {default_score, default_score, default_score, default_score}, {default_id, default_id, default_id, default_id});
+    auto&& [scores_vector_array_finite, ids_vector_array_finite] =
+        index.query(QueryType::FiniteRAM, FeatureVectorArray(queries), 1, 1, 0);
+    check_single_vector_equals(
+        scores_vector_array_finite,
+        ids_vector_array_finite,
+        {default_score, default_score, default_score, default_score},
+        {default_id, default_id, default_id, default_id});
+    auto&& [scores_vector_array, ids_vector_array] =
+        index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
+    check_single_vector_equals(
+        scores_vector_array,
+        ids_vector_array,
+        {default_score, default_score, default_score, default_score},
+        {default_id, default_id, default_id, default_id});
 
     auto typed_index = ivf_pq_index<
         feature_type_type,

--- a/src/include/test/unit_api_ivf_pq_index.cc
+++ b/src/include/test/unit_api_ivf_pq_index.cc
@@ -331,7 +331,6 @@ TEST_CASE(
   if (vfs.is_dir(index_uri)) {
     vfs.remove_dir(index_uri);
   }
-  std::cout << "--------------------------------------------" << std::endl;
   {
     auto index = IndexIVFPQ(std::make_optional<IndexOptions>(
         {{"feature_type", feature_type},
@@ -350,7 +349,6 @@ TEST_CASE(
     CHECK(index.id_type_string() == id_type);
     CHECK(index.partitioning_index_type_string() == partitioning_index_type);
   }
-  std::cout << "--------------------------------------------" << std::endl;
   {
     auto index = IndexIVFPQ(ctx, index_uri);
 

--- a/src/include/test/unit_api_ivf_pq_index.cc
+++ b/src/include/test/unit_api_ivf_pq_index.cc
@@ -32,6 +32,7 @@
 #include "api/ivf_pq_index.h"
 #include "catch2/catch_all.hpp"
 #include "test/utils/query_common.h"
+#include "test/utils/test_utils.h"
 
 TEST_CASE("init constructor", "[api_ivf_pq_index]") {
   SECTION("default") {
@@ -223,18 +224,9 @@ TEST_CASE("create empty index and then train and query", "[api_ivf_pq_index]") {
 
     auto queries = ColMajorMatrix<feature_type_type>{
         {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
-    auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
-        index.query(QueryType::InfiniteRAM, query_vector_array, 1, 1);
-
-    auto scores = std::span<float>(
-        (float*)scores_vector_array.data(), scores_vector_array.num_vectors());
-    auto ids = std::span<uint32_t>(
-        (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
-    CHECK(std::equal(
-        scores.begin(), scores.end(), std::vector<float>{0, 0, 0, 0}.begin()));
-    CHECK(std::equal(
-        ids.begin(), ids.end(), std::vector<int>{0, 1, 2, 3}.begin()));
+        index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
+    check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {0, 1, 2, 3});
   }
 }
 
@@ -302,18 +294,25 @@ TEST_CASE(
 
     auto queries = ColMajorMatrix<feature_type_type>{
         {8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
-    auto query_vector_array = FeatureVectorArray(queries);
+    
     auto&& [scores_vector_array, ids_vector_array] =
-        index.query(QueryType::InfiniteRAM, query_vector_array, 1, 1);
+        index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
+    check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {10, 11, 12, 13});
+  }
 
-    auto scores = std::span<float>(
-        (float*)scores_vector_array.data(), scores_vector_array.num_vectors());
-    auto ids = std::span<uint32_t>(
-        (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
-    CHECK(std::equal(
-        scores.begin(), scores.end(), std::vector<float>{0, 0, 0, 0}.begin()));
-    CHECK(std::equal(
-        ids.begin(), ids.end(), std::vector<uint32_t>{10, 11, 12, 13}.begin()));
+  {
+    auto index = IndexIVFPQ(ctx, index_uri);
+    size_t top_k = 1;
+    size_t nprobe = 1;
+
+    auto queries = ColMajorMatrix<feature_type_type>{{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
+    for (auto upper_bound: {3, 4, 5, 100, 0}) {
+      auto&& [scores_vector_array, ids_vector_array] = index.query(QueryType::FiniteRAM, FeatureVectorArray(queries), top_k, nprobe, upper_bound);
+      check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {10, 11, 12, 13});
+
+      auto&& [scores_vector_array_infinite, ids_vector_array_infinite] = index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), top_k, nprobe);
+      check_single_vector_equals(scores_vector_array_infinite, ids_vector_array_infinite, {0, 0, 0, 0}, {10, 11, 12, 13});
+    }
   }
 }
 
@@ -332,7 +331,7 @@ TEST_CASE(
   if (vfs.is_dir(index_uri)) {
     vfs.remove_dir(index_uri);
   }
-
+  std::cout << "--------------------------------------------" << std::endl;
   {
     auto index = IndexIVFPQ(std::make_optional<IndexOptions>(
         {{"feature_type", feature_type},
@@ -351,7 +350,7 @@ TEST_CASE(
     CHECK(index.id_type_string() == id_type);
     CHECK(index.partitioning_index_type_string() == partitioning_index_type);
   }
-
+  std::cout << "--------------------------------------------" << std::endl;
   {
     auto index = IndexIVFPQ(ctx, index_uri);
 
@@ -376,6 +375,28 @@ TEST_CASE(
     auto num_ids = num_vectors(ids);
     auto recall = intersections / static_cast<double>(num_ids * k_nn);
     CHECK(recall > 0.7);
+  }
+  
+  {
+    auto index = IndexIVFPQ(ctx, index_uri);
+    size_t nprobe = 5;
+
+    auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
+    auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
+    for (auto upper_bound: {400, 1000, 0}) {
+      auto&& [_, ids] = index.query(QueryType::InfiniteRAM, query_set, k_nn, nprobe);
+      auto intersections = count_intersections(ids, groundtruth_set, k_nn);
+      auto num_ids = num_vectors(ids);
+      auto recall = intersections / static_cast<double>(num_ids * k_nn);
+      CHECK(recall > 0.7);
+
+      auto&& [__, ids_finite] = index.query(QueryType::FiniteRAM, query_set, k_nn, nprobe, upper_bound);
+      intersections = count_intersections(ids_finite, groundtruth_set, k_nn);
+      num_ids = num_vectors(ids_finite);
+      recall = intersections / static_cast<double>(num_ids * k_nn);
+      CHECK(recall > 0.7);
+
+    }
   }
 }
 
@@ -478,16 +499,19 @@ TEST_CASE("read index and query", "[api_ivf_pq_index]") {
   auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
   auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
 
-  auto&& [s, t] = a.query(QueryType::InfiniteRAM, query_set, k_nn, 5);
-  auto&& [u, v] = b.query(QueryType::InfiniteRAM, query_set, k_nn, 5);
+  auto&& [scores_1, ids_1] = a.query(QueryType::InfiniteRAM, query_set, k_nn, 5);
+  auto&& [scores_2, ids_2] = b.query(QueryType::InfiniteRAM, query_set, k_nn, 5);
+  auto&& [scores_3, ids_3] = b.query(QueryType::FiniteRAM, query_set, k_nn, 5, 500);
+  auto&& [scores_4, ids_4] = b.query(QueryType::FiniteRAM, query_set, k_nn, 5, 0);
 
-  auto intersections_a = count_intersections(t, groundtruth_set, k_nn);
-  auto intersections_b = count_intersections(v, groundtruth_set, k_nn);
-  CHECK(intersections_a == intersections_b);
-  auto nt = num_vectors(t);
-  auto nv = num_vectors(v);
-  CHECK(nt == nv);
-  auto recall = intersections_a / static_cast<double>(nt * k_nn);
+  auto intersections_1 = count_intersections(ids_1, groundtruth_set, k_nn);
+  auto intersections_2 = count_intersections(ids_2, groundtruth_set, k_nn);
+  auto intersections_3 = count_intersections(ids_3, groundtruth_set, k_nn);
+  auto intersections_4 = count_intersections(ids_4, groundtruth_set, k_nn);
+  CHECK(num_vectors(ids_1) == num_vectors(ids_2));
+  CHECK(num_vectors(ids_1) == num_vectors(ids_3));
+  CHECK(num_vectors(ids_1) == num_vectors(ids_4));
+  auto recall = intersections_1 / static_cast<double>(num_vectors(ids_1) * k_nn);
   CHECK(recall > 0.7);
 }
 
@@ -710,18 +734,9 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
 
     auto queries = ColMajorMatrix<feature_type_type>{
         {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
-    auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
-        index.query(QueryType::InfiniteRAM, query_vector_array, 1, n_list);
-
-    auto scores = std::span<float>(
-        (float*)scores_vector_array.data(), scores_vector_array.num_vectors());
-    auto ids = std::span<uint32_t>(
-        (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
-    CHECK(std::equal(
-        scores.begin(), scores.end(), std::vector<float>{0, 0, 0, 0}.begin()));
-    CHECK(std::equal(
-        ids.begin(), ids.end(), std::vector<int>{1, 2, 3, 4}.begin()));
+        index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
+    check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {1, 2, 3, 4});
 
     auto typed_index = ivf_pq_index<
         feature_type_type,
@@ -745,6 +760,16 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
     // We then load the trained index and don't set a timestamp (which means
     // we'll load it at timestamp 99).
     auto index = IndexIVFPQ(ctx, index_uri);
+
+    // Check that we can do finite and infinite queries and then train + write the index.
+    {
+      auto queries = ColMajorMatrix<feature_type_type>{{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
+      auto&& [scores_vector_array, ids_vector_array] = index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
+      check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {1, 2, 3, 4});
+
+      auto&& [scores_vector_array_finite, ids_vector_array_finite] = index.query(QueryType::FiniteRAM, FeatureVectorArray(queries), 1, 1, 4);
+      check_single_vector_equals(scores_vector_array_finite, ids_vector_array_finite, {0, 0, 0, 0}, {1, 2, 3, 4});
+    }
 
     CHECK(index.temporal_policy().timestamp_start() == 0);
     CHECK(
@@ -776,18 +801,9 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
 
     auto queries = ColMajorMatrix<feature_type_type>{
         {11, 11, 11}, {22, 22, 22}, {33, 33, 33}, {44, 44, 44}, {55, 55, 55}};
-    auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
-        index.query(QueryType::InfiniteRAM, query_vector_array, 1, 1);
-
-    auto scores = std::span<float>(
-        (float*)scores_vector_array.data(), scores_vector_array.num_vectors());
-    auto ids = std::span<uint32_t>(
-        (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
-    CHECK(std::equal(
-        scores.begin(), scores.end(), std::vector<int>{0, 0, 0, 0, 0}.begin()));
-    CHECK(std::equal(
-        ids.begin(), ids.end(), std::vector<int>{11, 22, 33, 44, 55}.begin()));
+        index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
+    check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0, 0}, {11, 22, 33, 44, 55});
 
     auto typed_index = ivf_pq_index<
         feature_type_type,
@@ -834,18 +850,12 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
 
     auto queries = ColMajorMatrix<feature_type_type>{
         {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
-    auto query_vector_array = FeatureVectorArray(queries);
+    auto&& [scores_vector_array_finite, ids_vector_array_finite] =
+        index.query(QueryType::FiniteRAM, FeatureVectorArray(queries), 1, 1);
+    check_single_vector_equals(scores_vector_array_finite, ids_vector_array_finite, {0, 0, 0, 0}, {1, 2, 3, 4});
     auto&& [scores_vector_array, ids_vector_array] =
-        index.query(QueryType::InfiniteRAM, query_vector_array, 1, 1);
-
-    auto scores = std::span<float>(
-        (float*)scores_vector_array.data(), scores_vector_array.num_vectors());
-    auto ids = std::span<uint32_t>(
-        (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
-    CHECK(std::equal(
-        scores.begin(), scores.end(), std::vector<float>{0, 0, 0, 0}.begin()));
-    CHECK(std::equal(
-        ids.begin(), ids.end(), std::vector<uint32_t>{1, 2, 3, 4}.begin()));
+        index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
+    check_single_vector_equals(scores_vector_array, ids_vector_array, {0, 0, 0, 0}, {1, 2, 3, 4});
 
     auto typed_index = ivf_pq_index<
         feature_type_type,
@@ -893,47 +903,10 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
     CHECK(index.reassign_ratio() == reassign_ratio);
 
     auto queries = ColMajorMatrix<feature_type_type>{{1, 1, 1}};
-    auto query_vector_array = FeatureVectorArray(queries);
-    {
-      auto&& [scores_vector_array, ids_vector_array] =
-          index.query(QueryType::FiniteRAM, query_vector_array, 1, 1);
-
-      auto scores = std::span<float>(
-          (float*)scores_vector_array.data(),
-          scores_vector_array.num_vectors());
-      auto ids = std::span<uint32_t>(
-          (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
-
-      CHECK(std::equal(
-          scores.begin(),
-          scores.end(),
-          std::vector<float>{std::numeric_limits<float>::max()}.begin()));
-      CHECK(std::equal(
-          ids.begin(),
-          ids.end(),
-          std::vector<uint32_t>{std::numeric_limits<uint32_t>::max()}.begin()));
-    }
-    {
-      auto&& [scores_vector_array, ids_vector_array] =
-          index.query(QueryType::InfiniteRAM, query_vector_array, 1, 1);
-
-      auto scores = std::span<float>(
-          (float*)scores_vector_array.data(),
-          scores_vector_array.num_vectors());
-      auto ids = std::span<uint32_t>(
-          (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
-      debug_vector(scores, "scores");
-      debug_vector(ids, "ids");
-
-      CHECK(std::equal(
-          scores.begin(),
-          scores.end(),
-          std::vector<float>{std::numeric_limits<float>::max()}.begin()));
-      CHECK(std::equal(
-          ids.begin(),
-          ids.end(),
-          std::vector<uint32_t>{std::numeric_limits<uint32_t>::max()}.begin()));
-    }
+    auto&& [scores_vector_array, ids_vector_array] = index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
+    check_single_vector_equals(scores_vector_array, ids_vector_array, {std::numeric_limits<float>::max()}, {std::numeric_limits<uint32_t>::max()});
+    auto&& [scores_vector_array_finite, ids_vector_array_finite] = index.query(QueryType::FiniteRAM, FeatureVectorArray(queries), 1, 1, 4);
+    check_single_vector_equals(scores_vector_array_finite, ids_vector_array_finite, {std::numeric_limits<float>::max()}, {std::numeric_limits<uint32_t>::max()});
 
     auto typed_index = ivf_pq_index<
         feature_type_type,
@@ -986,29 +959,13 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
 
     auto queries = ColMajorMatrix<feature_type_type>{
         {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
-    auto query_vector_array = FeatureVectorArray(queries);
-    auto&& [scores_vector_array, ids_vector_array] =
-        index.query(QueryType::InfiniteRAM, query_vector_array, 1, 1);
 
-    auto scores = std::span<float>(
-        (float*)scores_vector_array.data(), scores_vector_array.num_vectors());
-    auto ids = std::span<uint32_t>(
-        (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
-    CHECK(scores.size() == 4);
-    CHECK(ids.size() == 4);
     auto default_score = std::numeric_limits<float>::max();
     auto default_id = std::numeric_limits<uint32_t>::max();
-    CHECK(std::equal(
-        scores.begin(),
-        scores.end(),
-        std::vector<float>{
-            default_score, default_score, default_score, default_score}
-            .begin()));
-    CHECK(std::equal(
-        ids.begin(),
-        ids.end(),
-        std::vector<uint32_t>{default_id, default_id, default_id, default_id}
-            .begin()));
+    auto&& [scores_vector_array_finite, ids_vector_array_finite] = index.query(QueryType::FiniteRAM, FeatureVectorArray(queries), 1, 1, 0);
+    check_single_vector_equals(scores_vector_array_finite, ids_vector_array_finite, {default_score, default_score, default_score, default_score}, {default_id, default_id, default_id, default_id});
+    auto&& [scores_vector_array, ids_vector_array] = index.query(QueryType::InfiniteRAM, FeatureVectorArray(queries), 1, 1);
+    check_single_vector_equals(scores_vector_array, ids_vector_array, {default_score, default_score, default_score, default_score}, {default_id, default_id, default_id, default_id});
 
     auto typed_index = ivf_pq_index<
         feature_type_type,

--- a/src/include/test/unit_api_ivf_pq_index.cc
+++ b/src/include/test/unit_api_ivf_pq_index.cc
@@ -352,6 +352,7 @@ TEST_CASE(
   if (vfs.is_dir(index_uri)) {
     vfs.remove_dir(index_uri);
   }
+
   {
     auto index = IndexIVFPQ(std::make_optional<IndexOptions>(
         {{"feature_type", feature_type},
@@ -370,6 +371,7 @@ TEST_CASE(
     CHECK(index.id_type_string() == id_type);
     CHECK(index.partitioning_index_type_string() == partitioning_index_type);
   }
+
   {
     auto index = IndexIVFPQ(ctx, index_uri);
 

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -931,7 +931,7 @@ TEST_CASE("vamana cosine distance", "[api_vamana_index]") {
   index.add(training_vector_array);
   index.write_index(ctx, index_uri);
 
-  auto queries = ColMajorMatrix<feature_type_type>{{2, 2, 2, 2}};
+  auto queries = ColMajorMatrix<feature_type_type>{{{2, 2, 2, 2}}};
   auto query_vector_array = FeatureVectorArray(queries);
   auto&& [scores_vector_array, ids_vector_array] =
       index.query(query_vector_array, 5);

--- a/src/include/test/unit_ivf_pq_index.cc
+++ b/src/include/test/unit_ivf_pq_index.cc
@@ -692,10 +692,6 @@ TEST_CASE("query simple", "[ivf_pq_index]") {
       auto&& [scores, ids] = index.query_infinite_ram(queries, k_nn, nprobe);
       CHECK(scores(0, 0) == 0);
       CHECK(ids(0, 0) == i * 11);
-
-//      auto&& [scores_from_finite, ids_from_finite] = index.query_finite_ram(queries, k_nn, nprobe, 1);
-//      CHECK(scores_from_finite(0, 0) == 0);
-//      CHECK(ids_from_finite(0, 0) == i * 11);
     }
 
     if (vfs.is_dir(ivf_index_uri)) {
@@ -705,21 +701,17 @@ TEST_CASE("query simple", "[ivf_pq_index]") {
   }
 
   // We can load and query the index.
-  std::cout << "----------------------------------------" << std::endl;
   {
     auto index2 = ivf_pq_index<feature_type, id_type>(ctx, ivf_index_uri);
     size_t k_nn = 1;
     size_t nprobe = nlist;
     for (int i = 1; i <= 4; ++i) {
-      std::cout << "-----" << std::endl;
       auto value = static_cast<feature_type>(i);
       auto queries = ColMajorMatrix<feature_type>{{value, value, value, value}};
       
       auto&& [scores_from_finite, ids_from_finite] = index2.query_finite_ram(queries, k_nn, nprobe, 5);
       CHECK(scores_from_finite(0, 0) == 0);
       CHECK(ids_from_finite(0, 0) == i * 11);
-      
-      return;
       
       auto&& [scores, ids] = index2.query_infinite_ram(queries, k_nn, nprobe);
       CHECK(scores(0, 0) == 0);

--- a/src/include/test/unit_ivf_pq_index.cc
+++ b/src/include/test/unit_ivf_pq_index.cc
@@ -688,7 +688,7 @@ TEST_CASE("query simple", "[ivf_pq_index]") {
     for (int i = 1; i <= 4; ++i) {
       auto value = static_cast<feature_type>(i);
       auto queries = ColMajorMatrix<feature_type>{{value, value, value, value}};
-      
+
       auto&& [scores, ids] = index.query_infinite_ram(queries, k_nn, nprobe);
       CHECK(scores(0, 0) == 0);
       CHECK(ids(0, 0) == i * 11);
@@ -708,11 +708,12 @@ TEST_CASE("query simple", "[ivf_pq_index]") {
     for (int i = 1; i <= 4; ++i) {
       auto value = static_cast<feature_type>(i);
       auto queries = ColMajorMatrix<feature_type>{{value, value, value, value}};
-      
-      auto&& [scores_from_finite, ids_from_finite] = index2.query_finite_ram(queries, k_nn, nprobe, 5);
+
+      auto&& [scores_from_finite, ids_from_finite] =
+          index2.query_finite_ram(queries, k_nn, nprobe, 5);
       CHECK(scores_from_finite(0, 0) == 0);
       CHECK(ids_from_finite(0, 0) == i * 11);
-      
+
       auto&& [scores, ids] = index2.query_infinite_ram(queries, k_nn, nprobe);
       CHECK(scores(0, 0) == 0);
       CHECK(ids(0, 0) == i * 11);
@@ -776,15 +777,18 @@ TEST_CASE("ivf_pq_index query index written twice", "[ivf_pq_index]") {
         partitioning_index_type_type>(ctx, index_uri);
     auto queries = ColMajorMatrix<feature_type_type>{
         {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
-    
-    auto&& [scores_from_finite, ids_from_finite] = index.query_finite_ram(queries, 1, n_list, 5);
+
+    auto&& [scores_from_finite, ids_from_finite] =
+        index.query_finite_ram(queries, 1, n_list, 5);
     CHECK(std::equal(
         scores_from_finite.data(),
         scores_from_finite.data() + 4,
         std::vector<float>{0, 0, 0, 0}.begin()));
     CHECK(std::equal(
-        ids_from_finite.data(), ids_from_finite.data() + 4, std::vector<uint32_t>{1, 2, 3, 4}.begin()));
-    
+        ids_from_finite.data(),
+        ids_from_finite.data() + 4,
+        std::vector<uint32_t>{1, 2, 3, 4}.begin()));
+
     auto&& [scores, ids] = index.query_infinite_ram(queries, 1, n_list);
     CHECK(std::equal(
         scores.data(),

--- a/src/include/test/unit_ivf_pq_index.cc
+++ b/src/include/test/unit_ivf_pq_index.cc
@@ -688,7 +688,6 @@ TEST_CASE("query simple", "[ivf_pq_index]") {
     for (int i = 1; i <= 4; ++i) {
       auto value = static_cast<feature_type>(i);
       auto queries = ColMajorMatrix<feature_type>{{value, value, value, value}};
-
       auto&& [scores, ids] = index.query_infinite_ram(queries, k_nn, nprobe);
       CHECK(scores(0, 0) == 0);
       CHECK(ids(0, 0) == i * 11);
@@ -708,12 +707,10 @@ TEST_CASE("query simple", "[ivf_pq_index]") {
     for (int i = 1; i <= 4; ++i) {
       auto value = static_cast<feature_type>(i);
       auto queries = ColMajorMatrix<feature_type>{{value, value, value, value}};
-
       auto&& [scores_from_finite, ids_from_finite] =
           index2.query_finite_ram(queries, k_nn, nprobe, 5);
       CHECK(scores_from_finite(0, 0) == 0);
       CHECK(ids_from_finite(0, 0) == i * 11);
-
       auto&& [scores, ids] = index2.query_infinite_ram(queries, k_nn, nprobe);
       CHECK(scores(0, 0) == 0);
       CHECK(ids(0, 0) == i * 11);

--- a/src/include/test/unit_partitioned_matrix.cc
+++ b/src/include/test/unit_partitioned_matrix.cc
@@ -126,7 +126,9 @@ TEST_CASE("partitioned_matrix: training constructor", "[partitioned_matrix]") {
       ColMajorPartitionedMatrix<feature_type, id_type, part_index_type>(
           training_set, part_labels, num_parts);
   CHECK(partitioned_matrix.num_vectors() == _cpo::num_vectors(training_set));
-  CHECK(partitioned_matrix.total_num_vectors() == _cpo::num_vectors(training_set));
+  CHECK(
+      partitioned_matrix.total_num_vectors() ==
+      _cpo::num_vectors(training_set));
   CHECK(partitioned_matrix.num_partitions() == num_parts);
   CHECK(std::equal(
       partitioned_matrix.data(),

--- a/src/include/test/unit_partitioned_matrix.cc
+++ b/src/include/test/unit_partitioned_matrix.cc
@@ -47,6 +47,7 @@ TEST_CASE("partitioned_matrix: sizes constructor", "[partitioned_matrix]") {
       ColMajorPartitionedMatrix<feature_type, id_type, part_index_type>(
           dimensions, max_num_vectors, max_num_partitions);
   CHECK(partitioned_matrix.num_vectors() == 0);
+  CHECK(partitioned_matrix.total_num_vectors() == 0);
   CHECK(partitioned_matrix.num_partitions() == 0);
   CHECK(std::equal(
       partitioned_matrix.ids().begin(),
@@ -59,6 +60,7 @@ TEST_CASE("partitioned_matrix: sizes constructor", "[partitioned_matrix]") {
 
   CHECK(partitioned_matrix.load() == false);
   CHECK(partitioned_matrix.num_vectors() == 0);
+  CHECK(partitioned_matrix.total_num_vectors() == 0);
   CHECK(partitioned_matrix.num_partitions() == 0);
   CHECK(std::equal(
       partitioned_matrix.ids().begin(),
@@ -85,6 +87,7 @@ TEST_CASE("partitioned_matrix: vectors constructor", "[partitioned_matrix]") {
           parts, ids, part_index);
 
   CHECK(partitioned_matrix.num_vectors() == 4);
+  CHECK(partitioned_matrix.total_num_vectors() == 4);
   CHECK(partitioned_matrix.num_partitions() == 2);
   CHECK(std::equal(
       partitioned_matrix.ids().begin(),
@@ -97,6 +100,7 @@ TEST_CASE("partitioned_matrix: vectors constructor", "[partitioned_matrix]") {
 
   CHECK(partitioned_matrix.load() == false);
   CHECK(partitioned_matrix.num_vectors() == 4);
+  CHECK(partitioned_matrix.total_num_vectors() == 4);
   CHECK(partitioned_matrix.num_partitions() == 2);
   CHECK(std::equal(
       partitioned_matrix.ids().begin(),
@@ -122,6 +126,7 @@ TEST_CASE("partitioned_matrix: training constructor", "[partitioned_matrix]") {
       ColMajorPartitionedMatrix<feature_type, id_type, part_index_type>(
           training_set, part_labels, num_parts);
   CHECK(partitioned_matrix.num_vectors() == _cpo::num_vectors(training_set));
+  CHECK(partitioned_matrix.total_num_vectors() == _cpo::num_vectors(training_set));
   CHECK(partitioned_matrix.num_partitions() == num_parts);
   CHECK(std::equal(
       partitioned_matrix.data(),

--- a/src/include/test/unit_tdb_partitioned_matrix.cc
+++ b/src/include/test/unit_tdb_partitioned_matrix.cc
@@ -122,6 +122,7 @@ TEST_CASE("can load correctly", "[tdb_partitioned_matrix]") {
     matrix.load();
 
     CHECK(matrix.num_vectors() == 5);
+    CHECK(matrix.total_num_vectors() == 5);
     CHECK(matrix.num_partitions() == 2);
     CHECK(std::equal(
         matrix.data(),
@@ -146,6 +147,7 @@ TEST_CASE("can load correctly", "[tdb_partitioned_matrix]") {
     matrix.load();
 
     CHECK(matrix.num_vectors() == 3);
+    CHECK(matrix.total_num_vectors() == 3);
     CHECK(matrix.num_partitions() == 1);
     CHECK(std::equal(
         matrix.data(),
@@ -170,6 +172,7 @@ TEST_CASE("can load correctly", "[tdb_partitioned_matrix]") {
     matrix.load();
 
     CHECK(matrix.num_vectors() == 0);
+    CHECK(matrix.total_num_vectors() == 0);
     CHECK(matrix.num_partitions() == 0);
     CHECK(std::equal(
         matrix.data(),
@@ -309,6 +312,7 @@ TEST_CASE("test different combinations", "[tdb_partitioned_matrix]") {
           }
 
           CHECK(tdb_partitioned_matrix.num_vectors() == expected_num_vectors);
+          CHECK(tdb_partitioned_matrix.total_num_vectors() == expected_num_vectors);
           CHECK(
               tdb_partitioned_matrix.num_partitions() ==
               expected_num_partitions);
@@ -336,6 +340,7 @@ TEST_CASE(
 
   size_t num_vectors = 10000;
   uint64_t dimensions = 128;
+  size_t upper_bound = 1000;
 
   // Setup data.
   {
@@ -365,7 +370,7 @@ TEST_CASE(
   // indices with the same value). These values were taken from running
   // `api_ivf_flat_index: read index and query infinite and finite - finite out
   // of core, 1000, nprobe: 32, max_iter: 8` which used to crash with these
-  // values.
+  // values. Note that 17, 30, 54, and 59 are all missing from the series 1 -> 100.
   std::vector<part_index_type> relevant_parts = {
       1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
       18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 31, 32, 33, 34,
@@ -383,16 +388,97 @@ TEST_CASE(
       7139, 7220, 7227, 7339, 7414, 7539, 7695, 7781, 8004, 8095, 8161, 8235,
       8320, 8389, 8495, 8619, 8769, 8840, 9043, 9088, 9183, 9241, 9293, 9425,
       9548, 9625, 9743, 9880, 10000};
+    
   auto matrix =
       tdbColMajorPartitionedMatrix<feature_type, id_type, part_index_type>(
-          ctx, partitioned_vectors_uri, indices, ids_uri, relevant_parts, 1000);
+          ctx, partitioned_vectors_uri, indices, ids_uri, relevant_parts, upper_bound);
+  CHECK(matrix.num_vectors() == 0);
   while (matrix.load()) {
     CHECK(matrix.num_vectors() > 0);
+    CHECK(matrix.num_vectors() <= upper_bound);
+    CHECK(matrix.num_partitions() > 0);
+    CHECK(_cpo::dimensions(matrix) == dimensions);
+  }
+  CHECK_FALSE(matrix.load());
+}
+
+TEST_CASE(
+    "tdb_partitioned_matrix: full partition", "[tdb_partitioned_matrix]") {
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
+
+  using feature_type = uint64_t;
+  using id_type = uint64_t;
+  using part_index_type = uint64_t;
+
+  std::string partitioned_vectors_uri =
+      (std::filesystem::temp_directory_path() / "partitioned_vectors").string();
+  std::string ids_uri =
+      (std::filesystem::temp_directory_path() / "ids").string();
+
+  size_t num_vectors = 10000;
+  uint64_t dimensions = 128;
+  size_t upper_bound = 250;
+
+  // Setup data.
+  {
+    if (vfs.is_dir(partitioned_vectors_uri)) {
+      vfs.remove_dir(partitioned_vectors_uri);
+    }
+    if (vfs.is_dir(ids_uri)) {
+      vfs.remove_dir(ids_uri);
+    }
+
+    auto partitioned_vectors =
+        ColMajorMatrix<feature_type>(dimensions, num_vectors);
+    for (size_t i = 0; i < dimensions; ++i) {
+      for (size_t j = 0; j < num_vectors; ++j) {
+        partitioned_vectors(i, j) = j;
+      }
+    }
+    CHECK(::num_vectors(partitioned_vectors) == num_vectors);
+    write_matrix(ctx, partitioned_vectors, partitioned_vectors_uri);
+    std::vector<id_type> ids(num_vectors, 0);
+    for (size_t i = 0; i < num_vectors; ++i) {
+      ids[i] = i;
+    }
+    CHECK(ids.size() == num_vectors);
+    write_vector(ctx, ids, ids_uri);
+  }
+
+  std::vector<part_index_type> relevant_parts = {
+      0, 1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
+      18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+      35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+      51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
+      69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84,
+      85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99};
+  std::vector<part_index_type> indices = {
+      0,    1,    116,  215,  318,  418,  600,  662,  862,  1041, 1176, 1248,
+      1349, 1488, 1612, 1754, 1877, 1878, 1880, 2028, 2135, 2228, 2328, 2330,
+      2464, 2526, 2682, 2785, 2911, 3059, 3191, 3192, 3266, 3395, 3516, 3607,
+      3757, 3758, 3861, 3998, 4100, 4306, 4446, 4618, 4733, 4838, 4958, 5112,
+      5169, 5277, 5372, 5466, 5653, 5729, 5810, 5811, 5977, 6056, 6057, 6266,
+      6269, 6337, 6338, 6338, 6437, 6570, 6660, 6727, 6820, 6900, 7004, 7138,
+      7139, 7220, 7227, 7339, 7414, 7539, 7695, 7781, 8004, 8095, 8161, 8235,
+      8320, 8389, 8495, 8619, 8769, 8840, 9043, 9088, 9183, 9241, 9293, 9425,
+      9548, 9625, 9743, 9880, 10000};
+
+  auto matrix =
+      tdbColMajorPartitionedMatrix<feature_type, id_type, part_index_type>(
+          ctx, partitioned_vectors_uri, indices, ids_uri, relevant_parts, upper_bound);
+  CHECK(matrix.num_vectors() == 0);
+  CHECK(matrix.total_num_vectors() == num_vectors);
+  while (matrix.load()) {
+    CHECK(matrix.num_vectors() > 0);
+    CHECK(matrix.num_vectors() <= upper_bound);
+    CHECK(matrix.total_num_vectors() == num_vectors);
     CHECK(matrix.num_partitions() > 0);
     CHECK(_cpo::dimensions(matrix) == dimensions);
   }
 
   CHECK_FALSE(matrix.load());
+  CHECK(matrix.total_num_vectors() == num_vectors);
 }
 
 TEST_CASE("single vector and single partition", "[tdb_partitioned_matrix]") {
@@ -433,6 +519,7 @@ TEST_CASE("single vector and single partition", "[tdb_partitioned_matrix]") {
   matrix.load();
 
   CHECK(matrix.num_vectors() == 1);
+  CHECK(matrix.total_num_vectors() == 1);
   CHECK(matrix.num_partitions() == 1);
   CHECK(matrix.data()[0] == 1);
   CHECK(matrix.ids()[0] == 1);

--- a/src/include/test/unit_tdb_partitioned_matrix.cc
+++ b/src/include/test/unit_tdb_partitioned_matrix.cc
@@ -312,7 +312,9 @@ TEST_CASE("test different combinations", "[tdb_partitioned_matrix]") {
           }
 
           CHECK(tdb_partitioned_matrix.num_vectors() == expected_num_vectors);
-          CHECK(tdb_partitioned_matrix.total_num_vectors() == expected_num_vectors);
+          CHECK(
+              tdb_partitioned_matrix.total_num_vectors() ==
+              expected_num_vectors);
           CHECK(
               tdb_partitioned_matrix.num_partitions() ==
               expected_num_partitions);
@@ -370,7 +372,8 @@ TEST_CASE(
   // indices with the same value). These values were taken from running
   // `api_ivf_flat_index: read index and query infinite and finite - finite out
   // of core, 1000, nprobe: 32, max_iter: 8` which used to crash with these
-  // values. Note that 17, 30, 54, and 59 are all missing from the series 1 -> 100.
+  // values. Note that 17, 30, 54, and 59 are all missing from the series 1 ->
+  // 100.
   std::vector<part_index_type> relevant_parts = {
       1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
       18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 31, 32, 33, 34,
@@ -388,10 +391,15 @@ TEST_CASE(
       7139, 7220, 7227, 7339, 7414, 7539, 7695, 7781, 8004, 8095, 8161, 8235,
       8320, 8389, 8495, 8619, 8769, 8840, 9043, 9088, 9183, 9241, 9293, 9425,
       9548, 9625, 9743, 9880, 10000};
-    
+
   auto matrix =
       tdbColMajorPartitionedMatrix<feature_type, id_type, part_index_type>(
-          ctx, partitioned_vectors_uri, indices, ids_uri, relevant_parts, upper_bound);
+          ctx,
+          partitioned_vectors_uri,
+          indices,
+          ids_uri,
+          relevant_parts,
+          upper_bound);
   CHECK(matrix.num_vectors() == 0);
   while (matrix.load()) {
     CHECK(matrix.num_vectors() > 0);
@@ -447,11 +455,11 @@ TEST_CASE(
   }
 
   std::vector<part_index_type> relevant_parts = {
-      0, 1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
-      18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34,
-      35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-      51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
-      69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84,
+      0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
+      17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+      34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+      51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
+      68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84,
       85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99};
   std::vector<part_index_type> indices = {
       0,    1,    116,  215,  318,  418,  600,  662,  862,  1041, 1176, 1248,
@@ -466,7 +474,12 @@ TEST_CASE(
 
   auto matrix =
       tdbColMajorPartitionedMatrix<feature_type, id_type, part_index_type>(
-          ctx, partitioned_vectors_uri, indices, ids_uri, relevant_parts, upper_bound);
+          ctx,
+          partitioned_vectors_uri,
+          indices,
+          ids_uri,
+          relevant_parts,
+          upper_bound);
   CHECK(matrix.num_vectors() == 0);
   CHECK(matrix.total_num_vectors() == num_vectors);
   while (matrix.load()) {

--- a/src/include/test/utils/test_utils.h
+++ b/src/include/test/utils/test_utils.h
@@ -193,9 +193,15 @@ void validate_metadata(
   check_expected_arithmetic<float>(read_group, expected_arithmetic_float);
 }
 
-void check_single_vector_equals(const FeatureVectorArray &scores_vector_array, const FeatureVectorArray &ids_vector_array, const std::vector<float> &expected_scores, const std::vector<uint32_t> &expected_ids) {
-  auto scores = std::span<float>((float*)scores_vector_array.data(), scores_vector_array.num_vectors());
-  auto ids = std::span<uint32_t>((uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
+void check_single_vector_equals(
+    const FeatureVectorArray& scores_vector_array,
+    const FeatureVectorArray& ids_vector_array,
+    const std::vector<float>& expected_scores,
+    const std::vector<uint32_t>& expected_ids) {
+  auto scores = std::span<float>(
+      (float*)scores_vector_array.data(), scores_vector_array.num_vectors());
+  auto ids = std::span<uint32_t>(
+      (uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
   CHECK(scores.size() == expected_scores.size());
   CHECK(ids.size() == expected_ids.size());
   if (!std::equal(scores.begin(), scores.end(), expected_scores.begin())) {
@@ -203,7 +209,7 @@ void check_single_vector_equals(const FeatureVectorArray &scores_vector_array, c
     debug_vector(expected_scores, "expected_scores");
     CHECK(false);
   }
-  if(!std::equal(ids.begin(), ids.end(), expected_ids.begin())) {
+  if (!std::equal(ids.begin(), ids.end(), expected_ids.begin())) {
     debug_vector(ids, "ids");
     debug_vector(expected_ids, "expected_ids");
     CHECK(false);

--- a/src/include/test/utils/test_utils.h
+++ b/src/include/test/utils/test_utils.h
@@ -34,9 +34,10 @@
 
 #include <catch2/catch_all.hpp>
 #include <ranges>
-
 #include <tiledb/tiledb>
+#include "api/feature_vector_array.h"
 #include "detail/linalg/tdb_io.h"
+#include "detail/linalg/vector.h"
 
 template <class id_type>
 std::string write_ids_to_uri(
@@ -190,6 +191,23 @@ void validate_metadata(
 
   check_expected_arithmetic<size_t>(read_group, expected_arithmetic);
   check_expected_arithmetic<float>(read_group, expected_arithmetic_float);
+}
+
+void check_single_vector_equals(const FeatureVectorArray &scores_vector_array, const FeatureVectorArray &ids_vector_array, const std::vector<float> &expected_scores, const std::vector<uint32_t> &expected_ids) {
+  auto scores = std::span<float>((float*)scores_vector_array.data(), scores_vector_array.num_vectors());
+  auto ids = std::span<uint32_t>((uint32_t*)ids_vector_array.data(), ids_vector_array.num_vectors());
+  CHECK(scores.size() == expected_scores.size());
+  CHECK(ids.size() == expected_ids.size());
+  if (!std::equal(scores.begin(), scores.end(), expected_scores.begin())) {
+    debug_vector(scores, "scores");
+    debug_vector(expected_scores, "expected_scores");
+    CHECK(false);
+  }
+  if(!std::equal(ids.begin(), ids.end(), expected_ids.begin())) {
+    debug_vector(ids, "ids");
+    debug_vector(expected_ids, "expected_ids");
+    CHECK(false);
+  }
 }
 
 #endif  // TILEDB_TEST_UTILS_H


### PR DESCRIPTION
### What
Add out-of-core `query()` support to IVF PQ. We achieve this by limiting the number of vectors we load in at a single time. In Python the number of vectors is called `memory_budge`, in C++ it is `upper_bound`.

### Testing
* Adds C++ and Python unit tests for new functionality, including a test to `tdbPartitionedMatrix` to make sure we load all vectors correctly by the time `load()` is finished.
* Existing tests pass.