### PR TITLE
DirectoryReader: set text/plain as default mime type if it is not found

### DIFF
--- a/apis/python/src/tiledb/vector_search/object_readers/directory_reader.py
+++ b/apis/python/src/tiledb/vector_search/object_readers/directory_reader.py
@@ -385,6 +385,9 @@ class TileDBLoader:
             mime_type = mimetypes.guess_type(self.uri)[0]
             f = vfs.open(self.uri)
 
+        if mime_type is None:
+            mime_type="text/plain"
+
         if mime_type.startswith("image/"):
             from langchain_community.document_loaders import UnstructuredFileIOLoader
 

--- a/apis/python/src/tiledb/vector_search/object_readers/directory_reader.py
+++ b/apis/python/src/tiledb/vector_search/object_readers/directory_reader.py
@@ -386,7 +386,7 @@ class TileDBLoader:
             f = vfs.open(self.uri)
 
         if mime_type is None:
-            mime_type="text/plain"
+            mime_type = "text/plain"
 
         if mime_type.startswith("image/"):
             from langchain_community.document_loaders import UnstructuredFileIOLoader


### PR DESCRIPTION
DirectoryReader: set text/plain as default mime type if it is not found.

This is useful when parsing several markdown formats that don't have a mime type.