### PR TITLE
Fix bug for Index clear_history

### DIFF
--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -638,7 +638,7 @@ class Index:
             new_partition_history = []
             i = 0
             for ingestion_timestamp in ingestion_timestamps:
-                if ingestion_timestamp==0 or ingestion_timestamp > timestamp:
+                if ingestion_timestamp == 0 or ingestion_timestamp > timestamp:
                     new_ingestion_timestamps.append(ingestion_timestamp)
                     new_base_sizes.append(base_sizes[i])
                     new_partition_history.append(partition_history[i])

--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -638,7 +638,7 @@ class Index:
             new_partition_history = []
             i = 0
             for ingestion_timestamp in ingestion_timestamps:
-                if ingestion_timestamp > timestamp:
+                if ingestion_timestamp==0 or ingestion_timestamp > timestamp:
                     new_ingestion_timestamps.append(ingestion_timestamp)
                     new_base_sizes.append(base_sizes[i])
                     new_partition_history.append(partition_history[i])


### PR DESCRIPTION
We always need to have `0` as the first ingestion timestamp, even if we don't have respective write fragments in the base index arrays. If not, `updates` that are before the `first_ingestion_timestamp` will not be visible. 

Testing: unit tests