### PR TITLE
IVF_PQ: Remove unused pq_ivf_centroids, remove extra call to train_ivf(), add comments, cleanup code

### DIFF
--- a/apis/python/test/test_type_erased_module.py
+++ b/apis/python/test/test_type_erased_module.py
@@ -500,7 +500,7 @@ def test_construct_IndexIVFPQ_with_empty_vector(tmp_path):
     a.add(training_set)
 
     _, ids = a.query_infinite_ram(query_set, k_nn, nprobe)
-    assert recall(ids, groundtruth_set, k_nn) >= 0.89
+    assert recall(ids, groundtruth_set, k_nn) >= 0.88
 
     index_uri = os.path.join(tmp_path, "array")
     a.write_index(ctx, index_uri)
@@ -508,10 +508,10 @@ def test_construct_IndexIVFPQ_with_empty_vector(tmp_path):
     b = vspy.IndexIVFPQ(ctx, index_uri)
 
     _, ids = b.query_infinite_ram(query_set, k_nn, nprobe)
-    assert recall(ids, groundtruth_set, k_nn) >= 0.89
+    assert recall(ids, groundtruth_set, k_nn) >= 0.88
 
     _, ids = b.query_finite_ram(query_set, k_nn, nprobe, 500)
-    assert recall(ids, groundtruth_set, k_nn) >= 0.89
+    assert recall(ids, groundtruth_set, k_nn) >= 0.88
 
 
 def test_inplace_build_query_IndexIVFPQ(tmp_path):

--- a/src/include/index/ivf_pq_group.h
+++ b/src/include/index/ivf_pq_group.h
@@ -40,7 +40,7 @@
 #include "index/ivf_pq_metadata.h"
 
 // flat_ivf_centroids, partitioned_pq_vectors, partitioned_pq_index,
-// partitioned_pq_ids, cluster_centroids, distance_tables.
+// partitioned_pq_ids, cluster_centroids.
 
 [[maybe_unused]] static StorageFormat ivf_pq_storage_formats = {
     {"0.3",
@@ -53,8 +53,6 @@
          {"pq_ivf_indices_array_name", "partitioned_pq_vector_indexes"},
          {"pq_ivf_ids_array_name", "partitioned_pq_vector_ids"},
          {"pq_ivf_vectors_array_name", "partitioned_pq_vectors"},
-
-         {"distance_tables_array_name", "pq_symmetric_distance_tables"},
      }}};
 
 template <class index_type>
@@ -105,16 +103,6 @@ class ivf_pq_group : public base_index_group<index_type> {
 
   void append_valid_array_names_impl() {
     for (auto&& [array_key, array_name] : ivf_pq_storage_formats[version_]) {
-      if (array_key == "distance_tables_array_name") {
-        for (size_t i = 0; i < this->get_num_subspaces(); ++i) {
-          valid_array_keys_.insert(array_key + "_" + std::to_string(i));
-          valid_array_names_.insert(array_name + "_" + std::to_string(i));
-          array_key_to_array_name_[array_key + "_" + std::to_string(i)] =
-              array_name + "_" + std::to_string(i);
-          array_name_to_uri_[array_name] =
-              array_name_to_uri(group_uri_, array_name);
-        }
-      }
       valid_array_keys_.insert(array_key);
       valid_array_names_.insert(array_name);
       array_key_to_array_name_[array_key] = array_name;
@@ -139,13 +127,6 @@ class ivf_pq_group : public base_index_group<index_type> {
         cached_ctx_, pq_ivf_ids_uri(), 0, timestamp);
     tiledb::Array::delete_fragments(
         cached_ctx_, pq_ivf_vectors_uri(), 0, timestamp);
-
-    for (size_t i = 0; i < this->get_num_subspaces(); ++i) {
-      std::string this_table_uri =
-          distance_tables_uri() + "_" + std::to_string(i);
-      tiledb::Array::delete_fragments(
-          cached_ctx_, this_table_uri, 0, timestamp);
-    }
   }
 
   /*****************************************************************************
@@ -196,9 +177,6 @@ class ivf_pq_group : public base_index_group<index_type> {
   [[nodiscard]] auto pq_ivf_vectors_uri() const {
     return this->array_key_to_uri("pq_ivf_vectors_array_name");
   }
-  [[nodiscard]] auto distance_tables_uri() const {
-    return this->array_key_to_uri("distance_tables_array_name");
-  }
 
   [[nodiscard]] auto cluster_centroids_array_name() const {
     return this->array_key_to_array_name("cluster_centroids_array_name");
@@ -214,9 +192,6 @@ class ivf_pq_group : public base_index_group<index_type> {
   }
   [[nodiscard]] auto pq_ivf_vectors_array_name() const {
     return this->array_key_to_array_name("pq_ivf_vectors_array_name");
-  }
-  [[nodiscard]] auto distance_tables_array_name() const {
-    return this->array_key_to_array_name("distance_tables_array_name");
   }
 
   /*****************************************************************************
@@ -316,7 +291,6 @@ class ivf_pq_group : public base_index_group<index_type> {
     // - cluster_centroids
     // - flat_ivf_centroids
     // - pq_ivf_vectors (i.e. the indices, IDs, and vectors)
-    // - distance_tables
     create_empty_for_matrix<
         typename index_type::feature_type,
         stdx::layout_left>(
@@ -395,25 +369,6 @@ class ivf_pq_group : public base_index_group<index_type> {
         default_compression);
     tiledb_helpers::add_to_group(
         write_group, pq_ivf_vectors_uri(), pq_ivf_vectors_array_name());
-
-    for (size_t i = 0; i < this->get_num_subspaces(); ++i) {
-      std::string this_table_uri =
-          distance_tables_uri() + "_" + std::to_string(i);
-      std::string this_table_array_name =
-          distance_tables_array_name() + "_" + std::to_string(i);
-      create_empty_for_matrix<
-          typename index_type::score_type,
-          stdx::layout_left>(
-          cached_ctx_,
-          this_table_uri,
-          this->get_num_clusters(),
-          this->get_num_clusters(),
-          this->get_num_clusters(),
-          this->get_num_clusters(),
-          default_compression);
-      tiledb_helpers::add_to_group(
-          write_group, this_table_uri, this_table_array_name);
-    }
 
     // Store the metadata if all the arrays were created successfully
     metadata_.store_metadata(write_group);

--- a/src/include/index/ivf_pq_group.h
+++ b/src/include/index/ivf_pq_group.h
@@ -39,9 +39,8 @@
 #include "index/index_group.h"
 #include "index/ivf_pq_metadata.h"
 
-// flat_ivf_centroids, pq_ivf_centroids,
-// partitioned_pq_vectors, partitioned_pq_index, partitioned_pq_ids
-// cluster_centroids, distance_tables,
+// flat_ivf_centroids, partitioned_pq_vectors, partitioned_pq_index,
+// partitioned_pq_ids, cluster_centroids, distance_tables.
 
 [[maybe_unused]] static StorageFormat ivf_pq_storage_formats = {
     {"0.3",
@@ -49,7 +48,6 @@
          // @todo Should these be kept consistent with ivf_flat?
          {"cluster_centroids_array_name", "pq_cluster_centroids"},
          {"flat_ivf_centroids_array_name", "uncompressed_centroids"},
-         {"pq_ivf_centroids_array_name", "partition_centroids"},
 
          // The partitioned, PQ-encoded vectors.
          {"pq_ivf_indices_array_name", "partitioned_pq_vector_indexes"},
@@ -136,9 +134,6 @@ class ivf_pq_group : public base_index_group<index_type> {
         cached_ctx_, flat_ivf_centroids_uri(), 0, timestamp);
 
     tiledb::Array::delete_fragments(
-        cached_ctx_, pq_ivf_centroids_uri(), 0, timestamp);
-
-    tiledb::Array::delete_fragments(
         cached_ctx_, pq_ivf_indices_uri(), 0, timestamp);
     tiledb::Array::delete_fragments(
         cached_ctx_, pq_ivf_ids_uri(), 0, timestamp);
@@ -192,9 +187,6 @@ class ivf_pq_group : public base_index_group<index_type> {
   [[nodiscard]] auto flat_ivf_centroids_uri() const {
     return this->array_key_to_uri("flat_ivf_centroids_array_name");
   }
-  [[nodiscard]] auto pq_ivf_centroids_uri() const {
-    return this->array_key_to_uri("pq_ivf_centroids_array_name");
-  }
   [[nodiscard]] auto pq_ivf_indices_uri() const {
     return this->array_key_to_uri("pq_ivf_indices_array_name");
   }
@@ -213,9 +205,6 @@ class ivf_pq_group : public base_index_group<index_type> {
   }
   [[nodiscard]] auto flat_ivf_centroids_array_name() const {
     return this->array_key_to_array_name("flat_ivf_centroids_array_name");
-  }
-  [[nodiscard]] auto pq_ivf_centroids_array_name() const {
-    return this->array_key_to_array_name("pq_ivf_centroids_array_name");
   }
   [[nodiscard]] auto pq_ivf_indices_array_name() const {
     return this->array_key_to_array_name("pq_ivf_indices_array_name");
@@ -326,7 +315,6 @@ class ivf_pq_group : public base_index_group<index_type> {
     // re-ingestion where we want to re-train centroids)
     // - cluster_centroids
     // - flat_ivf_centroids
-    // - pq_ivf_centroids
     // - pq_ivf_vectors (i.e. the indices, IDs, and vectors)
     // - distance_tables
     create_empty_for_matrix<
@@ -378,19 +366,6 @@ class ivf_pq_group : public base_index_group<index_type> {
         default_compression);
     tiledb_helpers::add_to_group(
         write_group, flat_ivf_centroids_uri(), flat_ivf_centroids_array_name());
-
-    create_empty_for_matrix<
-        typename index_type::pq_vector_feature_type,
-        stdx::layout_left>(
-        cached_ctx_,
-        pq_ivf_centroids_uri(),
-        this->get_num_subspaces(),
-        default_domain,
-        this->get_num_subspaces(),
-        default_tile_extent,
-        default_compression);
-    tiledb_helpers::add_to_group(
-        write_group, pq_ivf_centroids_uri(), pq_ivf_centroids_array_name());
 
     create_empty_for_vector<typename index_type::indices_type>(
         cached_ctx_,

--- a/src/include/test/unit_ivf_pq_index.cc
+++ b/src/include/test/unit_ivf_pq_index.cc
@@ -333,7 +333,6 @@ TEST_CASE("ivf_index write and read", "[ivf_pq_index]") {
   CHECK(idx.compare_ivf_index(idx2));
   CHECK(idx.compare_ivf_ids(idx2));
   CHECK(idx.compare_pq_ivf_vectors(idx2));
-  CHECK(idx.compare_distance_tables(idx2));
 }
 
 TEST_CASE(
@@ -356,18 +355,13 @@ TEST_CASE(
     auto avg_error = pq_idx.verify_pq_encoding(training_set);
     CHECK(avg_error < 0.081);
   }
-  SECTION("pq_distances") {
-    auto avg_error = pq_idx.verify_pq_distances(training_set);
-    CHECK(avg_error < 0.15);
-  }
   SECTION("asymmetric_pq_distances") {
     auto [max_error, avg_error] =
         pq_idx.verify_asymmetric_pq_distances(training_set);
     CHECK(avg_error < 0.081);
   }
   SECTION("symmetric_pq_distances") {
-    auto [max_error, avg_error] =
-        pq_idx.verify_symmetric_pq_distances(training_set);
+    auto avg_error = pq_idx.verify_symmetric_pq_distances(training_set);
     CHECK(avg_error < 0.15);
   }
 }


### PR DESCRIPTION
### What
* Remove unused `pq_ivf_centroids`. I believe this was from Algorithm #3 mentioned in the code, but we don't currently use it, and I don't see a world in which we move to needing it, so remove. Note that the big change is that we no longer store it in the index when we write to URI. To me this seems okay because if we really need it again we can compute it when we load the index, we'd just PQ-encode the `flat_ivf_centroids_`, which is a matrix of `original vector dimensions x IVF partitions`.
* Remove extra call to `train_ivf()` in `train()`: This is duplicate work because we do it again in `add()`. In fact, I'd like to move shortly after this PR to a C++ API which just has `add()`, `write_index()`, and `query()`, because we don't need both `train()` and `add()`, we only need one.
* Add comments about different parts of the algorithm.
* Delete some other unused code.

### Testing
Tests pass.
