### PR TITLE
Add explicit markdown parser for `DirectoryTextReader`

### DIFF
--- a/apis/python/src/tiledb/vector_search/object_readers/directory_reader.py
+++ b/apis/python/src/tiledb/vector_search/object_readers/directory_reader.py
@@ -355,6 +355,7 @@ class TileDBLoader:
             handlers={
                 "application/pdf": PyMuPDFParser(),
                 "text/plain": TextParser(),
+                "text/markdown": TextParser(),
                 "text/html": BS4HTMLParser(),
                 "application/msword": MsWordParser(),
                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document": (
@@ -385,7 +386,7 @@ class TileDBLoader:
             mime_type = mimetypes.guess_type(self.uri)[0]
             f = vfs.open(self.uri)
 
-        if mime_type is None:
+        if mime_type is None or mime_type.startswith("text"):
             mime_type = "text/plain"
 
         if mime_type.startswith("image/"):


### PR DESCRIPTION
Add explicit markdown parser for `DirectoryTextReader`

This is causing [failures](https://github.com/TileDB-Inc/TileDB-Documentation/actions/runs/11015378317/job/30588303124?pr=341) for the Academy index building CI task 