### PR TITLE
Delete index after use in `local-benchmarks.py`

### DIFF
--- a/apis/python/test/local-benchmarks.py
+++ b/apis/python/test/local-benchmarks.py
@@ -304,9 +304,9 @@ def get_uri(tag):
 
 def cleanup_uri(index_uri):
     if REMOTE_URI_TYPE == RemoteURIType.TILEDB:
-        from common import delete_uri
-
-        delete_uri(uri=index_uri, config=tiledb.cloud.Config())
+        Index.delete_index(uri=index_uri, config=tiledb.cloud.Config())
+    else:
+        Index.delete_index(uri=index_uri)
 
 
 def benchmark_ivf_flat():


### PR DESCRIPTION
### What
Delete index after use in `local-benchmarks.py`

### Testing
Works for me. Though one thing about `Index.delete_index()` is that the folders still show up locally, so seems something nice to fix eventually:

<img width="340" alt="Screenshot 2024-09-06 at 9 32 38 AM" src="https://github.com/user-attachments/assets/045db1d3-57eb-497a-a5d4-5b2436800196">
