### PR TITLE
Update IVF_PQ array names

### DIFF
--- a/src/include/index/ivf_pq_group.h
+++ b/src/include/index/ivf_pq_group.h
@@ -45,9 +45,10 @@
 [[maybe_unused]] static StorageFormat ivf_pq_storage_formats = {
     {"0.3",
      {
-         // @todo Should these be kept consistent with ivf_flat?
-         {"cluster_centroids_array_name", "pq_cluster_centroids"},
-         {"flat_ivf_centroids_array_name", "uncompressed_centroids"},
+         // The centroids for each subspace.
+         {"cluster_centroids_array_name", "pq_subspace_centroids"},
+         // The centroids for each partition (of the original vectors).
+         {"flat_ivf_centroids_array_name", "partition_centroids"},
 
          // The partitioned, PQ-encoded vectors.
          {"pq_ivf_indices_array_name", "partitioned_pq_vector_indexes"},


### PR DESCRIPTION
### What
Update IVF_PQ array names. Specifically, we:
* Call the centroids we compute for each subspace `pq_subspace_centroids` instead of `pq_cluster_centroids`. Note that `cluster` is what we call these in some of the code, but other places we call them `subspaces`, and I think `subspaces` makes more sense and also matches our public API (`num_subspaces`).
* Call the IVF centroids `partition_centroids` instead of `uncompressed_centroids`. This matches what `IVF_FLAT` does, which is good because they are the same thing.

Though please let me know if you have a different suggestion.

### Testing
Tests pass.