### PR TITLE
Add option to run local-benchmarks.py with index at a tiledb uri

### DIFF
--- a/apis/python/test/common.py
+++ b/apis/python/test/common.py
@@ -394,11 +394,12 @@ def setUpCloudToken():
     tiledb.cloud.login(token=token)
 
 
-def create_cloud_uri(name):
+def create_cloud_uri(name, folder_name=None):
     namespace, storage_path, _ = groups._default_ns_path_cred()
     storage_path = storage_path.replace("//", "/").replace("/", "//", 1)
-    rand_name = random_name("vector_search")
-    test_path = f"tiledb://{namespace}/{storage_path}/{rand_name}"
+    if not folder_name:
+        folder_name = random_name("vector_search")
+    test_path = f"tiledb://{namespace}/{storage_path}/{folder_name}"
     return f"{test_path}/{name}"
 
 

--- a/apis/python/test/local-benchmarks.py
+++ b/apis/python/test/local-benchmarks.py
@@ -13,23 +13,26 @@ import time
 import urllib.request
 from datetime import datetime
 from enum import Enum
-import tiledb
+
 import matplotlib
 import matplotlib.pyplot as plt
 from common import accuracy
 from common import get_groundtruth_ivec
 
+import tiledb
+from tiledb.vector_search.index import Index
 from tiledb.vector_search.ingestion import TrainingSamplingPolicy
 from tiledb.vector_search.ingestion import ingest
-from tiledb.vector_search.index import Index
 from tiledb.vector_search.utils import load_fvecs
+
 
 class RemoteURIType(Enum):
     LOCAL = 1
     TILEDB = 2
 
+
 ## Settings
-REMOTE_URI_TYPE = RemoteURIType.TILEDB
+REMOTE_URI_TYPE = RemoteURIType.LOCAL
 USE_SIFT_SMALL = True
 
 # Use headless mode for matplotlib.
@@ -289,6 +292,7 @@ def get_uri(tag):
     elif REMOTE_URI_TYPE == RemoteURIType.TILEDB:
         from common import create_cloud_uri
         from common import setUpCloudToken
+
         setUpCloudToken()
         index_uri = create_cloud_uri(index_name, "local_benchmarks")
         logger.info(f"TileDB URI {index_uri}")
@@ -297,10 +301,13 @@ def get_uri(tag):
     else:
         raise ValueError(f"Invalid REMOTE_URI_TYPE {REMOTE_URI_TYPE}")
 
+
 def cleanup_uri(index_uri):
     if REMOTE_URI_TYPE == RemoteURIType.TILEDB:
         from common import delete_uri
+
         delete_uri(uri=index_uri, config=tiledb.cloud.Config())
+
 
 def benchmark_ivf_flat():
     index_type = "IVF_FLAT"
@@ -321,7 +328,9 @@ def benchmark_ivf_flat():
             index_type=index_type,
             index_uri=index_uri,
             source_uri=SIFT_BASE_PATH,
-            config=tiledb.cloud.Config().dict() if REMOTE_URI_TYPE is not None else None,
+            config=tiledb.cloud.Config().dict()
+            if REMOTE_URI_TYPE is not None
+            else None,
             partitions=partitions,
             training_sampling_policy=TrainingSamplingPolicy.RANDOM,
         )
@@ -361,7 +370,9 @@ def benchmark_vamana():
                 index_type=index_type,
                 index_uri=index_uri,
                 source_uri=SIFT_BASE_PATH,
-                config=tiledb.cloud.Config().dict() if REMOTE_URI_TYPE is not None else None,
+                config=tiledb.cloud.Config().dict()
+                if REMOTE_URI_TYPE is not None
+                else None,
                 l_build=l_build,
                 r_max_degree=r_max_degree,
                 training_sampling_policy=TrainingSamplingPolicy.RANDOM,
@@ -376,7 +387,7 @@ def benchmark_vamana():
                 logger.info(
                     f"Finished {tag} with l_search={l_search}. Ingestion: {ingest_time:.4f}s. Query: {query_time:.4f}s. Accuracy: {acc:.4f}."
                 )
-            
+
             cleanup_uri(index_uri)
 
     timer.save_and_print_results()
@@ -403,7 +414,9 @@ def benchmark_ivf_pq():
                 index_type=index_type,
                 index_uri=index_uri,
                 source_uri=SIFT_BASE_PATH,
-                config=tiledb.cloud.Config().dict() if REMOTE_URI_TYPE is not None else None,
+                config=tiledb.cloud.Config().dict()
+                if REMOTE_URI_TYPE is not None
+                else None,
                 partitions=partitions,
                 training_sampling_policy=TrainingSamplingPolicy.RANDOM,
                 num_subspaces=num_subspaces,
@@ -418,7 +431,7 @@ def benchmark_ivf_pq():
                 logger.info(
                     f"Finished {tag} with nprobe={nprobe}. Ingestion: {ingest_time:.4f}s. Query: {query_time:.4f}s. Accuracy: {acc:.4f}."
                 )
-            
+
             cleanup_uri(index_uri)
 
     timer.save_and_print_results()
@@ -434,5 +447,6 @@ def main():
     benchmark_ivf_pq()
 
     timer_manager.save_charts()
+
 
 main()

--- a/apis/python/test/local-benchmarks.py
+++ b/apis/python/test/local-benchmarks.py
@@ -113,7 +113,7 @@ class Timer:
         self.tagToAccuracies[tag].append(acc)
         return acc
 
-    def summarize_data(self):
+    def _summarize_data(self):
         summary = {}
         for key, intervals in self.keyToTimes.items():
             tag, mode = key.rsplit("_", 1)
@@ -144,8 +144,8 @@ class Timer:
 
         return summary
 
-    def summary_string(self):
-        summary = self.summarize_data()
+    def _summary_string(self):
+        summary = self._summarize_data()
         summary_str = f"Timer: {self.name}\n"
         for tag, data in summary.items():
             summary_str += f"{tag}\n"
@@ -160,14 +160,9 @@ class Timer:
             summary_str += "\n"
         return summary_str
 
-    def save_charts(self):
-        summary = self.summarize_data()
+    def add_data_to_ingestion_time_vs_average_query_accuracy(self):
+        summary = self._summarize_data()
 
-        # Plot ingestion.
-        plt.figure(figsize=(20, 12))
-        plt.xlabel("Average Query Accuracy")
-        plt.ylabel("Time (seconds)")
-        plt.title(f"{self.name}: Ingestion Time vs Average Query Accuracy")
         for tag, data in summary.items():
             ingestion_times = []
             average_accuracy = sum(data["query"]["accuracies"]) / len(
@@ -180,6 +175,25 @@ class Timer:
             x, y = zip(*ingestion_times)
             plt.scatter(y, x, marker="o", label=tag)
 
+    def add_data_to_query_time_vs_accuracy(self):
+        summary = self._summarize_data()
+
+        for tag, data in summary.items():
+            query_times = []
+            for i in range(data["query"]["count"]):
+                query_times.append(
+                    (data["query"]["times"][i], data["query"]["accuracies"][i])
+                )
+            x, y = zip(*query_times)
+            plt.plot(y, x, marker="o", label=tag)
+
+    def save_charts(self):
+        # Plot ingestion.
+        plt.figure(figsize=(20, 12))
+        plt.xlabel("Average Query Accuracy")
+        plt.ylabel("Time (seconds)")
+        plt.title(f"{self.name}: Ingestion Time vs Average Query Accuracy")
+        self.add_data_to_ingestion_time_vs_average_query_accuracy()
         plt.legend()
         plt.savefig(
             os.path.join(RESULTS_DIR, f"{self.name}_ingestion_time_vs_accuracy.png")
@@ -191,15 +205,7 @@ class Timer:
         plt.xlabel("Accuracy")
         plt.ylabel("Time (seconds)")
         plt.title(f"{self.name}: Query Time vs Accuracy")
-        for tag, data in summary.items():
-            query_times = []
-            for i in range(data["query"]["count"]):
-                query_times.append(
-                    (data["query"]["times"][i], data["query"]["accuracies"][i])
-                )
-            x, y = zip(*query_times)
-            plt.plot(y, x, marker="o", label=tag)
-
+        self.add_data_to_query_time_vs_accuracy()
         plt.legend()
         plt.savefig(
             os.path.join(RESULTS_DIR, f"{self.name}_query_time_vs_accuracy.png")
@@ -207,10 +213,46 @@ class Timer:
         plt.close()
 
     def save_and_print_results(self):
-        summary_string = self.summary_string()
+        summary_string = self._summary_string()
         logger.info(summary_string)
 
         self.save_charts()
+
+
+class TimerManager:
+    def __init__(self):
+        self.timers = []
+
+    def new_timer(self, name):
+        timer = Timer(name)
+        self.timers.append(timer)
+        return timer
+
+    def save_charts(self):
+        # Plot ingestion.
+        plt.figure(figsize=(20, 12))
+        plt.xlabel("Average Query Accuracy")
+        plt.ylabel("Time (seconds)")
+        plt.title("Ingestion Time vs Average Query Accuracy")
+        for timer in self.timers:
+            timer.add_data_to_ingestion_time_vs_average_query_accuracy()
+        plt.legend()
+        plt.savefig(os.path.join(RESULTS_DIR, "ingestion_time_vs_accuracy.png"))
+        plt.close()
+
+        # Plot query.
+        plt.figure(figsize=(20, 12))
+        plt.xlabel("Accuracy")
+        plt.ylabel("Time (seconds)")
+        plt.title("Query Time vs Accuracy")
+        for timer in self.timers:
+            timer.add_data_to_query_time_vs_accuracy()
+        plt.legend()
+        plt.savefig(os.path.join(RESULTS_DIR, "query_time_vs_accuracy.png"))
+        plt.close()
+
+
+timer_manager = TimerManager()
 
 
 def download_and_extract(url, download_path, extract_path):
@@ -231,7 +273,7 @@ def download_and_extract(url, download_path, extract_path):
 
 def benchmark_ivf_flat():
     index_type = "IVF_FLAT"
-    timer = Timer(name=index_type)
+    timer = timer_manager.new_timer(index_type)
 
     k = 100
     queries = load_fvecs(SIFT_QUERIES_PATH)
@@ -269,7 +311,7 @@ def benchmark_ivf_flat():
 
 def benchmark_vamana():
     index_type = "VAMANA"
-    timer = Timer(name=index_type)
+    timer = timer_manager.new_timer(index_type)
 
     k = 100
     queries = load_fvecs(SIFT_QUERIES_PATH)
@@ -309,7 +351,7 @@ def benchmark_vamana():
 
 def benchmark_ivf_pq():
     index_type = "IVF_PQ"
-    timer = Timer(name=index_type)
+    timer = timer_manager.new_timer(index_type)
 
     k = 100
     queries = load_fvecs(SIFT_QUERIES_PATH)
@@ -354,6 +396,8 @@ def main():
     benchmark_ivf_flat()
     benchmark_vamana()
     benchmark_ivf_pq()
+
+    timer_manager.save_charts()
 
 
 main()


### PR DESCRIPTION
### What
Add option to run local-benchmarks.py with index at a tiledb uri.

### Testing
Runs successfully. Seems to show that IO / network latency becomes the bottleneck and there is pretty large variability in query speed. IVF_PQ also shows off one of its current benefits with infinite ram, which is that it caches data:
```
TileDB URI tiledb://paris-morgan/s3://tiledb-paris/tiledb/groups/local_benchmarks/index_IVF_PQ_partitions_50_num_subspaces_16.0
Finished IVF_PQ_partitions=50_num_subspaces=16.0 with nprobe=5. Ingestion: 202.4755s. Query: 3.0375s. Accuracy: 0.7435.
Finished IVF_PQ_partitions=50_num_subspaces=16.0 with nprobe=10. Ingestion: 202.4755s. Query: 0.0065s. Accuracy: 0.7890.
Finished IVF_PQ_partitions=50_num_subspaces=16.0 with nprobe=20. Ingestion: 202.4755s. Query: 0.0073s. Accuracy: 0.7969.
Finished IVF_PQ_partitions=50_num_subspaces=16.0 with nprobe=40. Ingestion: 202.4755s. Query: 0.0103s. Accuracy: 0.7969.
Finished IVF_PQ_partitions=50_num_subspaces=16.0 with nprobe=60. Ingestion: 202.4755s. Query: 0.0101s. Accuracy: 0.7969.
```

![IVF_FLAT_query_time_vs_accuracy](https://github.com/user-attachments/assets/fa17dcd4-fc3d-43aa-a083-cff6bf6daac3)

![IVF_PQ_query_time_vs_accuracy](https://github.com/user-attachments/assets/bcd16e5e-8b43-4cc9-be35-53ac415fbcba)

![query_time_vs_accuracy](https://github.com/user-attachments/assets/4df43ace-2cae-4c92-8d65-31493cc603a9)

```
Saving results to /Users/parismorgan/repo/TileDB-Vector-Search-2/apis/python/test/results/2024-09-03_18-25-29
Skipping download of ftp://ftp.irisa.fr/local/texmex/corpus/siftsmall.tar.gz to /Users/parismorgan/repo/TileDB-Vector-Search-2/apis/python/test/results/siftsmall.tar.gz because it already exists.
Extracting files.
Finished extracting files.

Running IVF_PQ_partitions=50_num_subspaces=64.0
TileDB URI tiledb://paris-morgan/s3://tiledb-paris/tiledb/groups/local_benchmarks/index_IVF_PQ_partitions_50_num_subspaces_64.0
Finished IVF_PQ_partitions=50_num_subspaces=64.0 with nprobe=5. Ingestion: 197.1708s. Query: 4.1207s. Accuracy: 0.8743.
Finished IVF_PQ_partitions=50_num_subspaces=64.0 with nprobe=10. Ingestion: 197.1708s. Query: 0.0148s. Accuracy: 0.9283.
Finished IVF_PQ_partitions=50_num_subspaces=64.0 with nprobe=20. Ingestion: 197.1708s. Query: 0.0133s. Accuracy: 0.9345.
Finished IVF_PQ_partitions=50_num_subspaces=64.0 with nprobe=40. Ingestion: 197.1708s. Query: 0.0170s. Accuracy: 0.9345.
Finished IVF_PQ_partitions=50_num_subspaces=64.0 with nprobe=60. Ingestion: 197.1708s. Query: 0.0148s. Accuracy: 0.9345.

Running IVF_PQ_partitions=50_num_subspaces=32.0
TileDB URI tiledb://paris-morgan/s3://tiledb-paris/tiledb/groups/local_benchmarks/index_IVF_PQ_partitions_50_num_subspaces_32.0
Finished IVF_PQ_partitions=50_num_subspaces=32.0 with nprobe=5. Ingestion: 195.2962s. Query: 2.9434s. Accuracy: 0.8065.
Finished IVF_PQ_partitions=50_num_subspaces=32.0 with nprobe=10. Ingestion: 195.2962s. Query: 0.0103s. Accuracy: 0.8634.
Finished IVF_PQ_partitions=50_num_subspaces=32.0 with nprobe=20. Ingestion: 195.2962s. Query: 0.0116s. Accuracy: 0.8695.
Finished IVF_PQ_partitions=50_num_subspaces=32.0 with nprobe=40. Ingestion: 195.2962s. Query: 0.0128s. Accuracy: 0.8694.
Finished IVF_PQ_partitions=50_num_subspaces=32.0 with nprobe=60. Ingestion: 195.2962s. Query: 0.0117s. Accuracy: 0.8694.

Running IVF_PQ_partitions=50_num_subspaces=16.0
TileDB URI tiledb://paris-morgan/s3://tiledb-paris/tiledb/groups/local_benchmarks/index_IVF_PQ_partitions_50_num_subspaces_16.0
Finished IVF_PQ_partitions=50_num_subspaces=16.0 with nprobe=5. Ingestion: 202.4755s. Query: 3.0375s. Accuracy: 0.7435.
Finished IVF_PQ_partitions=50_num_subspaces=16.0 with nprobe=10. Ingestion: 202.4755s. Query: 0.0065s. Accuracy: 0.7890.
Finished IVF_PQ_partitions=50_num_subspaces=16.0 with nprobe=20. Ingestion: 202.4755s. Query: 0.0073s. Accuracy: 0.7969.
Finished IVF_PQ_partitions=50_num_subspaces=16.0 with nprobe=40. Ingestion: 202.4755s. Query: 0.0103s. Accuracy: 0.7969.
Finished IVF_PQ_partitions=50_num_subspaces=16.0 with nprobe=60. Ingestion: 202.4755s. Query: 0.0101s. Accuracy: 0.7969.

Timer: IVF_PQ
IVF_PQ_partitions=50_num_subspaces=64.0
  Ingestion (count: 1):
    Average Time: 197.1708 seconds
  Query (count: 5):
    Average Time: 0.8361 seconds
    Average Accuracy: 0.9212

IVF_PQ_partitions=50_num_subspaces=32.0
  Ingestion (count: 1):
    Average Time: 195.2962 seconds
  Query (count: 5):
    Average Time: 0.5979 seconds
    Average Accuracy: 0.8556

IVF_PQ_partitions=50_num_subspaces=16.0
  Ingestion (count: 1):
    Average Time: 202.4755 seconds
  Query (count: 5):
    Average Time: 0.6144 seconds
    Average Accuracy: 0.7846

Running IVF_FLAT_partitions=20
TileDB URI tiledb://paris-morgan/s3://tiledb-paris/tiledb/groups/local_benchmarks/index_IVF_FLAT_partitions_20
Finished IVF_FLAT_partitions=20 with nprobe=1. Ingestion: 173.0355s. Query: 2.5724s. Accuracy: 0.6099.
Finished IVF_FLAT_partitions=20 with nprobe=2. Ingestion: 173.0355s. Query: 2.2274s. Accuracy: 0.7953.
Finished IVF_FLAT_partitions=20 with nprobe=3. Ingestion: 173.0355s. Query: 2.6136s. Accuracy: 0.8784.
Finished IVF_FLAT_partitions=20 with nprobe=4. Ingestion: 173.0355s. Query: 2.7724s. Accuracy: 0.9364.
Finished IVF_FLAT_partitions=20 with nprobe=5. Ingestion: 173.0355s. Query: 2.5642s. Accuracy: 0.9679.
Finished IVF_FLAT_partitions=20 with nprobe=10. Ingestion: 173.0355s. Query: 2.7190s. Accuracy: 1.0000.
Finished IVF_FLAT_partitions=20 with nprobe=20. Ingestion: 173.0355s. Query: 2.2826s. Accuracy: 1.0000.

Running IVF_FLAT_partitions=50
TileDB URI tiledb://paris-morgan/s3://tiledb-paris/tiledb/groups/local_benchmarks/index_IVF_FLAT_partitions_50
Finished IVF_FLAT_partitions=50 with nprobe=1. Ingestion: 197.2947s. Query: 2.5700s. Accuracy: 0.4460.
Finished IVF_FLAT_partitions=50 with nprobe=2. Ingestion: 197.2947s. Query: 2.1868s. Accuracy: 0.6338.
Finished IVF_FLAT_partitions=50 with nprobe=3. Ingestion: 197.2947s. Query: 2.7094s. Accuracy: 0.7615.
Finished IVF_FLAT_partitions=50 with nprobe=4. Ingestion: 197.2947s. Query: 2.5223s. Accuracy: 0.8392.
Finished IVF_FLAT_partitions=50 with nprobe=5. Ingestion: 197.2947s. Query: 2.2088s. Accuracy: 0.8901.
Finished IVF_FLAT_partitions=50 with nprobe=10. Ingestion: 197.2947s. Query: 2.7960s. Accuracy: 0.9781.
Finished IVF_FLAT_partitions=50 with nprobe=20. Ingestion: 197.2947s. Query: 2.3367s. Accuracy: 0.9995.

Running IVF_FLAT_partitions=100
TileDB URI tiledb://paris-morgan/s3://tiledb-paris/tiledb/groups/local_benchmarks/index_IVF_FLAT_partitions_100
Finished IVF_FLAT_partitions=100 with nprobe=1. Ingestion: 208.1174s. Query: 2.5413s. Accuracy: 0.3480.
Finished IVF_FLAT_partitions=100 with nprobe=2. Ingestion: 208.1174s. Query: 2.3959s. Accuracy: 0.5053.
Finished IVF_FLAT_partitions=100 with nprobe=3. Ingestion: 208.1174s. Query: 2.5121s. Accuracy: 0.6216.
Finished IVF_FLAT_partitions=100 with nprobe=4. Ingestion: 208.1174s. Query: 2.7497s. Accuracy: 0.7045.
Finished IVF_FLAT_partitions=100 with nprobe=5. Ingestion: 208.1174s. Query: 2.5755s. Accuracy: 0.7531.
Finished IVF_FLAT_partitions=100 with nprobe=10. Ingestion: 208.1174s. Query: 2.2877s. Accuracy: 0.9197.
Finished IVF_FLAT_partitions=100 with nprobe=20. Ingestion: 208.1174s. Query: 2.5300s. Accuracy: 0.9875.

Running IVF_FLAT_partitions=200
TileDB URI tiledb://paris-morgan/s3://tiledb-paris/tiledb/groups/local_benchmarks/index_IVF_FLAT_partitions_200
Finished IVF_FLAT_partitions=200 with nprobe=1. Ingestion: 194.8487s. Query: 3.0289s. Accuracy: 0.2410.
Finished IVF_FLAT_partitions=200 with nprobe=2. Ingestion: 194.8487s. Query: 2.8141s. Accuracy: 0.4031.
Finished IVF_FLAT_partitions=200 with nprobe=3. Ingestion: 194.8487s. Query: 2.6683s. Accuracy: 0.5198.
Finished IVF_FLAT_partitions=200 with nprobe=4. Ingestion: 194.8487s. Query: 2.7463s. Accuracy: 0.5908.
Finished IVF_FLAT_partitions=200 with nprobe=5. Ingestion: 194.8487s. Query: 4.0996s. Accuracy: 0.6464.
Finished IVF_FLAT_partitions=200 with nprobe=10. Ingestion: 194.8487s. Query: 3.0012s. Accuracy: 0.8291.
Finished IVF_FLAT_partitions=200 with nprobe=20. Ingestion: 194.8487s. Query: 3.0589s. Accuracy: 0.9469.


Timer: IVF_FLAT
IVF_FLAT_partitions=20
  Ingestion (count: 1):
    Average Time: 173.0355 seconds
  Query (count: 7):
    Average Time: 2.5359 seconds
    Average Accuracy: 0.8840

IVF_FLAT_partitions=50
  Ingestion (count: 1):
    Average Time: 197.2947 seconds
  Query (count: 7):
    Average Time: 2.4757 seconds
    Average Accuracy: 0.7926

IVF_FLAT_partitions=100
  Ingestion (count: 1):
    Average Time: 208.1174 seconds
  Query (count: 7):
    Average Time: 2.5132 seconds
    Average Accuracy: 0.6914

IVF_FLAT_partitions=200
  Ingestion (count: 1):
    Average Time: 194.8487 seconds
  Query (count: 7):
    Average Time: 3.0596 seconds
    Average Accuracy: 0.5967
```