### PR TITLE
Update TileDB Core 2.26.0 and pin `tiledb` Python package to exact version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 dependencies = [
     "tiledb-cloud>=0.11",
-    "tiledb>=0.31.0",
+    "tiledb==0.32.0",
     "typing-extensions", # for tiledb-cloud indirect, x-ref https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/428
     "scikit-learn",
     "numpy<2.0.0",

--- a/src/cmake/Modules/FindTileDB_EP.cmake
+++ b/src/cmake/Modules/FindTileDB_EP.cmake
@@ -57,13 +57,13 @@ else()
     # - Copy the release hash from the `releases.csv.sha256` file in the release.
     if(DOWNLOAD_TILEDB_PREBUILT)
         fetch_prebuilt_tiledb(
-                VERSION 2.25.0
-                RELLIST_HASH SHA256=398a1da194a59817b6f354b3232f6575c97c350d6dc792de54c529162e30763c
+                VERSION 2.26.0
+                RELLIST_HASH SHA256=f9086d53d4f9daaf7f4b22d78cb66c45f571de5dd77caf8a18b3d7de3551e1c7
         )
     else() # Build from source
         fetch_source_tiledb(
-                VERSION 2.25.0
-                RELLIST_HASH SHA256=398a1da194a59817b6f354b3232f6575c97c350d6dc792de54c529162e30763c
+                VERSION 2.26.0
+                RELLIST_HASH SHA256=f9086d53d4f9daaf7f4b22d78cb66c45f571de5dd77caf8a18b3d7de3551e1c7
         )
     endif()
 


### PR DESCRIPTION
### What
* Update TileDB Core 2.26.0 
* Pin `tiledb` Python package to exact version