### PR TITLE
Remove train() API from type-erased indexes

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -1636,13 +1636,12 @@ def ingest(
         )
         if index_type == "VAMANA":
             index = vspy.IndexVamana(ctx, index_group_uri)
-            index.train(data)
+            index.add(data)
         elif index_type == "IVF_PQ":
             index = vspy.IndexIVFPQ(ctx, index_group_uri)
-            index.train(data, partitions)
+            index.add(data, partitions)
         else:
             raise ValueError(f"Unsupported index type: {index_type}")
-        index.add(data)
         index.write_index(ctx, index_group_uri, to_temporal_policy(index_timestamp))
 
     def write_centroids(

--- a/apis/python/src/tiledb/vector_search/ivf_pq_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_pq_index.py
@@ -185,7 +185,6 @@ def create(
     empty_vector = vspy.FeatureVectorArray(
         dimensions, 0, np.dtype(vector_type).name, np.dtype(np.uint64).name
     )
-    index.train(empty_vector)
     index.add(empty_vector)
     index.write_index(ctx, uri, vspy.TemporalPolicy(0), storage_version)
     return IVFPQIndex(uri=uri, config=config)

--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -407,12 +407,6 @@ void init_type_erased_module(py::module_& m) {
             new (&instance) IndexVamana(args);
           })
       .def(
-          "train",
-          [](IndexVamana& index, const FeatureVectorArray& vectors) {
-            index.train(vectors);
-          },
-          py::arg("vectors"))
-      .def(
           "add",
           [](IndexVamana& index, const FeatureVectorArray& vectors) {
             index.add(vectors);
@@ -481,18 +475,12 @@ void init_type_erased_module(py::module_& m) {
             new (&instance) IndexIVFPQ(args);
           })
       .def(
-          "train",
+          "add",
           [](IndexIVFPQ& index,
              const FeatureVectorArray& vectors,
-             std::optional<size_t> nlist) { index.train(vectors, nlist); },
+             std::optional<size_t> nlist) { index.add(vectors, nlist); },
           py::arg("vectors"),
           py::arg("nlist") = std::nullopt)
-      .def(
-          "add",
-          [](IndexIVFPQ& index, const FeatureVectorArray& vectors) {
-            index.add(vectors);
-          },
-          py::arg("vectors"))
       .def(
           "query",
           [](IndexIVFPQ& index,

--- a/apis/python/src/tiledb/vector_search/vamana_index.py
+++ b/apis/python/src/tiledb/vector_search/vamana_index.py
@@ -185,7 +185,6 @@ def create(
     empty_vector = vspy.FeatureVectorArray(
         dimensions, 0, np.dtype(vector_type).name, np.dtype(np.uint64).name
     )
-    index.train(empty_vector)
     index.add(empty_vector)
     index.write_index(ctx, uri, vspy.TemporalPolicy(0), storage_version)
     return VamanaIndex(uri=uri, config=config)

--- a/apis/python/test/test_type_erased_module.py
+++ b/apis/python/test/test_type_erased_module.py
@@ -386,7 +386,7 @@ def test_construct_IndexVamana_with_empty_vector(tmp_path):
         r_max_degree=r_max_degree,
     )
     empty_vector = vspy.FeatureVectorArray(dimensions, 0, feature_type, id_type)
-    a.train(empty_vector)
+    a.add(empty_vector)
     a.write_index(ctx, index_uri)
 
     # Then load it again, retrain, and query.
@@ -400,7 +400,7 @@ def test_construct_IndexVamana_with_empty_vector(tmp_path):
     assert a.l_build() == l_build
     assert a.r_max_degree() == r_max_degree
 
-    a.train(training_set)
+    a.add(training_set)
 
     s, t = a.query(query_set, k_nn, l_search)
 
@@ -423,7 +423,7 @@ def test_inplace_build_query_IndexVamana():
     groundtruth_set = vspy.FeatureVectorArray(ctx, siftsmall_groundtruth_uri)
     assert groundtruth_set.feature_type_string() == "uint64"
 
-    a.train(training_set)
+    a.add(training_set)
     s, t = a.query(query_set, k_nn, l_search)
 
     intersections = vspy.count_intersections(t, groundtruth_set, k_nn)
@@ -482,7 +482,6 @@ def test_construct_IndexIVFPQ_with_empty_vector(tmp_path):
         num_subspaces=dimensions / 2,
     )
     empty_vector = vspy.FeatureVectorArray(dimensions, 0, feature_type, id_type)
-    a.train(empty_vector)
     a.add(empty_vector)
     a.write_index(ctx, index_uri)
 
@@ -495,7 +494,6 @@ def test_construct_IndexIVFPQ_with_empty_vector(tmp_path):
     groundtruth_set = vspy.FeatureVectorArray(ctx, siftsmall_groundtruth_uri)
     assert groundtruth_set.feature_type_string() == "uint64"
 
-    a.train(training_set)
     a.add(training_set)
 
     s, t = a.query(vspy.QueryType.InfiniteRAM, query_set, k_nn, nprobe)
@@ -524,7 +522,6 @@ def test_inplace_build_query_IndexIVFPQ():
     groundtruth_set = vspy.FeatureVectorArray(ctx, siftsmall_groundtruth_uri)
     assert groundtruth_set.feature_type_string() == "uint64"
 
-    a.train(training_set)
     a.add(training_set)
     s, t = a.query(vspy.QueryType.InfiniteRAM, query_set, k_nn, nprobe)
 

--- a/src/include/api/vamana_index.h
+++ b/src/include/api/vamana_index.h
@@ -54,7 +54,6 @@
  * An index class is provides
  *   - URI-based constructor
  *   - Array-based constructor
- *   - A train method
  *   - An add method
  *   - A query method
  *
@@ -71,15 +70,13 @@ class IndexVamana {
   IndexVamana(IndexVamana&&) = default;
   IndexVamana& operator=(const IndexVamana&) = delete;
   IndexVamana& operator=(IndexVamana&&) = default;
+
   /**
    * @brief Create an index with the given configuration. The index in this
-   * state must next be trained. The sequence for creating an index in this
-   * fashion is:
+   * state must next be trained. The sequence for creating an index:
    *  - Create an IndexVamana object with the desired configuration (using this
    *  constructor
-   *  - Call train() with the training data
-   *  - Call add() to add a set of vectors to the index (often the same as the
-   *  training data)
+   *  - Call add() to add a set of vectors to the index.
    *  Either (or both)
    *    - Perform a query
    *    - Call write_index() to write the index to disk
@@ -152,19 +149,19 @@ class IndexVamana {
   }
 
   /**
-   * @brief Train the index based on the given training set.
-   * @param training_set
-   * @param init
+   * @brief Train the index and add vectors to it.
+   *
+   * @param vectors The input vectors.
+   * @todo -- infer feature type from input
    */
-  // @todo -- infer feature type from input
-  void train(const FeatureVectorArray& training_set) {
+  void add(const FeatureVectorArray& vectors) {
     if (feature_datatype_ == TILEDB_ANY) {
-      feature_datatype_ = training_set.feature_type();
-    } else if (feature_datatype_ != training_set.feature_type()) {
+      feature_datatype_ = vectors.feature_type();
+    } else if (feature_datatype_ != vectors.feature_type()) {
       throw std::runtime_error(
           "Feature datatype mismatch: " +
           datatype_to_string(feature_datatype_) +
-          " != " + datatype_to_string(training_set.feature_type()));
+          " != " + datatype_to_string(vectors.feature_type()));
     }
 
     auto type = std::tuple{
@@ -178,13 +175,13 @@ class IndexVamana {
     // l_build_, r_max_degree_), but we should also use the
     // timestamp from that already loaded index.
     index_ = dispatch_table.at(type)(
-        training_set.num_vectors(),
+        vectors.num_vectors(),
         l_build_,
         r_max_degree_,
         index_ ? std::make_optional<TemporalPolicy>(index_->temporal_policy()) :
                  std::nullopt,
         distance_metric_);
-    index_->train(training_set);
+    index_->add(vectors);
 
     if (dimensions_ != 0 && dimensions_ != index_->dimensions()) {
       throw std::runtime_error(
@@ -192,23 +189,6 @@ class IndexVamana {
           " != " + std::to_string(index_->dimensions()));
     }
     dimensions_ = index_->dimensions();
-  }
-
-  /**
-   * @brief Add a set of vectors to a trained index.
-   * @param data_set
-   */
-  void add(const FeatureVectorArray& data_set) {
-    if (feature_datatype_ != data_set.feature_type()) {
-      throw std::runtime_error(
-          "Feature datatype mismatch: " +
-          datatype_to_string(feature_datatype_) +
-          " != " + datatype_to_string(data_set.feature_type()));
-    }
-    if (!index_) {
-      throw std::runtime_error("Cannot add() because there is no index.");
-    }
-    index_->add(data_set);
   }
 
   // todo query() or search() -- or both?
@@ -323,9 +303,7 @@ class IndexVamana {
   struct index_base {
     virtual ~index_base() = default;
 
-    virtual void train(const FeatureVectorArray& training_set) = 0;
-
-    virtual void add(const FeatureVectorArray& data_set) = 0;
+    virtual void add(const FeatureVectorArray& vectors) = 0;
 
     [[nodiscard]] virtual std::tuple<FeatureVectorArray, FeatureVectorArray>
     query(
@@ -377,32 +355,23 @@ class IndexVamana {
         : impl_index_(ctx, index_uri, temporal_policy) {
     }
 
-    void train(const FeatureVectorArray& training_set) override {
+    void add(const FeatureVectorArray& vectors) override {
       using feature_type = typename T::feature_type;
       auto fspan = MatrixView<feature_type, stdx::layout_left>{
-          (feature_type*)training_set.data(),
-          extents(training_set)[0],
-          extents(training_set)[1]};
+          (feature_type*)vectors.data(),
+          extents(vectors)[0],
+          extents(vectors)[1]};
 
       using id_type = typename T::id_type;
-      if (num_ids(training_set) > 0) {
-        auto ids = std::span<id_type>(
-            (id_type*)training_set.ids(), training_set.num_vectors());
-        impl_index_.train(fspan, ids);
+      if (num_ids(vectors) > 0) {
+        auto ids =
+            std::span<id_type>((id_type*)vectors.ids(), vectors.num_vectors());
+        impl_index_.add(fspan, ids);
       } else {
-        auto ids = std::vector<id_type>(::num_vectors(training_set));
+        auto ids = std::vector<id_type>(::num_vectors(vectors));
         std::iota(ids.begin(), ids.end(), 0);
-        impl_index_.train(fspan, ids);
+        impl_index_.add(fspan, ids);
       }
-    }
-
-    void add(const FeatureVectorArray& data_set) override {
-      using feature_type = typename T::feature_type;
-      auto fspan = MatrixView<feature_type, stdx::layout_left>{
-          (feature_type*)data_set.data(),
-          extents(data_set)[0],
-          extents(data_set)[1]};
-      impl_index_.add(fspan);
     }
 
     /**

--- a/src/include/concepts.h
+++ b/src/include/concepts.h
@@ -210,16 +210,6 @@ concept partition_index =
     subscriptable_range<P>;
 
 // ----------------------------------------------------------------------------
-// vector_search_index concept (WIP)
-// ----------------------------------------------------------------------------
-template <typename I>
-concept vector_search_index = requires(I i) {
-  { i.train() };
-  { i.add() };
-  { i.search() };
-};
-
-// ----------------------------------------------------------------------------
 // distance function concepts (for function objects)
 // - A distance function takes two feature vectors and returns a distance.
 // - A sub_distance function takes two feature vectors, a start and a stop, and

--- a/src/include/index/vamana_index.h
+++ b/src/include/index/vamana_index.h
@@ -312,12 +312,18 @@ class vamana_index {
    * out-neighbors of σ(i). foreach " j∈N_"out "  (σ(i))" do " Update N_"out "
    * (j)←N_"out " (j)∪{σ(i)} if |N_"out "  (j)|>R then Run FilteredRobustPrune
    * (j,N_"out " (j),α,R) to update out-neighbors of j.
+   *
+   * @tparam Array Type of the array of vectors to be added.
+   * @tparam Vector Type of the array of vector ids to be added.
+   * @tparam Distance Type of distance metric to use.
+   * @param training_set The vectors to be added.
+   * @param training_set_ids The ids of the vectors to be added.
    */
   template <
       feature_vector_array Array,
       feature_vector Vector,
       class Distance = sum_of_squares_distance>
-  void train(
+  void add(
       const Array& training_set,
       const Vector& training_set_ids,
       Distance distance = Distance{}) {
@@ -349,7 +355,7 @@ class vamana_index {
     //    for (float alpha : {alpha_min_, alpha_max_}) {
     // Just use one value of alpha
     for (float alpha : {alpha_max_}) {
-      scoped_timer _("train " + std::to_string(counter));
+      scoped_timer _("add " + std::to_string(counter));
       size_t total_visited{0};
       for (size_t p = 0; p < num_vectors_; ++p) {
         ++counter;
@@ -406,17 +412,6 @@ class vamana_index {
       }
       // debug_index();
     }
-  }
-
-  /**
-   * @brief Add a set of vectors to the index (the vectors that will be
-   * searched over in subsequent queries).  This is a no-op for vamana.
-   *
-   * @tparam A Type of the array of vectors to be added
-   * @param database The vectors to be added
-   */
-  template <feature_vector_array A>
-  void add(const A& database) {
   }
 
   /*

--- a/src/include/test/unit_api_ivf_pq_index.cc
+++ b/src/include/test/unit_api_ivf_pq_index.cc
@@ -194,7 +194,6 @@ TEST_CASE("create empty index and then train and query", "[api_ivf_pq_index]") {
     size_t num_vectors = 0;
     auto empty_training_vector_array =
         FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
-    index.train(empty_training_vector_array);
     index.add(empty_training_vector_array);
     index.write_index(ctx, index_uri);
 
@@ -213,7 +212,6 @@ TEST_CASE("create empty index and then train and query", "[api_ivf_pq_index]") {
     auto training = ColMajorMatrix<feature_type_type>{
         {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
     auto training_vector_array = FeatureVectorArray(training);
-    index.train(training_vector_array);
     index.add(training_vector_array);
     index.write_index(ctx, index_uri);
 
@@ -269,7 +267,6 @@ TEST_CASE(
     size_t num_vectors = 0;
     auto empty_training_vector_array =
         FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
-    index.train(empty_training_vector_array);
     index.add(empty_training_vector_array);
     index.write_index(ctx, index_uri);
 
@@ -292,7 +289,6 @@ TEST_CASE(
         {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}, {10, 11, 12, 13}};
 
     auto training_vector_array = FeatureVectorArray(training);
-    index.train(training_vector_array);
     index.add(training_vector_array);
     index.write_index(ctx, index_uri);
 
@@ -343,7 +339,6 @@ TEST_CASE(
     size_t num_vectors = 0;
     auto empty_training_vector_array = FeatureVectorArray(
         siftsmall_dimensions, num_vectors, feature_type, id_type);
-    index.train(empty_training_vector_array);
     index.add(empty_training_vector_array);
     index.write_index(ctx, index_uri);
 
@@ -360,7 +355,6 @@ TEST_CASE(
     CHECK(index.partitioning_index_type_string() == partitioning_index_type);
 
     auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-    index.train(training_set);
     index.add(training_set);
     index.write_index(ctx, index_uri);
 
@@ -384,7 +378,7 @@ TEST_CASE("infer feature type", "[api_ivf_pq_index]") {
       {{"id_type", "uint32"}, {"partitioning_index_type", "uint32"}}));
   auto ctx = tiledb::Context{};
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-  a.train(training_set);
+  a.add(training_set);
   CHECK(a.feature_type() == TILEDB_FLOAT32);
   CHECK(a.id_type() == TILEDB_UINT32);
   CHECK(a.partitioning_index_type() == TILEDB_UINT32);
@@ -396,7 +390,7 @@ TEST_CASE("infer dimension", "[api_ivf_pq_index]") {
   auto ctx = tiledb::Context{};
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   CHECK(dimensions(a) == 0);
-  a.train(training_set);
+  a.add(training_set);
   CHECK(a.feature_type() == TILEDB_FLOAT32);
   CHECK(a.id_type() == TILEDB_UINT32);
   CHECK(a.partitioning_index_type() == TILEDB_UINT32);
@@ -418,7 +412,6 @@ TEST_CASE("write and read", "[api_ivf_pq_index]") {
        {"partitioning_index_type", "uint32"},
        {"num_subspaces", "1"}}));
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-  a.train(training_set);
   a.add(training_set);
   a.write_index(ctx, api_ivf_pq_index_uri);
 
@@ -440,7 +433,6 @@ TEST_CASE("build index and query", "[api_ivf_pq_index]") {
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
   auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
-  a.train(training_set);
   a.add(training_set);
 
   auto&& [s, t] = a.query(QueryType::InfiniteRAM, query_set, k_nn, 5);
@@ -470,7 +462,6 @@ TEST_CASE("read index and query", "[api_ivf_pq_index]") {
        {"num_subspaces", std::to_string(sift_dimensions / 4)}}));
 
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-  a.train(training_set);
   a.add(training_set);
   a.write_index(ctx, api_ivf_pq_index_uri);
   auto b = IndexIVFPQ(ctx, api_ivf_pq_index_uri);
@@ -518,7 +509,6 @@ TEST_CASE("storage_version", "[api_ivf_pq_index]") {
     size_t num_vectors = 0;
     auto empty_training_vector_array =
         FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
-    index.train(empty_training_vector_array);
     index.add(empty_training_vector_array);
     index.write_index(ctx, index_uri, std::nullopt, "0.3");
 
@@ -535,7 +525,6 @@ TEST_CASE("storage_version", "[api_ivf_pq_index]") {
         {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}, {10, 11, 12, 13}};
 
     auto training_vector_array = FeatureVectorArray(training);
-    index.train(training_vector_array);
     index.add(training_vector_array);
 
     // Throw with the wrong version.
@@ -581,7 +570,6 @@ TEST_CASE("clear history with an open index", "[api_ivf_pq_index]") {
   auto training = ColMajorMatrixWithIds<feature_type_type, id_type_type>{
       {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}, {1, 2, 3, 4}};
   auto training_vector_array = FeatureVectorArray(training);
-  index.train(training_vector_array);
   index.add(training_vector_array);
   index.write_index(ctx, index_uri, TemporalPolicy(TimeTravel, 99));
 
@@ -638,7 +626,6 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
     size_t num_vectors = 0;
     auto empty_training_vector_array =
         FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
-    index.train(empty_training_vector_array);
     index.add(empty_training_vector_array);
     index.write_index(ctx, index_uri, TemporalPolicy(TimeTravel, 0));
 
@@ -697,7 +684,6 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
         {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}, {1, 2, 3, 4}};
 
     auto training_vector_array = FeatureVectorArray(training);
-    index.train(training_vector_array);
     index.add(training_vector_array);
     // We then write the index at timestamp 99.
     index.write_index(ctx, index_uri, TemporalPolicy(TimeTravel, 99));
@@ -762,7 +748,6 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
         {11, 22, 33, 44, 55}};
 
     auto training_vector_array = FeatureVectorArray(training);
-    index.train(training_vector_array);
     index.add(training_vector_array);
     // We then write the index at timestamp 100.
     index.write_index(ctx, index_uri, TemporalPolicy(TimeTravel, 100));

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -150,7 +150,6 @@ TEST_CASE("create empty index and then train and query", "[api_vamana_index]") {
     size_t num_vectors = 0;
     auto empty_training_vector_array =
         FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
-    index.train(empty_training_vector_array);
     index.add(empty_training_vector_array);
     index.write_index(ctx, index_uri);
 
@@ -167,7 +166,6 @@ TEST_CASE("create empty index and then train and query", "[api_vamana_index]") {
     auto training = ColMajorMatrix<feature_type_type>{
         {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
     auto training_vector_array = FeatureVectorArray(training);
-    index.train(training_vector_array);
     index.add(training_vector_array);
     index.write_index(ctx, index_uri);
 
@@ -216,7 +214,6 @@ TEST_CASE(
     size_t num_vectors = 0;
     auto empty_training_vector_array =
         FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
-    index.train(empty_training_vector_array);
     index.add(empty_training_vector_array);
     index.write_index(ctx, index_uri);
 
@@ -234,7 +231,6 @@ TEST_CASE(
         {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}, {10, 11, 12, 13}};
 
     auto training_vector_array = FeatureVectorArray(training);
-    index.train(training_vector_array);
     index.add(training_vector_array);
     index.write_index(ctx, index_uri);
 
@@ -280,7 +276,6 @@ TEST_CASE(
     size_t num_vectors = 0;
     auto empty_training_vector_array = FeatureVectorArray(
         siftsmall_dimensions, num_vectors, feature_type, id_type);
-    index.train(empty_training_vector_array);
     index.add(empty_training_vector_array);
     index.write_index(ctx, index_uri);
 
@@ -295,7 +290,6 @@ TEST_CASE(
     CHECK(index.id_type_string() == id_type);
 
     auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-    index.train(training_set);
     index.add(training_set);
     index.write_index(ctx, index_uri);
 
@@ -317,7 +311,7 @@ TEST_CASE("infer feature type", "[api_vamana_index]") {
       IndexVamana(std::make_optional<IndexOptions>({{"id_type", "uint32"}}));
   auto ctx = tiledb::Context{};
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-  a.train(training_set);
+  a.add(training_set);
   CHECK(a.feature_type() == TILEDB_FLOAT32);
   CHECK(a.id_type() == TILEDB_UINT32);
 }
@@ -328,7 +322,7 @@ TEST_CASE("infer dimension", "[api_vamana_index]") {
   auto ctx = tiledb::Context{};
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   CHECK(dimensions(a) == 0);
-  a.train(training_set);
+  a.add(training_set);
   CHECK(a.feature_type() == TILEDB_FLOAT32);
   CHECK(a.id_type() == TILEDB_UINT32);
   CHECK(dimensions(a) == 128);
@@ -348,7 +342,6 @@ TEST_CASE("api_vamana_index write and read", "[api_vamana_index]") {
       {"id_type", "uint32"},
   }));
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-  a.train(training_set);
   a.add(training_set);
   a.write_index(ctx, api_vamana_index_uri);
 
@@ -369,7 +362,6 @@ TEST_CASE("build index and query", "[api_vamana_index]") {
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
   auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
   auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
-  a.train(training_set);
   a.add(training_set);
 
   auto&& [s, t] = a.query(query_set, k_nn);
@@ -397,7 +389,6 @@ TEST_CASE("read index and query", "[api_vamana_index]") {
   }));
 
   auto training_set = FeatureVectorArray(ctx, siftsmall_inputs_uri);
-  a.train(training_set);
   a.add(training_set);
   a.write_index(ctx, api_vamana_index_uri);
   auto b = IndexVamana(ctx, api_vamana_index_uri);
@@ -441,7 +432,6 @@ TEST_CASE("storage_version", "[api_vamana_index]") {
     size_t num_vectors = 0;
     auto empty_training_vector_array =
         FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
-    index.train(empty_training_vector_array);
     index.add(empty_training_vector_array);
     index.write_index(ctx, index_uri, std::nullopt, "0.3");
 
@@ -457,7 +447,6 @@ TEST_CASE("storage_version", "[api_vamana_index]") {
         {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}, {10, 11, 12, 13}};
 
     auto training_vector_array = FeatureVectorArray(training);
-    index.train(training_vector_array);
     index.add(training_vector_array);
 
     // Throw with the wrong version.
@@ -497,7 +486,6 @@ TEST_CASE("clear history with an open index", "[api_ivf_pq_index]") {
   auto training = ColMajorMatrixWithIds<feature_type_type, id_type_type>{
       {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}, {1, 2, 3, 4}};
   auto training_vector_array = FeatureVectorArray(training);
-  index.train(training_vector_array);
   index.add(training_vector_array);
   index.write_index(ctx, index_uri, TemporalPolicy(TimeTravel, 99));
 
@@ -545,7 +533,6 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     size_t num_vectors = 0;
     auto empty_training_vector_array =
         FeatureVectorArray(dimensions, num_vectors, feature_type, id_type);
-    index.train(empty_training_vector_array);
     index.add(empty_training_vector_array);
     index.write_index(ctx, index_uri, TemporalPolicy(TimeTravel, 0));
 
@@ -594,7 +581,6 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
         {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}, {1, 2, 3, 4}};
 
     auto training_vector_array = FeatureVectorArray(training);
-    index.train(training_vector_array);
     index.add(training_vector_array);
     // We then write the index at timestamp 99.
     index.write_index(ctx, index_uri, TemporalPolicy(TimeTravel, 99));
@@ -658,7 +644,6 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
         {11, 22, 33, 44, 55}};
 
     auto training_vector_array = FeatureVectorArray(training);
-    index.train(training_vector_array);
     index.add(training_vector_array);
     // We then write the index at timestamp 100.
     index.write_index(ctx, index_uri, TemporalPolicy(TimeTravel, 100));

--- a/src/include/test/unit_ivf_pq_index.cc
+++ b/src/include/test/unit_ivf_pq_index.cc
@@ -531,7 +531,6 @@ TEST_CASE("ivf_pq_index write and read", "[ivf_pq_index]") {
 
   auto idx = ivf_pq_index<siftsmall_feature_type, siftsmall_ids_type>(
       10, siftsmall_dimensions / 2);
-  idx.train(training_set, ids);
   idx.add(training_set, ids);
   uint64_t write_timestamp = 1000;
   idx.write_index(
@@ -597,7 +596,6 @@ TEST_CASE("query empty index", "[ivf_pq_index]") {
     auto data =
         ColMajorMatrixWithIds<siftsmall_feature_type>(dimensions, num_vectors);
     debug_matrix_with_ids(data, "data");
-    index.train(data, data.raveled_ids());
     index.add(data, data.raveled_ids());
   }
 
@@ -670,7 +668,6 @@ TEST_CASE("query simple", "[ivf_pq_index]") {
     auto training = ColMajorMatrixWithIds<feature_type>{
         {{1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}, {4, 4, 4, 4}},
         {11, 22, 33, 44}};
-    index.train(training, training.raveled_ids());
     index.add(training, training.raveled_ids());
 
     size_t k_nn = 1;
@@ -738,7 +735,6 @@ TEST_CASE("ivf_pq_index query index written twice", "[ivf_pq_index]") {
         partitioning_index_type_type>(n_list, dimensions / 2);
     auto data =
         ColMajorMatrixWithIds<feature_type_type, id_type_type>(dimensions, 0);
-    index.train(data, data.raveled_ids());
     index.add(data, data.raveled_ids());
     index.write_index(ctx, index_uri, TemporalPolicy(TimeTravel, 0));
   }
@@ -751,7 +747,6 @@ TEST_CASE("ivf_pq_index query index written twice", "[ivf_pq_index]") {
         partitioning_index_type_type>(ctx, index_uri);
     auto data = ColMajorMatrixWithIds<feature_type_type, id_type_type>{
         {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}, {1, 2, 3, 4}};
-    index.train(data, data.raveled_ids());
     index.add(data, data.raveled_ids());
     index.write_index(ctx, index_uri, TemporalPolicy(TimeTravel, 99));
   }

--- a/src/include/test/unit_ivf_pq_metadata.cc
+++ b/src/include/test/unit_ivf_pq_metadata.cc
@@ -90,7 +90,6 @@ TEST_CASE("load metadata from index", "[ivf_pq_metadata]") {
     auto training_vectors =
         ColMajorMatrixWithIds<siftsmall_feature_type, siftsmall_ids_type>(
             128, 0);
-    idx.train(training_vectors, training_vectors.raveled_ids());
     idx.add(training_vectors, training_vectors.raveled_ids());
     idx.write_index(ctx, uri, TemporalPolicy(TimeTravel, 0));
     auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);
@@ -131,7 +130,6 @@ TEST_CASE("load metadata from index", "[ivf_pq_metadata]") {
         siftsmall_feature_type,
         siftsmall_ids_type>(ctx, siftsmall_inputs_uri, siftsmall_ids_uri, 222);
 
-    idx.train(training_vectors, training_vectors.raveled_ids());
     idx.add(training_vectors, training_vectors.raveled_ids());
     idx.write_index(ctx, uri, TemporalPolicy(TimeTravel, 2), "");
 
@@ -165,7 +163,6 @@ TEST_CASE("load metadata from index", "[ivf_pq_metadata]") {
         siftsmall_feature_type,
         siftsmall_ids_type>(ctx, siftsmall_inputs_uri, siftsmall_ids_uri, 333);
 
-    idx.train(training_vectors, training_vectors.raveled_ids());
     idx.add(training_vectors, training_vectors.raveled_ids());
     idx.write_index(ctx, uri, TemporalPolicy(TimeTravel, 3));
 

--- a/src/include/test/unit_vamana_index.cc
+++ b/src/include/test/unit_vamana_index.cc
@@ -1180,7 +1180,7 @@ TEST_CASE("vamana_index vector diskann_test_256bin", "[vamana]") {
   std::vector<siftsmall_ids_type> ids(num_vectors(x));
   std::iota(begin(ids), end(ids), 0);
 
-  index.train(x, ids);
+  index.add(x, ids);
 
   // x, 5, 7, 7, 1.0, 1, 1);
   // 0
@@ -1293,7 +1293,7 @@ TEST_CASE("vamana_index geometric 2D graph", "[vamana]") {
   std::vector<siftsmall_ids_type> ids(num_nodes);
   auto ids_start = 10;
   std::iota(begin(ids), end(ids), ids_start);
-  idx.train(training_set, ids);
+  idx.add(training_set, ids);
 
   auto query = training_set[17];
   auto&& [scores, top_k] = idx.query(query, k_nn);
@@ -1352,7 +1352,7 @@ TEST_CASE("vamana_index siftsmall", "[vamana]") {
 
   auto idx = vamana_index<siftsmall_feature_type, siftsmall_ids_type>(
       num_vectors(training_set), l_build, r_max_degree);
-  idx.train(training_set, ids);
+  idx.add(training_set, ids);
 
   auto&& [mat_scores, mat_top_k] = idx.query(queries, k_nn);
 
@@ -1397,7 +1397,7 @@ TEST_CASE("vamana_index write and read", "[vamana]") {
 
   auto idx = vamana_index<siftsmall_feature_type, siftsmall_ids_type>(
       num_vectors(training_set), l_build, r_max_degree);
-  idx.train(training_set, ids);
+  idx.add(training_set, ids);
   uint64_t write_timestamp = 1000;
   idx.write_index(
       ctx, vamana_index_uri, TemporalPolicy(TimeTravel, write_timestamp));
@@ -1462,7 +1462,7 @@ TEST_CASE("query empty index", "[vamana]") {
       num_vectors, l_build, r_max_degree);
   auto data =
       ColMajorMatrixWithIds<siftsmall_feature_type>(dimensions, num_vectors);
-  index.train(data, data.raveled_ids());
+  index.add(data, data.raveled_ids());
 
   auto&& [scores, ids] = index.query(data, 1);
   CHECK(_cpo::num_vectors(scores) == 0);

--- a/src/include/test/unit_vamana_metadata.cc
+++ b/src/include/test/unit_vamana_metadata.cc
@@ -79,8 +79,7 @@ TEST_CASE("load metadata from index", "[vamana_metadata]") {
     auto training_vectors =
         ColMajorMatrixWithIds<siftsmall_feature_type, siftsmall_ids_type>(
             128, 0);
-    idx.train(training_vectors, training_vectors.raveled_ids());
-    idx.add(training_vectors);
+    idx.add(training_vectors, training_vectors.raveled_ids());
     idx.write_index(ctx, uri, TemporalPolicy(TimeTravel, 0));
 
     auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);
@@ -115,8 +114,7 @@ TEST_CASE("load metadata from index", "[vamana_metadata]") {
         siftsmall_feature_type,
         siftsmall_ids_type>(ctx, siftsmall_inputs_uri, siftsmall_ids_uri, 222);
 
-    idx.train(training_vectors, training_vectors.raveled_ids());
-    idx.add(training_vectors);
+    idx.add(training_vectors, training_vectors.raveled_ids());
     idx.write_index(ctx, uri, TemporalPolicy(TimeTravel, 2), "");
 
     auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);
@@ -148,8 +146,7 @@ TEST_CASE("load metadata from index", "[vamana_metadata]") {
         siftsmall_feature_type,
         siftsmall_ids_type>(ctx, siftsmall_inputs_uri, siftsmall_ids_uri, 333);
 
-    idx.train(training_vectors, training_vectors.raveled_ids());
-    idx.add(training_vectors);
+    idx.add(training_vectors, training_vectors.raveled_ids());
     idx.write_index(ctx, uri, TemporalPolicy(TimeTravel, 3));
 
     auto read_group = tiledb::Group(ctx, uri, TILEDB_READ, cfg);

--- a/src/include/test/utils/query_common.h
+++ b/src/include/test/utils/query_common.h
@@ -196,11 +196,9 @@ struct siftsmall_test_init : public siftsmall_test_init_defaults {
                       IndexType,
                       ivf_flat_index<feature_type, id_type, px_type>>) {
       idx.train(training_set);
-    } else if constexpr (std::is_same_v<
+    } else if constexpr (!std::is_same_v<
                              IndexType,
                              ivf_pq_index<feature_type, id_type, px_type>>) {
-      idx.train_ivf(training_set);
-    } else {
       std::cout << "Unsupported index type" << std::endl;
     }
     idx.add(training_set, ids);

--- a/src/src/vamana/vamana_index.cc
+++ b/src/src/vamana/vamana_index.cc
@@ -113,7 +113,7 @@ int main(int argc, char* argv[]) {
 
     auto idx =
         vamana_index<feature_type, id_type>(num_vectors(X), Lbuild, max_degree);
-    idx.train(X);
+    idx.add(X);
     idx.write_index(ctx, index_uri, overwrite);
 
     if (args["--log"]) {


### PR DESCRIPTION
### What
Here we remove the `train()` API from type-erased indexes for a few reasons:
1. It is unused.
2. I don't see a path anytime soon with Vamana or IVF PQ to need this.
3. Removing it will make our code somewhat faster (just not needing to call into C++, even though I believe everything should be by reference).
4. The code is simpler.
5. If we want this API in the future, we can just add it back, but actually have it do something.

Note that I was motivated to do this because when looking at out of core ingestion, it seems easier to reason about things without having two separate APIs which do the same thing.

### Testing
Tests pass.