### PR TITLE
Update matrix to take in a `std::vector` instead of `std::initializer_list`

### DIFF
--- a/src/include/detail/linalg/matrix.h
+++ b/src/include/detail/linalg/matrix.h
@@ -179,7 +179,7 @@ class Matrix : public stdx::mdspan<T, matrix_extents<I>, LayoutPolicy> {
    * Initializer list constructor.  Useful for testing and for examples.
    * The intializer list is assumed to be in row-major order.
    */
-  Matrix(std::initializer_list<std::initializer_list<T>> list) noexcept
+  Matrix(const std::vector<std::vector<T>>& list) noexcept
     requires(std::is_same_v<LayoutPolicy, stdx::layout_right>)
       : num_rows_{list.size()}
       , num_cols_{list.begin()->size()}
@@ -200,7 +200,7 @@ class Matrix : public stdx::mdspan<T, matrix_extents<I>, LayoutPolicy> {
    * Initializer list constructor.  Useful for testing and for examples.
    * The initializer list is assumed to be in column-major order.
    */
-  Matrix(std::initializer_list<std::initializer_list<T>> list) noexcept
+  Matrix(const std::vector<std::vector<T>>& list) noexcept
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
       : num_rows_{list.begin()->size()}
       , num_cols_{list.size()}

--- a/src/include/detail/linalg/matrix_with_ids.h
+++ b/src/include/detail/linalg/matrix_with_ids.h
@@ -122,7 +122,7 @@ class MatrixWithIds : public Matrix<T, LayoutPolicy, I> {
    * The initializer list is assumed to be in row-major order.
    */
   MatrixWithIds(
-      std::initializer_list<std::initializer_list<T>> matrix,
+      const std::vector<std::vector<T>>& matrix,
       const std::vector<IdsType>& ids) noexcept
     requires(std::is_same_v<LayoutPolicy, stdx::layout_right>)
       : Base(matrix)
@@ -141,7 +141,7 @@ class MatrixWithIds : public Matrix<T, LayoutPolicy, I> {
    * The initializer list is assumed to be in column-major order.
    */
   MatrixWithIds(
-      std::initializer_list<std::initializer_list<T>> matrix,
+      const std::vector<std::vector<T>>& matrix,
       const std::vector<IdsType>& ids) noexcept
     requires(std::is_same_v<LayoutPolicy, stdx::layout_left>)
       : Base(matrix)

--- a/src/include/test/unit_api_ivf_pq_index.cc
+++ b/src/include/test/unit_api_ivf_pq_index.cc
@@ -211,7 +211,7 @@ TEST_CASE("create empty index and then train and query", "[api_ivf_pq_index]") {
     CHECK(index.partitioning_index_type_string() == partitioning_index_type);
 
     auto training = ColMajorMatrix<feature_type_type>{
-        {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
+        {{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}}};
     auto training_vector_array = FeatureVectorArray(training);
     index.train(training_vector_array);
     index.add(training_vector_array);
@@ -222,7 +222,7 @@ TEST_CASE("create empty index and then train and query", "[api_ivf_pq_index]") {
     CHECK(index.partitioning_index_type_string() == partitioning_index_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
-        {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
+        {{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}}};
     auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(QueryType::InfiniteRAM, query_vector_array, 1, 1);
@@ -301,7 +301,7 @@ TEST_CASE(
     CHECK(index.partitioning_index_type_string() == partitioning_index_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
-        {8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
+        {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}};
     auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(QueryType::InfiniteRAM, query_vector_array, 1, 1);
@@ -709,7 +709,7 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
     CHECK(index.partitioning_index_type_string() == partitioning_index_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
-        {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
+        {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}};
     auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(QueryType::InfiniteRAM, query_vector_array, 1, n_list);
@@ -775,7 +775,7 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
     CHECK(index.partitioning_index_type_string() == partitioning_index_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
-        {11, 11, 11}, {22, 22, 22}, {33, 33, 33}, {44, 44, 44}, {55, 55, 55}};
+        {{11, 11, 11}, {22, 22, 22}, {33, 33, 33}, {44, 44, 44}, {55, 55, 55}}};
     auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(QueryType::InfiniteRAM, query_vector_array, 1, 1);
@@ -833,7 +833,7 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
     CHECK(index.reassign_ratio() == reassign_ratio);
 
     auto queries = ColMajorMatrix<feature_type_type>{
-        {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
+        {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}};
     auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(QueryType::InfiniteRAM, query_vector_array, 1, 1);
@@ -892,7 +892,7 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
     CHECK(index.convergence_tolerance() == convergence_tolerance);
     CHECK(index.reassign_ratio() == reassign_ratio);
 
-    auto queries = ColMajorMatrix<feature_type_type>{{1, 1, 1}};
+    auto queries = ColMajorMatrix<feature_type_type>{{{1, 1, 1}}};
     auto query_vector_array = FeatureVectorArray(queries);
     {
       auto&& [scores_vector_array, ids_vector_array] =
@@ -985,7 +985,7 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
     CHECK(index.partitioning_index_type_string() == partitioning_index_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
-        {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
+        {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}};
     auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(QueryType::InfiniteRAM, query_vector_array, 1, 1);

--- a/src/include/test/unit_api_vamana_index.cc
+++ b/src/include/test/unit_api_vamana_index.cc
@@ -165,7 +165,7 @@ TEST_CASE("create empty index and then train and query", "[api_vamana_index]") {
     CHECK(index.id_type_string() == id_type);
 
     auto training = ColMajorMatrix<feature_type_type>{
-        {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
+        {{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}}};
     auto training_vector_array = FeatureVectorArray(training);
     index.train(training_vector_array);
     index.add(training_vector_array);
@@ -175,7 +175,7 @@ TEST_CASE("create empty index and then train and query", "[api_vamana_index]") {
     CHECK(index.id_type_string() == id_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
-        {3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
+        {{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}}};
     auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(query_vector_array, 1);
@@ -242,7 +242,7 @@ TEST_CASE(
     CHECK(index.id_type_string() == id_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
-        {8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
+        {{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}};
     auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(query_vector_array, 1);
@@ -607,7 +607,7 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(index.id_type_string() == id_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
-        {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
+        {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}};
     auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(query_vector_array, 1);
@@ -670,7 +670,7 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(index.id_type_string() == id_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
-        {11, 11, 11}, {22, 22, 22}, {33, 33, 33}, {44, 44, 44}, {55, 55, 55}};
+        {{11, 11, 11}, {22, 22, 22}, {33, 33, 33}, {44, 44, 44}, {55, 55, 55}}};
     auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(query_vector_array, 1);
@@ -726,7 +726,7 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(index.id_type_string() == id_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
-        {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
+        {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}};
     auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(query_vector_array, 1);
@@ -783,7 +783,7 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(index.feature_type_string() == feature_type);
     CHECK(index.id_type_string() == id_type);
 
-    auto queries = ColMajorMatrix<feature_type_type>{{1, 1, 1}};
+    auto queries = ColMajorMatrix<feature_type_type>{{{1, 1, 1}}};
     auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(query_vector_array, 1);
@@ -847,7 +847,7 @@ TEST_CASE("write and load index with timestamps", "[api_vamana_index]") {
     CHECK(index.id_type_string() == id_type);
 
     auto queries = ColMajorMatrix<feature_type_type>{
-        {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
+        {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}};
     auto query_vector_array = FeatureVectorArray(queries);
     auto&& [scores_vector_array, ids_vector_array] =
         index.query(query_vector_array, 1);

--- a/src/include/test/unit_flat_qv.cc
+++ b/src/include/test/unit_flat_qv.cc
@@ -36,7 +36,7 @@
 #include "test/utils/query_common.h"
 
 TEST_CASE("flat qv simple case", "[flat qv]") {
-  auto db = ColMajorMatrix<float>{
+  auto db = ColMajorMatrix<float>{{
       {
           1,
           1,
@@ -181,10 +181,10 @@ TEST_CASE("flat qv simple case", "[flat qv]") {
           1,
           0,
       },
-  };
+  }};
 
   auto centroids = ColMajorMatrix<float>{
-      {38.9571, 109.171, 155.557, 180.971, 149.514, 80.2286}};
+      {{38.9571, 109.171, 155.557, 180.971, 149.514, 80.2286}}};
 
   auto parts = detail::flat::qv_partition(centroids, db, 8);
   auto z = 0;

--- a/src/include/test/unit_ivf_flat_index.cc
+++ b/src/include/test/unit_ivf_flat_index.cc
@@ -146,17 +146,19 @@ TEST_CASE("debug w/ sk", "[ivf_index]") {
   const bool debug = false;
 
   ColMajorMatrix<float> training_data{
-      {1.0573647, 5.082087},
-      {-6.229642, -1.3590931},
-      {0.7446737, 6.3828287},
-      {-7.698864, -3.0493321},
-      {2.1362762, -4.4448104},
-      {1.04019, -4.0389647},
-      {0.38996044, 5.7235265},
-      {1.7470839, -4.717076}};
-  ColMajorMatrix<float> queries{{-7.3712273, -1.1178735}};
+      {{1.0573647, 5.082087},
+       {-6.229642, -1.3590931},
+       {0.7446737, 6.3828287},
+       {-7.698864, -3.0493321},
+       {2.1362762, -4.4448104},
+       {1.04019, -4.0389647},
+       {0.38996044, 5.7235265},
+       {1.7470839, -4.717076}}};
+  ColMajorMatrix<float> queries{{{-7.3712273, -1.1178735}}};
   ColMajorMatrix<float> sklearn_centroids{
-      {-6.964253, -2.2042127}, {1.6411834, -4.400284}, {0.7306664, 5.7294807}};
+      {{-6.964253, -2.2042127},
+       {1.6411834, -4.400284},
+       {0.7306664, 5.7294807}}};
 
   SECTION("one iteration") {
     if (debug) {
@@ -315,30 +317,30 @@ TEMPLATE_TEST_CASE(
     auto query4 = ColMajorMatrix<TestType>();
 
     SECTION("query2/4 = 0...") {
-      query2 = ColMajorMatrix<TestType>{{0, 0, 0, 0, 0, 0}};
-      query4 = ColMajorMatrix<TestType>{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
+      query2 = ColMajorMatrix<TestType>{{{0, 0, 0, 0, 0, 0}}};
+      query4 = ColMajorMatrix<TestType>{{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}};
     }
     SECTION("query2/4 = 127...") {
-      query2 = ColMajorMatrix<TestType>{{127, 127, 127, 127, 127, 127}};
+      query2 = ColMajorMatrix<TestType>{{{127, 127, 127, 127, 127, 127}}};
       query4 = ColMajorMatrix<TestType>{
-          {127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127}};
+          {{127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127}}};
     }
     SECTION("query2/4 = 0...") {
-      query2 = ColMajorMatrix<TestType>{{0, 0, 0, 127, 127, 127}};
+      query2 = ColMajorMatrix<TestType>{{{0, 0, 0, 127, 127, 127}}};
       query4 = ColMajorMatrix<TestType>{
-          {0, 0, 0, 0, 0, 0, 127, 127, 127, 127, 127, 127}};
+          {{0, 0, 0, 0, 0, 0, 127, 127, 127, 127, 127, 127}}};
     }
     SECTION("query2/4 = 127...") {
-      query2 = ColMajorMatrix<TestType>{{127, 127, 127, 0, 0, 0}};
+      query2 = ColMajorMatrix<TestType>{{{127, 127, 127, 0, 0, 0}}};
       query4 = ColMajorMatrix<TestType>{
-          {127, 127, 127, 127, 127, 127, 0, 0, 0, 0, 0, 0}};
+          {{127, 127, 127, 127, 127, 127, 0, 0, 0, 0, 0, 0}}};
     }
     SECTION("query2/4 = 127...") {
       query2 = ColMajorMatrix<TestType>{
-          {127, 0, 127, 0, 127, 0}, {0, 127, 0, 127, 0, 127}};
+          {{127, 0, 127, 0, 127, 0}, {0, 127, 0, 127, 0, 127}}};
       query4 = ColMajorMatrix<TestType>{
-          {127, 0, 127, 0, 127, 0, 127, 0, 127, 0, 127, 0},
-          {0, 127, 0, 127, 0, 127, 0, 127, 0, 127, 0, 127}};
+          {{127, 0, 127, 0, 127, 0, 127, 0, 127, 0, 127, 0},
+           {0, 127, 0, 127, 0, 127, 0, 127, 0, 127, 0, 127}}};
     }
 
     std::tie(top_k_scores, top_k) = detail::flat::qv_query_heap(

--- a/src/include/test/unit_ivf_pq_index.cc
+++ b/src/include/test/unit_ivf_pq_index.cc
@@ -185,17 +185,19 @@ TEST_CASE("debug w/ sk", "[ivf_pq_index]") {
   const bool debug = false;
 
   ColMajorMatrix<float> training_data{
-      {1.0573647, 5.082087},
-      {-6.229642, -1.3590931},
-      {0.7446737, 6.3828287},
-      {-7.698864, -3.0493321},
-      {2.1362762, -4.4448104},
-      {1.04019, -4.0389647},
-      {0.38996044, 5.7235265},
-      {1.7470839, -4.717076}};
-  ColMajorMatrix<float> queries{{-7.3712273, -1.1178735}};
+      {{1.0573647, 5.082087},
+       {-6.229642, -1.3590931},
+       {0.7446737, 6.3828287},
+       {-7.698864, -3.0493321},
+       {2.1362762, -4.4448104},
+       {1.04019, -4.0389647},
+       {0.38996044, 5.7235265},
+       {1.7470839, -4.717076}}};
+  ColMajorMatrix<float> queries{{{-7.3712273, -1.1178735}}};
   ColMajorMatrix<float> sklearn_centroids{
-      {-6.964253, -2.2042127}, {1.6411834, -4.400284}, {0.7306664, 5.7294807}};
+      {{-6.964253, -2.2042127},
+       {1.6411834, -4.400284},
+       {0.7306664, 5.7294807}}};
 
   SECTION("one iteration") {
     if (debug) {
@@ -590,7 +592,7 @@ TEST_CASE("query empty index", "[ivf_pq_index]") {
   auto index = ivf_pq_index<siftsmall_feature_type, siftsmall_ids_type>(
       nlist, dimensions / 2);
   auto queries =
-      ColMajorMatrix<siftsmall_feature_type>{{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}};
+      ColMajorMatrix<siftsmall_feature_type>{{{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}}};
 
   // We can train and add to an empty index.
   {
@@ -677,7 +679,8 @@ TEST_CASE("query simple", "[ivf_pq_index]") {
     size_t nprobe = nlist;
     for (int i = 1; i <= 4; ++i) {
       auto value = static_cast<feature_type>(i);
-      auto queries = ColMajorMatrix<feature_type>{{value, value, value, value}};
+      auto queries =
+          ColMajorMatrix<feature_type>{{{value, value, value, value}}};
       auto&& [scores, ids] = index.query_infinite_ram(queries, k_nn, nprobe);
       debug_matrix(scores, "scores");
       debug_matrix(ids, "ids");
@@ -698,7 +701,8 @@ TEST_CASE("query simple", "[ivf_pq_index]") {
     size_t nprobe = nlist;
     for (int i = 1; i <= 4; ++i) {
       auto value = static_cast<feature_type>(i);
-      auto queries = ColMajorMatrix<feature_type>{{value, value, value, value}};
+      auto queries =
+          ColMajorMatrix<feature_type>{{{value, value, value, value}}};
       auto&& [scores, ids] = index.query_infinite_ram(queries, k_nn, nprobe);
       debug_matrix(scores, "scores");
       debug_matrix(ids, "ids");
@@ -763,7 +767,7 @@ TEST_CASE("ivf_pq_index query index written twice", "[ivf_pq_index]") {
         id_type_type,
         partitioning_index_type_type>(ctx, index_uri);
     auto queries = ColMajorMatrix<feature_type_type>{
-        {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
+        {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}};
     auto&& [scores, ids] = index.query_infinite_ram(queries, 1, n_list);
     CHECK(std::equal(
         scores.data(),

--- a/src/include/test/unit_linalg.cc
+++ b/src/include/test/unit_linalg.cc
@@ -208,7 +208,7 @@ TEMPLATE_LIST_TEST_CASE(
     "test Matrix initializer_list constructor, row oriented",
     "[linalg][matrix][create][row]",
     TestTypes) {
-  auto a = Matrix<TestType, Kokkos::layout_right>{{1, 2}, {3, 4}, {5, 6}};
+  auto a = Matrix<TestType, Kokkos::layout_right>{{{1, 2}, {3, 4}, {5, 6}}};
   auto v = a.data();
   std::iota(v, v + 6, 1);
 
@@ -244,7 +244,7 @@ TEMPLATE_LIST_TEST_CASE(
     "test Matrix initializer list constructor, column oriented",
     "[linalg][matrixx][create][column]",
     TestTypes) {
-  auto a = Matrix<TestType, Kokkos::layout_left>{{1, 2, 3}, {4, 5, 6}};
+  auto a = Matrix<TestType, Kokkos::layout_left>{{{1, 2, 3}, {4, 5, 6}}};
   auto v = a.data();
   std::iota(v, v + 6, 1);
 

--- a/src/include/test/unit_matrix.cc
+++ b/src/include/test/unit_matrix.cc
@@ -42,14 +42,14 @@ using TestTypes = std::tuple<float, double, int, char, size_t, uint32_t>;
  * Many tests remain in linalg.cc from before the refactor.
  */
 TEST_CASE("initializer list", "[matrix]") {
-  auto A = Matrix<float>{{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
+  auto A = Matrix<float>{{{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}}};
   auto a = std::vector<float>{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8};
   CHECK(
       std::equal(A.data(), A.data() + A.num_rows() * A.num_cols(), a.begin()));
 }
 
 TEST_CASE("copy", "[matrix]") {
-  auto A = Matrix<float>{{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
+  auto A = Matrix<float>{{{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}}};
   auto a = std::vector<float>{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8};
   auto aptr = A.data();
   //  auto B = A;  // Error: copy constructor is deleted
@@ -64,10 +64,10 @@ TEST_CASE("copy", "[matrix]") {
 }
 
 TEST_CASE("assign", "[matrix]") {
-  auto A = Matrix<float>{{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}};
+  auto A = Matrix<float>{{{8, 6, 7}, {5, 3, 0}, {9, 5, 0}, {2, 7, 3}}};
   auto a = std::vector<float>{8, 6, 7, 5, 3, 0, 9, 5, 0, 2, 7, 3};
 
-  auto B = Matrix<float>{{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}};
+  auto B = Matrix<float>{{{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}}};
 
   auto aptr = A.data();
 
@@ -85,7 +85,7 @@ TEST_CASE("assign", "[matrix]") {
 TEST_CASE("vector of matrix", "[matrix]") {
   std::vector<Matrix<float>> v;
 
-  auto A = Matrix<float>{{8, 6, 7}, {5, 3, 0}, {9, 5, 0}};
+  auto A = Matrix<float>{{{8, 6, 7}, {5, 3, 0}, {9, 5, 0}}};
   auto aptr = A.data();
 
   SECTION("push_back and emplace_back") {

--- a/src/include/test/unit_partition.cc
+++ b/src/include/test/unit_partition.cc
@@ -35,7 +35,7 @@
 #include "test/utils/query_common.h"
 
 TEST_CASE("top_centroids", "[partition]") {
-  auto parts = ColMajorMatrix<float>{
+  auto parts = ColMajorMatrix<float>{{
       {
           1,
           1,
@@ -56,8 +56,8 @@ TEST_CASE("top_centroids", "[partition]") {
           3,
           3,
       },
-  };
-  auto centroids = ColMajorMatrix<float>{
+  }};
+  auto centroids = ColMajorMatrix<float>{{
       {
           1,
           1,
@@ -65,7 +65,7 @@ TEST_CASE("top_centroids", "[partition]") {
           1,
       },
       {2, 2, 2, 2},
-  };
+  }};
   auto top_centroids = detail::ivf::ivf_top_centroids(centroids, parts, 1, 1);
 
   CHECK(top_centroids.num_cols() == 5);

--- a/src/include/test/unit_partitioned_matrix.cc
+++ b/src/include/test/unit_partitioned_matrix.cc
@@ -75,8 +75,8 @@ TEST_CASE("partitioned_matrix: vectors constructor", "[partitioned_matrix]") {
   using id_type = float;
   using part_index_type = float;
 
-  auto parts =
-      ColMajorMatrix<feature_type>{{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
+  auto parts = ColMajorMatrix<feature_type>{
+      {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}}};
   std::vector<id_type> ids = {1, 2, 3, 4};
   std::vector<part_index_type> part_index = {0, 1, 4};
 
@@ -114,7 +114,7 @@ TEST_CASE("partitioned_matrix: training constructor", "[partitioned_matrix]") {
   using part_index_type = uint64_t;
 
   auto training_set =
-      ColMajorMatrix<feature_type>{{1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}};
+      ColMajorMatrix<feature_type>{{{1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}}};
   std::vector<id_type> part_labels = {1, 0, 1, 0, 1};
   size_t num_parts = 2;
 

--- a/src/include/test/unit_scoring.cc
+++ b/src/include/test/unit_scoring.cc
@@ -112,7 +112,7 @@ TEMPLATE_LIST_TEST_CASE(
   using index_type = std::tuple_element_t<1, TestType>;
   using groundtruth_type = std::tuple_element_t<2, TestType>;
 
-  ColMajorMatrix<score_type> scores{
+  ColMajorMatrix<score_type> scores{{
       //  0  1  2  3  4  5  6  7  8
       {8, 6, 7, 5, 3, 0, 9, 1, 2},
       {3, 1, 4, 1, 5, 9, 2, 6, 7},
@@ -121,7 +121,7 @@ TEMPLATE_LIST_TEST_CASE(
       {9, 8, 7, 2, 5, 4, 3, 2, 9},
       {9, 8, 3, 6, 5, 4, 3, 9, 1},
       {7, 5, 3, 0, 9, 1, 2, 8, 1},
-  };
+  }};
 
   CHECK(scores.num_rows() == 9);
   CHECK(scores.num_cols() == 7);
@@ -405,14 +405,14 @@ TEMPLATE_LIST_TEST_CASE("get_top_k", "[scoring]", scoring_typelist) {
           })};
 
   // Matrix not used
-  ColMajorMatrix<groundtruth_type> gt_neighbors_mat{
+  ColMajorMatrix<groundtruth_type> gt_neighbors_mat{{
       {0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
       {9, 8, 7, 6, 5, 4, 3, 2, 1, 0},
-  };
-  ColMajorMatrix<score_type> gt_scores_mat{
+  }};
+  ColMajorMatrix<score_type> gt_scores_mat{{
       {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0},
       {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9},
-  };
+  }};
 
   SECTION("std::vector get_top_k") {
     CHECK((size_t)size(scores00[0]) == (size_t)(asize));
@@ -572,14 +572,14 @@ TEMPLATE_LIST_TEST_CASE(
   };
 
   // Matrix not used
-  ColMajorMatrix<groundtruth_type> gt_neighbors_mat{
+  ColMajorMatrix<groundtruth_type> gt_neighbors_mat{{
       {9, 8, 7, 6, 5},
       {9, 4, 0, 5, 1},
-  };
-  ColMajorMatrix<score_type> gt_scores_mat{
+  }};
+  ColMajorMatrix<score_type> gt_scores_mat{{
       {1, 2, 3, 4, 5},
       {0, 1, 2, 3, 4},
-  };
+  }};
   std::vector<fixed_min_pair_heap<score_type, index_type>> scores{a, b};
   SECTION("std::vector") {
     auto top_k = get_top_k(scores, 5);

--- a/src/include/test/unit_tdb_partitioned_matrix.cc
+++ b/src/include/test/unit_tdb_partitioned_matrix.cc
@@ -105,7 +105,7 @@ TEST_CASE("can load correctly", "[tdb_partitioned_matrix]") {
     }
 
     auto partitioned_vectors =
-        ColMajorMatrix<feature_type>{{1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}};
+        ColMajorMatrix<feature_type>{{{1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}}};
     write_matrix(ctx, partitioned_vectors, partitioned_vectors_uri);
     std::vector<id_type> ids = {1, 2, 3, 4, 5};
     write_vector(ctx, ids, ids_uri);
@@ -418,7 +418,7 @@ TEST_CASE("single vector and single partition", "[tdb_partitioned_matrix]") {
       vfs.remove_dir(ids_uri);
     }
 
-    auto partitioned_vectors = ColMajorMatrix<feature_type>{{1}};
+    auto partitioned_vectors = ColMajorMatrix<feature_type>{{{1}}};
     write_matrix(ctx, partitioned_vectors, partitioned_vectors_uri);
     std::vector<id_type> ids = {1};
     write_vector(ctx, ids, ids_uri);

--- a/src/include/test/utils/query_common.h
+++ b/src/include/test/utils/query_common.h
@@ -43,7 +43,7 @@
 // clang-format off
 
   auto centroids = ColMajorMatrix<float> {
-      {
+      {{
           {8, 6, 7},
           {5, 3, 0},
           {9, 1, 2},
@@ -66,23 +66,23 @@
           {1, 5, 9},
           {9, 0, 3,},
           {5, 7, 6},
-      }
+      }}
   };
   auto query = ColMajorMatrix<float> {
-      {
+      {{
           {3, 4, 5},
           {2, 300, 8},
           {3, 1, 3.5},
           {3, 1, 3},
           {4, 5, 6},
-      }
+      }}
   };
 
   /**
    * Taken from [0:5,9:12] of sift_base
    */
   auto sift_base = ColMajorMatrix<float>
-      {
+      {{
           { 21.,  13.,  17.},
           { 13.,  60.,  10.},
           { 18.,  15.,   6.},
@@ -115,16 +115,16 @@
           { 21.,  35.,  30.},
           { 20.,  10.,  12.},
           { 13.,   2.,  10.},
-      };
+      }};
 
   auto sift_query = ColMajorMatrix<float>
-      {
+      {{
           { 0.,  7., 50.},
           {11.,  4., 43.},
           {77.,  5.,  9.},
           {24., 11.,  1.},
           { 3.,  2.,  0.}
-      };
+      }};
 
 // clang-format on
 


### PR DESCRIPTION
### What
`std::initializer_list` is not as useful as `std::vector` because you can only create it in the constructor. But during testing of an IVF PQ I wanted to use `std::vector` to construct a matrix in a for-loop. So here we change over. Performance is also not an issue here because we only use this constructor during tests.

### Testing
Tests pass.