### PR TITLE
Check finite and infinite IVF_PQ queries return the same ids and distances, fix `count_intersections()` to not modify inputs, update `read_index_finite()` to return data

### DIFF
--- a/src/include/api/feature_vector_array.h
+++ b/src/include/api/feature_vector_array.h
@@ -543,4 +543,203 @@ auto count_intersections(
   }
 }
 
+bool are_equal(
+    const FeatureVectorArray& a,
+    const FeatureVectorArray& b,
+    double epsilon = 0.0) {
+  if (a.feature_type() != b.feature_type()) {
+    std::cout << "[feature_vector_array@are_equal] Feature types do not match: "
+              << a.feature_type_string() << " vs " << b.feature_type_string()
+              << std::endl;
+    return false;
+  }
+  if (a.feature_size() != b.feature_size()) {
+    std::cout << "[feature_vector_array@are_equal] Feature sizes do not match: "
+              << a.feature_size() << " vs " << b.feature_size() << std::endl;
+    return false;
+  }
+  if (a.num_vectors() != b.num_vectors()) {
+    std::cout
+        << "[feature_vector_array@are_equal] Number of vectors do not match: "
+        << a.num_vectors() << " vs " << b.num_vectors() << std::endl;
+    return false;
+  }
+  if (a.dimensions() != b.dimensions()) {
+    std::cout << "[feature_vector_array@are_equal] Number of dimensions do not "
+                 "match: "
+              << a.dimensions() << " vs " << b.dimensions() << std::endl;
+    return false;
+  }
+
+  if (a.ids_type() != b.ids_type()) {
+    std::cout << "[feature_vector_array@are_equal] IDs types do not match: "
+              << a.ids_type_string() << " vs " << b.ids_type_string()
+              << std::endl;
+    return false;
+  }
+  if (a.ids_size() != b.ids_size()) {
+    std::cout << "[feature_vector_array@are_equal] IDs sizes do not match: "
+              << a.ids_size() << " vs " << b.ids_size() << std::endl;
+    return false;
+  }
+  if (a.num_ids() != b.num_ids()) {
+    std::cout << "[feature_vector_array@are_equal] Number of IDs do not match: "
+              << a.num_ids() << " vs " << b.num_ids() << std::endl;
+    return false;
+  }
+
+  if (a.extents() != b.extents()) {
+    std::cout << "[feature_vector_array@are_equal] Extents do not match: "
+              << "A: {" << a.extents()[0] << ", " << a.dimensions() << "}, "
+              << "B: {" << b.extents()[0] << ", " << b.dimensions() << "}"
+              << std::endl;
+    return false;
+  }
+
+  // Compare the data of the feature vectors with optional epsilon
+  auto compare_data = [&epsilon](
+                          const auto* data_a, const auto* data_b, size_t size) {
+    if (epsilon > 0.0) {
+      for (size_t i = 0; i < size; ++i) {
+        if (std::abs(
+                static_cast<double>(data_a[i]) -
+                static_cast<double>(data_b[i])) > epsilon) {
+          std::cout
+              << "[feature_vector_array@are_equal] Data mismatch at index " << i
+              << ": " << data_a[i] << " vs " << data_b[i]
+              << " (epsilon: " << epsilon << ")" << std::endl;
+          return false;
+        }
+      }
+    } else {
+      for (size_t i = 0; i < size; ++i) {
+        if (data_a[i] != data_b[i]) {
+          std::cout
+              << "[feature_vector_array@are_equal] Data mismatch at index " << i
+              << ": " << data_a[i] << " vs " << data_b[i] << std::endl;
+          return false;
+        }
+      }
+    }
+    return true;
+  };
+
+  switch (a.feature_type()) {
+    case TILEDB_FLOAT32: {
+      const auto* data_a = static_cast<const float*>(a.data());
+      const auto* data_b = static_cast<const float*>(b.data());
+      if (!compare_data(data_a, data_b, a.num_vectors() * a.dimensions())) {
+        std::cout << "[feature_vector_array@are_equal] Feature vector data "
+                     "comparison failed for type FLOAT32"
+                  << std::endl;
+        return false;
+      }
+      break;
+    }
+    case TILEDB_INT8: {
+      const auto* data_a = static_cast<const int8_t*>(a.data());
+      const auto* data_b = static_cast<const int8_t*>(b.data());
+      if (!compare_data(data_a, data_b, a.num_vectors() * a.dimensions())) {
+        std::cout << "[feature_vector_array@are_equal] Feature vector data "
+                     "comparison failed for type INT8"
+                  << std::endl;
+        return false;
+      }
+      break;
+    }
+    case TILEDB_UINT8: {
+      const auto* data_a = static_cast<const uint8_t*>(a.data());
+      const auto* data_b = static_cast<const uint8_t*>(b.data());
+      if (!compare_data(data_a, data_b, a.num_vectors() * a.dimensions())) {
+        std::cout << "[feature_vector_array@are_equal] Feature vector data "
+                     "comparison failed for type UINT8"
+                  << std::endl;
+        return false;
+      }
+      break;
+    }
+    case TILEDB_INT32: {
+      const auto* data_a = static_cast<const int32_t*>(a.data());
+      const auto* data_b = static_cast<const int32_t*>(b.data());
+      if (!compare_data(data_a, data_b, a.num_vectors() * a.dimensions())) {
+        std::cout << "[feature_vector_array@are_equal] Feature vector data "
+                     "comparison failed for type INT32"
+                  << std::endl;
+        return false;
+      }
+      break;
+    }
+    case TILEDB_UINT32: {
+      const auto* data_a = static_cast<const uint32_t*>(a.data());
+      const auto* data_b = static_cast<const uint32_t*>(b.data());
+      if (!compare_data(data_a, data_b, a.num_vectors() * a.dimensions())) {
+        std::cout << "[feature_vector_array@are_equal] Feature vector data "
+                     "comparison failed for type UINT32"
+                  << std::endl;
+        return false;
+      }
+      break;
+    }
+    case TILEDB_INT64: {
+      const auto* data_a = static_cast<const int64_t*>(a.data());
+      const auto* data_b = static_cast<const int64_t*>(b.data());
+      if (!compare_data(data_a, data_b, a.num_vectors() * a.dimensions())) {
+        std::cout << "[feature_vector_array@are_equal] Feature vector data "
+                     "comparison failed for type INT64"
+                  << std::endl;
+        return false;
+      }
+      break;
+    }
+    case TILEDB_UINT64: {
+      const auto* data_a = static_cast<const uint64_t*>(a.data());
+      const auto* data_b = static_cast<const uint64_t*>(b.data());
+      if (!compare_data(data_a, data_b, a.num_vectors() * a.dimensions())) {
+        std::cout << "[feature_vector_array@are_equal] Feature vector data "
+                     "comparison failed for type UINT64"
+                  << std::endl;
+        return false;
+      }
+      break;
+    }
+    default:
+      std::cout << "[feature_vector_array@are_equal] Unsupported feature "
+                   "vector attribute type"
+                << std::endl;
+      throw std::runtime_error("Unsupported attribute type");
+  }
+
+  // If the arrays have IDs, compare the IDs as well
+  if (a.ids_type() != TILEDB_ANY && b.ids_type() != TILEDB_ANY) {
+    switch (a.ids_type()) {
+      case TILEDB_UINT32: {
+        const auto* ids_a = static_cast<const uint32_t*>(a.ids());
+        const auto* ids_b = static_cast<const uint32_t*>(b.ids());
+        if (!compare_data(ids_a, ids_b, a.num_ids())) {
+          std::cout << "[feature_vector_array@are_equal] ID comparison failed "
+                       "for type UINT32"
+                    << std::endl;
+          return false;
+        }
+        break;
+      }
+      case TILEDB_UINT64: {
+        const auto* ids_a = static_cast<const uint64_t*>(a.ids());
+        const auto* ids_b = static_cast<const uint64_t*>(b.ids());
+        if (!compare_data(ids_a, ids_b, a.num_ids())) {
+          std::cout << "[feature_vector_array@are_equal] ID comparison failed "
+                       "for type UINT64"
+                    << std::endl;
+          return false;
+        }
+        break;
+      }
+      default:
+        throw std::runtime_error("Unsupported ID type");
+    }
+  }
+
+  return true;
+}
+
 #endif  // TILEDB_API_FEATURE_VECTOR_ARRAY_H

--- a/src/include/detail/linalg/matrix.h
+++ b/src/include/detail/linalg/matrix.h
@@ -442,8 +442,10 @@ constexpr auto SubMatrix(
 template <class Matrix>
 void debug_matrix(
     const Matrix& matrix, const std::string& msg = "", size_t max_size = 10) {
-  auto rowsEnd = std::min(dimensions(matrix), static_cast<size_t>(max_size));
-  auto colsEnd = std::min(num_vectors(matrix), static_cast<size_t>(max_size));
+  auto rowsEnd = std::min(
+      dimensions(matrix), static_cast<typename Matrix::size_type>(max_size));
+  auto colsEnd = std::min(
+      num_vectors(matrix), static_cast<typename Matrix::size_type>(max_size));
 
   std::cout << "# " << msg << " (" << dimensions(matrix) << " rows x "
             << num_vectors(matrix) << " cols) ("

--- a/src/include/detail/linalg/matrix_with_ids.h
+++ b/src/include/detail/linalg/matrix_with_ids.h
@@ -218,8 +218,12 @@ void debug_matrix_with_ids(
     const MatrixWithIds& matrix,
     const std::string& msg = "",
     size_t max_size = 10) {
-  auto rowsEnd = std::min(dimensions(matrix), static_cast<size_t>(max_size));
-  auto colsEnd = std::min(num_vectors(matrix), static_cast<size_t>(max_size));
+  auto rowsEnd = std::min(
+      dimensions(matrix),
+      static_cast<typename MatrixWithIds::size_type>(max_size));
+  auto colsEnd = std::min(
+      num_vectors(matrix),
+      static_cast<typename MatrixWithIds::size_type>(max_size));
 
   debug_matrix(matrix, msg, max_size);
 

--- a/src/include/detail/linalg/partitioned_matrix.h
+++ b/src/include/detail/linalg/partitioned_matrix.h
@@ -242,7 +242,7 @@ void debug_partitioned_matrix(
   debug_matrix(matrix, msg, max_size);
 
   std::cout << "# ids: [";
-  auto end = std::min(matrix.ids().size(), static_cast<size_t>(max_size));
+  auto end = std::min(matrix.num_vectors(), static_cast<size_t>(max_size));
   for (size_t i = 0; i < end; ++i) {
     std::cout << matrix.ids()[i];
     if (i != matrix.ids().size() - 1) {

--- a/src/include/scoring.h
+++ b/src/include/scoring.h
@@ -680,36 +680,39 @@ bool validate_top_k(TK& top_k, const G& g) {
 
 template <feature_vector_array U, feature_vector_array V>
 auto count_intersections(const U& I, const V& groundtruth, size_t k_nn) {
-  // print_types(I, groundtruth);
-
   size_t total_intersected = 0;
 
   if constexpr (feature_vector_array<std::remove_cvref_t<decltype(I)>>) {
     for (size_t i = 0; i < I.num_cols(); ++i) {
-      std::sort(begin(I[i]), end(I[i]));
-      std::sort(begin(groundtruth[i]), begin(groundtruth[i]) + k_nn);
+      std::vector<std::decay_t<decltype(I[i][0])>> sorted_I(
+          begin(I[i]), end(I[i]));
+      std::vector<std::decay_t<decltype(groundtruth[i][0])>> sorted_groundtruth(
+          begin(groundtruth[i]), begin(groundtruth[i]) + k_nn);
 
-      // @todo remove -- for debugging only
-      std::vector<size_t> x(begin(I[i]), end(I[i]));
-      std::vector<size_t> y(begin(groundtruth[i]), end(groundtruth[i]));
+      std::sort(begin(sorted_I), end(sorted_I));
+      std::sort(begin(sorted_groundtruth), end(sorted_groundtruth));
 
       total_intersected += std::set_intersection(
-          begin(I[i]),
-          end(I[i]),
-          begin(groundtruth[i]),
-          /*end(groundtruth[i]*/ begin(groundtruth[i]) + k_nn,
+          begin(sorted_I),
+          end(sorted_I),
+          begin(sorted_groundtruth),
+          end(sorted_groundtruth),
           assignment_counter{});
     }
   } else {
     if constexpr (feature_vector<std::remove_cvref_t<decltype(I)>>) {
-      std::sort(begin(I), end(I));
-      std::sort(begin(groundtruth), begin(groundtruth) + k_nn);
+      std::vector<std::decay_t<decltype(I[0])>> sorted_I(begin(I), end(I));
+      std::vector<std::decay_t<decltype(groundtruth[0])>> sorted_groundtruth(
+          begin(groundtruth), begin(groundtruth) + k_nn);
+
+      std::sort(begin(sorted_I), end(sorted_I));
+      std::sort(begin(sorted_groundtruth), end(sorted_groundtruth));
 
       total_intersected += std::set_intersection(
-          begin(I),
-          end(I),
-          begin(groundtruth),
-          /*end(groundtruth)*/ begin(groundtruth) + k_nn,
+          begin(sorted_I),
+          end(sorted_I),
+          begin(sorted_groundtruth),
+          end(sorted_groundtruth),
           assignment_counter{});
     } else {
       static_assert(
@@ -718,7 +721,7 @@ auto count_intersections(const U& I, const V& groundtruth, size_t k_nn) {
     }
   }
   return total_intersected;
-};
+}
 
 #if defined(TILEDB_VS_ENABLE_BLAS) && 0
 

--- a/src/include/test/unit_api_ivf_pq_index.cc
+++ b/src/include/test/unit_api_ivf_pq_index.cc
@@ -405,19 +405,22 @@ TEST_CASE(
     auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
     auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
     for (auto upper_bound : {400, 1000, 0}) {
-      auto&& [_, ids] =
+      auto&& [distances, ids] =
           index.query(QueryType::InfiniteRAM, query_set, k_nn, nprobe);
       auto intersections = count_intersections(ids, groundtruth_set, k_nn);
       auto num_ids = num_vectors(ids);
       auto recall = intersections / static_cast<double>(num_ids * k_nn);
       CHECK(recall > 0.7);
 
-      auto&& [__, ids_finite] = index.query(
+      auto&& [distances_finite, ids_finite] = index.query(
           QueryType::FiniteRAM, query_set, k_nn, nprobe, upper_bound);
       intersections = count_intersections(ids_finite, groundtruth_set, k_nn);
       num_ids = num_vectors(ids_finite);
-      recall = intersections / static_cast<double>(num_ids * k_nn);
-      CHECK(recall > 0.7);
+      auto recall_finite = intersections / static_cast<double>(num_ids * k_nn);
+      CHECK(recall == recall_finite);
+
+      CHECK(are_equal(ids, ids_finite));
+      CHECK(are_equal(distances, distances_finite));
     }
   }
 }

--- a/src/include/test/unit_api_ivf_pq_index.cc
+++ b/src/include/test/unit_api_ivf_pq_index.cc
@@ -404,7 +404,7 @@ TEST_CASE(
 
     auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
     auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
-    for (auto upper_bound : {400, 1000, 0}) {
+    for (auto upper_bound : {450, 1000, 0}) {
       auto&& [distances, ids] =
           index.query(QueryType::InfiniteRAM, query_set, k_nn, nprobe);
       auto intersections = count_intersections(ids, groundtruth_set, k_nn);

--- a/src/include/test/unit_api_ivf_pq_index.cc
+++ b/src/include/test/unit_api_ivf_pq_index.cc
@@ -414,11 +414,6 @@ TEST_CASE(
 
       auto&& [distances_finite, ids_finite] = index.query(
           QueryType::FiniteRAM, query_set, k_nn, nprobe, upper_bound);
-      intersections = count_intersections(ids_finite, groundtruth_set, k_nn);
-      num_ids = num_vectors(ids_finite);
-      auto recall_finite = intersections / static_cast<double>(num_ids * k_nn);
-      CHECK(recall == recall_finite);
-
       CHECK(are_equal(ids, ids_finite));
       CHECK(are_equal(distances, distances_finite));
     }

--- a/src/include/test/unit_api_ivf_pq_index.cc
+++ b/src/include/test/unit_api_ivf_pq_index.cc
@@ -342,6 +342,7 @@ TEST_CASE(
     "[api_ivf_pq_index]") {
   auto ctx = tiledb::Context{};
   size_t k_nn = 10;
+  size_t n_list = 100;
   auto feature_type = "float32";
   auto id_type = "uint32";
   auto partitioning_index_type = "uint32";
@@ -358,6 +359,7 @@ TEST_CASE(
         {{"feature_type", feature_type},
          {"id_type", id_type},
          {"partitioning_index_type", partitioning_index_type},
+         {"n_list", std::to_string(n_list)},
          {"num_subspaces", std::to_string(siftsmall_dimensions / 4)}}));
 
     size_t num_vectors = 0;
@@ -404,18 +406,27 @@ TEST_CASE(
 
     auto query_set = FeatureVectorArray(ctx, siftsmall_query_uri);
     auto groundtruth_set = FeatureVectorArray(ctx, siftsmall_groundtruth_uri);
-    for (auto upper_bound : {450, 1000, 0}) {
+
+    for (auto [nprobe, expected_accuracy, expected_accuracy_with_reranking] :
+         std::vector<std::tuple<int, float, float>>{
+             {1, .4f, .45f},
+             {2, .5f, .6f},
+             {5, .7f, .7f},
+             {10, .75f, .9f},
+             {100, .8f, 1.f}}) {
       auto&& [distances, ids] =
           index.query(QueryType::InfiniteRAM, query_set, k_nn, nprobe);
       auto intersections = count_intersections(ids, groundtruth_set, k_nn);
-      auto num_ids = num_vectors(ids);
-      auto recall = intersections / static_cast<double>(num_ids * k_nn);
-      CHECK(recall > 0.7);
+      CHECK(
+          (intersections / static_cast<double>(num_vectors(ids) * k_nn)) >=
+          expected_accuracy);
 
-      auto&& [distances_finite, ids_finite] = index.query(
-          QueryType::FiniteRAM, query_set, k_nn, nprobe, upper_bound);
-      CHECK(are_equal(ids, ids_finite));
-      CHECK(are_equal(distances, distances_finite));
+      for (auto upper_bound : {450, 1000, 0}) {
+        auto&& [distances_finite, ids_finite] = index.query(
+            QueryType::FiniteRAM, query_set, k_nn, nprobe, upper_bound);
+        CHECK(are_equal(ids_finite, ids));
+        CHECK(are_equal(distances_finite, distances));
+      }
     }
   }
 }


### PR DESCRIPTION
### What
A few IVF_PQ changes:
* Adds `are_equal()` to compare two `FeatureVectorArray`'s. Note it is so long because these are type-erased objects.
* Checks that finite and infinite IVF_PQ queries result in equal IDs and distances. 
  * To do this I also fixed `count_intersections()`, which before this change was modifying the inputs in-place. Now we make a copy and sort that  instead.
* Increases `upper_bound` in a test to fix flaky `Upper bound is less than max partition size: 400 < 420` errors.
* Fixes the way we calculate max cols in a few debug matrix helper functions.
* Updates `read_index_finite()` to return `partitioned_pq_vectors` instead of setting it as a member variable. This simplifies the code and cleans up this data after use.
* Removes `local_sub_distance` which is unused.

### Testing 
* Tests pass.