### PR TITLE
Fix infinite loop in kmeans

### DIFF
--- a/src/include/index/kmeans.h
+++ b/src/include/index/kmeans.h
@@ -81,16 +81,18 @@ void kmeans_pp(
     Distance distancex = Distance{}) {
   scoped_timer _{__FUNCTION__};
   if (::num_vectors(centroids_) != num_partitions_) {
-    throw std::runtime_error("[kmeans@kmeans_random_init] Number of partitions (" +
-                             std::to_string(num_partitions_) +
-                             ") does not match number of centroids (" +
-                             std::to_string(::num_vectors(centroids_)) + ")");
+    throw std::runtime_error(
+        "[kmeans@kmeans_random_init] Number of partitions (" +
+        std::to_string(num_partitions_) +
+        ") does not match number of centroids (" +
+        std::to_string(::num_vectors(centroids_)) + ")");
   }
   if (num_vectors(training_set) < num_partitions_) {
-    throw std::runtime_error("[kmeans@kmeans_random_init] Number of vectors (" +
-                             std::to_string(num_vectors(training_set)) +
-                             ") is less than number of partitions (" +
-                             std::to_string(num_partitions_) + ")");
+    throw std::runtime_error(
+        "[kmeans@kmeans_random_init] Number of vectors (" +
+        std::to_string(num_vectors(training_set)) +
+        ") is less than number of partitions (" +
+        std::to_string(num_partitions_) + ")");
   }
   if (::num_vectors(training_set) == 0) {
     return;
@@ -179,16 +181,18 @@ void kmeans_random_init(
     const V& training_set, C& centroids_, size_t num_partitions_) {
   scoped_timer _{__FUNCTION__};
   if (::num_vectors(centroids_) != num_partitions_) {
-    throw std::runtime_error("[kmeans@kmeans_random_init] Number of partitions (" +
-                             std::to_string(num_partitions_) +
-                             ") does not match number of centroids (" +
-                             std::to_string(::num_vectors(centroids_)) + ")");
+    throw std::runtime_error(
+        "[kmeans@kmeans_random_init] Number of partitions (" +
+        std::to_string(num_partitions_) +
+        ") does not match number of centroids (" +
+        std::to_string(::num_vectors(centroids_)) + ")");
   }
   if (num_vectors(training_set) < num_partitions_) {
-    throw std::runtime_error("[kmeans@kmeans_random_init] Number of vectors (" +
-                             std::to_string(num_vectors(training_set)) +
-                             ") is less than number of partitions (" +
-                             std::to_string(num_partitions_) + ")");
+    throw std::runtime_error(
+        "[kmeans@kmeans_random_init] Number of vectors (" +
+        std::to_string(num_vectors(training_set)) +
+        ") is less than number of partitions (" +
+        std::to_string(num_partitions_) + ")");
   }
   if (::num_vectors(training_set) == 0) {
     return;

--- a/src/include/index/kmeans.h
+++ b/src/include/index/kmeans.h
@@ -166,15 +166,22 @@ template <feature_vector_array V, feature_vector_array C>
 void kmeans_random_init(
     const V& training_set, C& centroids_, size_t num_partitions_) {
   scoped_timer _{__FUNCTION__};
-  if (::num_vectors(training_set) == 0) {
+  if (::num_vectors(centroids_) != num_partitions_) {
+    throw std::runtime_error("[kmeans@kmeans_random_init] Number of partitions does not match number of centroids");
+  }
+  size_t num_to_choose = std::min(num_partitions_, num_vectors(training_set));
+  if (num_to_choose == 0) {
+    for (size_t i = 0; i < ::num_vectors(centroids_); ++i) {
+      std::fill(begin(centroids_[i]), end(centroids_[i]), 0.0f);
+    }
     return;
   }
 
-  std::vector<size_t> indices(num_partitions_);
+  std::vector<size_t> indices(num_to_choose);
 
   std::vector<bool> visited(training_set.num_cols(), false);
   std::uniform_int_distribution<> dis(0, training_set.num_cols() - 1);
-  for (size_t i = 0; i < num_partitions_; ++i) {
+  for (size_t i = 0; i < num_to_choose; ++i) {
     size_t index;
     do {
       index = dis(PRNG::get().generator());
@@ -185,7 +192,7 @@ void kmeans_random_init(
 
   // std::iota(begin(indices), end(indices), 0);
   // std::shuffle(begin(indices), end(indices), gen_);
-  for (size_t i = 0; i < num_partitions_; ++i) {
+  for (size_t i = 0; i < num_to_choose; ++i) {
     std::copy(
         begin(training_set[indices[i]]),
         end(training_set[indices[i]]),

--- a/src/include/index/kmeans.h
+++ b/src/include/index/kmeans.h
@@ -80,23 +80,23 @@ void kmeans_pp(
     size_t num_threads_,
     Distance distancex = Distance{}) {
   scoped_timer _{__FUNCTION__};
+
   if (::num_vectors(centroids_) != num_partitions_) {
     throw std::runtime_error(
-        "[kmeans@kmeans_random_init] Number of partitions (" +
+        "[kmeans@kmeans_pp] Number of partitions (" +
         std::to_string(num_partitions_) +
         ") does not match number of centroids (" +
         std::to_string(::num_vectors(centroids_)) + ")");
   }
-  if (num_vectors(training_set) < num_partitions_) {
-    throw std::runtime_error(
-        "[kmeans@kmeans_random_init] Number of vectors (" +
-        std::to_string(num_vectors(training_set)) +
-        ") is less than number of partitions (" +
-        std::to_string(num_partitions_) + ")");
-  }
-  if (::num_vectors(training_set) == 0) {
+
+  size_t num_to_choose = std::min(num_partitions_, num_vectors(training_set));
+  if (num_to_choose == 0) {
+    for (size_t i = 0; i < ::num_vectors(centroids_); ++i) {
+      std::fill(begin(centroids_[i]), end(centroids_[i]), 0.0f);
+    }
     return;
   }
+
   using score_type = typename C::value_type;
 
   std::uniform_int_distribution<> dis(0, training_set.num_cols() - 1);
@@ -117,7 +117,7 @@ void kmeans_pp(
 #endif
 
   // Calculate the remaining centroids using K-means++ algorithm
-  for (size_t i = 1; i < num_partitions_; ++i) {
+  for (size_t i = 1; i < num_to_choose; ++i) {
     stdx::execution::indexed_parallel_policy par{num_threads_};
     stdx::range_for_each(
         std::move(par),
@@ -170,6 +170,11 @@ void kmeans_pp(
     }
 #endif
   }
+
+  // Fill remaining centroids with zeros if num_partitions_ > num_to_choose
+  for (size_t i = num_to_choose; i < num_partitions_; ++i) {
+    std::fill(begin(centroids_[i]), end(centroids_[i]), 0.0f);
+  }
 }
 
 /**
@@ -187,22 +192,18 @@ void kmeans_random_init(
         ") does not match number of centroids (" +
         std::to_string(::num_vectors(centroids_)) + ")");
   }
-  if (num_vectors(training_set) < num_partitions_) {
-    throw std::runtime_error(
-        "[kmeans@kmeans_random_init] Number of vectors (" +
-        std::to_string(num_vectors(training_set)) +
-        ") is less than number of partitions (" +
-        std::to_string(num_partitions_) + ")");
-  }
-  if (::num_vectors(training_set) == 0) {
+  size_t num_to_choose = std::min(num_partitions_, num_vectors(training_set));
+  if (num_to_choose == 0) {
+    for (size_t i = 0; i < ::num_vectors(centroids_); ++i) {
+      std::fill(begin(centroids_[i]), end(centroids_[i]), 0.0f);
+    }
     return;
   }
 
-  std::vector<size_t> indices(num_partitions_);
-
+  std::vector<size_t> indices(num_to_choose);
   std::vector<bool> visited(training_set.num_cols(), false);
   std::uniform_int_distribution<> dis(0, training_set.num_cols() - 1);
-  for (size_t i = 0; i < num_partitions_; ++i) {
+  for (size_t i = 0; i < num_to_choose; ++i) {
     size_t index;
     do {
       index = dis(PRNG::get().generator());
@@ -213,11 +214,14 @@ void kmeans_random_init(
 
   // std::iota(begin(indices), end(indices), 0);
   // std::shuffle(begin(indices), end(indices), gen_);
-  for (size_t i = 0; i < num_partitions_; ++i) {
+  for (size_t i = 0; i < num_to_choose; ++i) {
     std::copy(
         begin(training_set[indices[i]]),
         end(training_set[indices[i]]),
         begin(centroids_[i]));
+  }
+  for (size_t i = num_to_choose; i < num_partitions_; ++i) {
+    std::fill(begin(centroids_[i]), end(centroids_[i]), 0.0f);
   }
 }
 

--- a/src/include/index/kmeans.h
+++ b/src/include/index/kmeans.h
@@ -167,21 +167,23 @@ void kmeans_random_init(
     const V& training_set, C& centroids_, size_t num_partitions_) {
   scoped_timer _{__FUNCTION__};
   if (::num_vectors(centroids_) != num_partitions_) {
-    throw std::runtime_error("[kmeans@kmeans_random_init] Number of partitions does not match number of centroids");
+    throw std::runtime_error("[kmeans@kmeans_random_init] Number of partitions (" +
+                             std::to_string(num_partitions_) +
+                             ") does not match number of centroids (" +
+                             std::to_string(::num_vectors(centroids_)) + ")");
   }
-  size_t num_to_choose = std::min(num_partitions_, num_vectors(training_set));
-  if (num_to_choose == 0) {
-    for (size_t i = 0; i < ::num_vectors(centroids_); ++i) {
-      std::fill(begin(centroids_[i]), end(centroids_[i]), 0.0f);
-    }
-    return;
+  if (num_vectors(training_set) < num_partitions_) {
+    throw std::runtime_error("[kmeans@kmeans_random_init] Number of vectors (" +
+                             std::to_string(num_vectors(training_set)) +
+                             ") is less than number of partitions (" +
+                             std::to_string(num_partitions_) + ")");
   }
 
-  std::vector<size_t> indices(num_to_choose);
+  std::vector<size_t> indices(num_partitions_);
 
   std::vector<bool> visited(training_set.num_cols(), false);
   std::uniform_int_distribution<> dis(0, training_set.num_cols() - 1);
-  for (size_t i = 0; i < num_to_choose; ++i) {
+  for (size_t i = 0; i < num_partitions_; ++i) {
     size_t index;
     do {
       index = dis(PRNG::get().generator());
@@ -192,7 +194,7 @@ void kmeans_random_init(
 
   // std::iota(begin(indices), end(indices), 0);
   // std::shuffle(begin(indices), end(indices), gen_);
-  for (size_t i = 0; i < num_to_choose; ++i) {
+  for (size_t i = 0; i < num_partitions_; ++i) {
     std::copy(
         begin(training_set[indices[i]]),
         end(training_set[indices[i]]),

--- a/src/include/index/kmeans.h
+++ b/src/include/index/kmeans.h
@@ -80,6 +80,18 @@ void kmeans_pp(
     size_t num_threads_,
     Distance distancex = Distance{}) {
   scoped_timer _{__FUNCTION__};
+  if (::num_vectors(centroids_) != num_partitions_) {
+    throw std::runtime_error("[kmeans@kmeans_random_init] Number of partitions (" +
+                             std::to_string(num_partitions_) +
+                             ") does not match number of centroids (" +
+                             std::to_string(::num_vectors(centroids_)) + ")");
+  }
+  if (num_vectors(training_set) < num_partitions_) {
+    throw std::runtime_error("[kmeans@kmeans_random_init] Number of vectors (" +
+                             std::to_string(num_vectors(training_set)) +
+                             ") is less than number of partitions (" +
+                             std::to_string(num_partitions_) + ")");
+  }
   if (::num_vectors(training_set) == 0) {
     return;
   }
@@ -177,6 +189,9 @@ void kmeans_random_init(
                              std::to_string(num_vectors(training_set)) +
                              ") is less than number of partitions (" +
                              std::to_string(num_partitions_) + ")");
+  }
+  if (::num_vectors(training_set) == 0) {
+    return;
   }
 
   std::vector<size_t> indices(num_partitions_);

--- a/src/include/test/CMakeLists.txt
+++ b/src/include/test/CMakeLists.txt
@@ -128,6 +128,8 @@ kmeans_add_test(unit_index_defs)
 
 kmeans_add_test(unit_ivf_qv)
 
+kmeans_add_test(unit_kmeans)
+
 # Needs to be updated to new partitioned matrix API
 # kmeans_add_test(unit_ivf_vq)
 

--- a/src/include/test/unit_kmeans.cc
+++ b/src/include/test/unit_kmeans.cc
@@ -1,0 +1,164 @@
+/**
+ * @file unit_kmeans.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ */
+
+#include <catch2/catch_all.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include "index/ivf_flat_index.h"
+#include "test/utils/array_defs.h"
+#include "test/utils/gen_graphs.h"
+#include "test/utils/query_common.h"
+
+TEST_CASE("test kmeans random initialization", "[kmeans][init]") {
+  const bool debug = false;
+
+  // Sample data: 4-dimensional data points, 8 data points total
+  std::vector<float> data = {8, 6, 7, 5, 3, 3, 7, 2, 1, 4, 1, 3, 
+                             0, 5, 1, 2, 9, 9, 5, 9, 2, 0, 2, 7, 
+                             7, 9, 8, 6, 7, 9, 6, 6};
+
+  ColMajorMatrix<float> training_data(4, 8);  // 4 rows, 8 columns
+  std::copy(begin(data), end(data), training_data.data());
+
+  // Number of partitions (centroids) to initialize
+  size_t num_partitions = 3;
+
+  // Create an empty matrix for centroids with dimensions matching the number of partitions
+  ColMajorMatrix<float> centroids(4, num_partitions);
+
+  // Perform random initialization of centroids
+  kmeans_random_init(training_data, centroids, num_partitions);
+
+  {
+    // Verify Centroid Dimensions
+    CHECK(centroids.num_cols() == num_partitions);
+    CHECK(centroids.num_rows() == 4);
+  }
+
+  {
+    // Verify Centroid Uniqueness
+    for (size_t i = 0; i < centroids.num_cols() - 1; ++i) {
+      for (size_t j = i + 1; j < centroids.num_cols(); ++j) {
+        CHECK_FALSE(std::equal(
+          centroids[i].begin(), centroids[i].end(),
+          centroids[j].begin()));
+      }
+    }
+  }
+
+  {
+    // Centroids Match Training Data Points
+    size_t outer_counts = 0;
+    for (size_t i = 0; i < centroids.num_cols(); ++i) {
+      size_t inner_counts = 0;
+      for (size_t j = 0; j < training_data.num_cols(); ++j) {
+        inner_counts += std::equal(
+          centroids[i].begin(), centroids[i].end(),
+          training_data[j].begin());
+      }
+      CHECK(inner_counts == 1); // Each centroid should match exactly one training data point
+      outer_counts += inner_counts;
+    }
+    CHECK(outer_counts == centroids.num_cols()); // Total matches should equal the number of centroids
+  }
+}
+
+TEST_CASE("test kmeans random initialization edge cases", "[kmeans][init][edge]") {
+
+  {
+    // Case: Empty training data
+    ColMajorMatrix<float> training_data(0, 0);  // No rows, no columns
+    size_t num_partitions = 3;
+    ColMajorMatrix<float> centroids(4, num_partitions);  // Centroids matrix initialized with space
+    debug_matrix(centroids, "centroids");
+    kmeans_random_init(training_data, centroids, num_partitions);
+    debug_matrix(centroids, "centroids");
+
+    // Expect centroids to remain unchanged because there is no data to initialize from
+    CHECK(centroids.num_cols() == num_partitions);
+    CHECK(centroids.num_rows() == 4);
+    for (size_t i = 0; i < centroids.num_cols(); ++i) {
+      for (size_t j = 0; j < centroids.num_rows(); ++j) {
+        CHECK(centroids[i][j] == 0.0f);  // Assuming default initialization to zero
+      }
+    }
+  }
+
+  {
+    // Case: num_partitions is 0
+    std::vector<float> data = {8, 6, 7, 5, 3, 3, 7, 2, 1, 4, 1, 3, 
+                               0, 5, 1, 2, 9, 9, 5, 9, 2, 0, 2, 7, 
+                               7, 9, 8, 6, 7, 9, 6, 6};
+    ColMajorMatrix<float> training_data(4, 8);
+    std::copy(begin(data), end(data), training_data.data());
+    size_t num_partitions = 0;
+    ColMajorMatrix<float> centroids(4, num_partitions);  // Centroids matrix with zero partitions
+
+    kmeans_random_init(training_data, centroids, num_partitions);
+
+    // Expect centroids to have zero columns
+    CHECK(centroids.num_cols() == 0);
+    CHECK(centroids.num_rows() == 4);
+  }
+
+  {
+    // Case: Empty centroids and num_partitions is 0
+    std::vector<float> data = {8, 6, 7, 5, 3, 3, 7, 2, 1, 4, 1, 3, 
+                               0, 5, 1, 2, 9, 9, 5, 9, 2, 0, 2, 7, 
+                               7, 9, 8, 6, 7, 9, 6, 6};
+    ColMajorMatrix<float> training_data(4, 8);
+    std::copy(begin(data), end(data), training_data.data());
+    size_t num_partitions = 0;
+    ColMajorMatrix<float> centroids(0, 0);  // Empty centroids matrix
+
+    kmeans_random_init(training_data, centroids, num_partitions);
+
+    // Expect centroids to remain empty
+    CHECK(centroids.num_cols() == 0);
+    CHECK(centroids.num_rows() == 0);
+  }
+
+  {
+    // Case: All empty
+    ColMajorMatrix<float> training_data(0, 0);  // No rows, no columns
+    size_t num_partitions = 0;
+    ColMajorMatrix<float> centroids(0, 0);  // Empty centroids matrix
+
+    kmeans_random_init(training_data, centroids, num_partitions);
+
+    // Expect centroids to remain empty
+    CHECK(centroids.num_cols() == 0);
+    CHECK(centroids.num_rows() == 0);
+  }
+}

--- a/src/include/test/unit_kmeans.cc
+++ b/src/include/test/unit_kmeans.cc
@@ -141,4 +141,45 @@ TEST_CASE("test kmeans random initialization edge cases", "[kmeans][init][edge]"
     CHECK(centroids.num_cols() == 0);
     CHECK(centroids.num_rows() == 0);
   }
+
+  {
+    // Invalid Case: num_partitions is greater than number of vectors in the training set
+    std::vector<float> data = {8, 6, 7, 5, 3, 3, 7, 2, 1, 4, 1, 3, 
+                               0, 5, 1, 2, 9, 9, 5, 9, 2, 0, 2, 7, 
+                               7, 9, 8, 6, 7, 9, 6, 6};
+    ColMajorMatrix<float> training_data(4, 8);
+    std::copy(begin(data), end(data), training_data.data());
+    size_t num_partitions = 10;  // More partitions than available vectors
+    ColMajorMatrix<float> centroids(4, num_partitions);  // Centroids matrix
+
+    CHECK_THROWS_AS(
+        kmeans_random_init(training_data, centroids, num_partitions),
+        std::runtime_error);
+  }
+
+  {
+    // Invalid Case: num_partitions does not match the number of centroids
+    std::vector<float> data = {8, 6, 7, 5, 3, 3, 7, 2, 1, 4, 1, 3, 
+                               0, 5, 1, 2, 9, 9, 5, 9, 2, 0, 2, 7, 
+                               7, 9, 8, 6, 7, 9, 6, 6};
+    ColMajorMatrix<float> training_data(4, 8);
+    std::copy(begin(data), end(data), training_data.data());
+    size_t num_partitions = 3;
+    ColMajorMatrix<float> centroids(4, 2);  // Mismatch: 2 centroids for 3 partitions
+
+    CHECK_THROWS_AS(
+        kmeans_random_init(training_data, centroids, num_partitions),
+        std::runtime_error);
+  }
+
+  {
+    // Invalid Case: Empty training data with non-zero partitions
+    ColMajorMatrix<float> training_data(0, 0);  // No rows, no columns
+    size_t num_partitions = 3;
+    ColMajorMatrix<float> centroids(4, num_partitions);
+
+    CHECK_THROWS_AS(
+        kmeans_random_init(training_data, centroids, num_partitions),
+        std::runtime_error);
+  }
 }

--- a/src/include/test/unit_kmeans.cc
+++ b/src/include/test/unit_kmeans.cc
@@ -95,26 +95,6 @@ TEST_CASE("test kmeans random initialization", "[kmeans][init]") {
 }
 
 TEST_CASE("test kmeans random initialization edge cases", "[kmeans][init][edge]") {
-
-  {
-    // Case: Empty training data
-    ColMajorMatrix<float> training_data(0, 0);  // No rows, no columns
-    size_t num_partitions = 3;
-    ColMajorMatrix<float> centroids(4, num_partitions);  // Centroids matrix initialized with space
-    debug_matrix(centroids, "centroids");
-    kmeans_random_init(training_data, centroids, num_partitions);
-    debug_matrix(centroids, "centroids");
-
-    // Expect centroids to remain unchanged because there is no data to initialize from
-    CHECK(centroids.num_cols() == num_partitions);
-    CHECK(centroids.num_rows() == 4);
-    for (size_t i = 0; i < centroids.num_cols(); ++i) {
-      for (size_t j = 0; j < centroids.num_rows(); ++j) {
-        CHECK(centroids[i][j] == 0.0f);  // Assuming default initialization to zero
-      }
-    }
-  }
-
   {
     // Case: num_partitions is 0
     std::vector<float> data = {8, 6, 7, 5, 3, 3, 7, 2, 1, 4, 1, 3, 


### PR DESCRIPTION
### What
Before this change, if you called `kmeans_random_init()` with less vectors in `training_set` than `num_partitions_`, we would get into an infinite loop. Now we fill centroids in with zeroes instead.

We also add unit tests for this code as it was implicitly tested through other classes, but not explicitly, and not for edge cases like this.

### Testing
* Existing tests pass.
* New tests pass.