### PR TITLE
Parallelize asset creation and registration

### DIFF
--- a/apis/python/src/tiledb/vector_search/index.py
+++ b/apis/python/src/tiledb/vector_search/index.py
@@ -853,34 +853,25 @@ class Index(metaclass=ABCMeta):
 
 
 def create_metadata(
-    uri: str,
+    group: tiledb.Group,
     dimensions: int,
     vector_type: np.dtype,
     index_type: str,
     storage_version: str,
     distance_metric: vspy.DistanceMetric,
-    group_exists: bool = False,
-    config: Optional[Mapping[str, Any]] = None,
 ):
     """
     Creates the index group adding index metadata.
     """
-    with tiledb.scope_ctx(ctx_or_config=config):
-        if not group_exists:
-            try:
-                tiledb.group_create(uri)
-            except tiledb.TileDBError as err:
-                raise err
-        group = tiledb.Group(uri, "w")
-        group.meta["dataset_type"] = DATASET_TYPE
-        group.meta["dtype"] = np.dtype(vector_type).name
-        group.meta["storage_version"] = storage_version
-        group.meta["index_type"] = index_type
-        group.meta["base_sizes"] = json.dumps([0])
-        group.meta["ingestion_timestamps"] = json.dumps([0])
-        group.meta["has_updates"] = False
-        group.meta["distance_metric"] = int(distance_metric)
-        group.close()
+    group.meta["dataset_type"] = DATASET_TYPE
+    group.meta["dtype"] = np.dtype(vector_type).name
+    group.meta["dimensions"] = dimensions
+    group.meta["storage_version"] = storage_version
+    group.meta["index_type"] = index_type
+    group.meta["base_sizes"] = json.dumps([0])
+    group.meta["ingestion_timestamps"] = json.dumps([0])
+    group.meta["has_updates"] = False
+    group.meta["distance_metric"] = int(distance_metric)
 
 
 """

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -14,7 +14,8 @@ It enables:
 
 import enum
 from functools import partial
-from typing import Any, Mapping, Optional, Tuple
+from threading import Thread
+from typing import Any, Mapping, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -24,6 +25,7 @@ from tiledb.vector_search._tiledbvspy import *
 from tiledb.vector_search.storage_formats import STORAGE_VERSION
 from tiledb.vector_search.storage_formats import validate_storage_version
 from tiledb.vector_search.utils import add_to_group
+from tiledb.vector_search.utils import create_array_and_add_to_group
 from tiledb.vector_search.utils import is_type_erased_index
 from tiledb.vector_search.utils import normalize_vectors
 from tiledb.vector_search.utils import to_temporal_policy
@@ -611,6 +613,7 @@ def ingest(
         dimensions: int,
         filters: Any,
         create_index_array: bool,
+        asset_creation_threads: Sequence[Thread],
     ) -> str:
         tile_size = int(
             ivf_flat_index.TILE_SIZE_BYTES / np.dtype(vector_type).itemsize / dimensions
@@ -640,12 +643,17 @@ def ingest(
                 cell_order="col-major",
                 tile_order="col-major",
             )
-            tiledb.Array.create(partial_write_array_index_uri, index_schema)
-            add_to_group(
-                temp_data_group,
-                partial_write_array_index_uri,
-                INDEX_ARRAY_NAME,
+            thread = Thread(
+                target=create_array_and_add_to_group,
+                kwargs={
+                    "array_uri": partial_write_array_index_uri,
+                    "array_name": INDEX_ARRAY_NAME,
+                    "group": temp_data_group,
+                    "schema": index_schema,
+                },
             )
+            thread.start()
+            asset_creation_threads.append(thread)
 
         if not tiledb.array_exists(partial_write_array_ids_uri):
             logger.debug("Creating temp ids array")
@@ -670,12 +678,17 @@ def ingest(
                 tile_order="col-major",
             )
             logger.debug(ids_schema)
-            tiledb.Array.create(partial_write_array_ids_uri, ids_schema)
-            add_to_group(
-                temp_data_group,
-                partial_write_array_ids_uri,
-                IDS_ARRAY_NAME,
+            thread = Thread(
+                target=create_array_and_add_to_group,
+                kwargs={
+                    "array_uri": partial_write_array_ids_uri,
+                    "array_name": IDS_ARRAY_NAME,
+                    "group": temp_data_group,
+                    "schema": ids_schema,
+                },
             )
+            thread.start()
+            asset_creation_threads.append(thread)
 
         if not tiledb.array_exists(partial_write_array_parts_uri):
             logger.debug("Creating temp parts array")
@@ -702,12 +715,17 @@ def ingest(
             )
             logger.debug(parts_schema)
             logger.debug(partial_write_array_parts_uri)
-            tiledb.Array.create(partial_write_array_parts_uri, parts_schema)
-            add_to_group(
-                temp_data_group,
-                partial_write_array_parts_uri,
-                PARTS_ARRAY_NAME,
+            thread = Thread(
+                target=create_array_and_add_to_group,
+                kwargs={
+                    "array_uri": partial_write_array_parts_uri,
+                    "array_name": PARTS_ARRAY_NAME,
+                    "group": temp_data_group,
+                    "schema": parts_schema,
+                },
             )
+            thread.start()
+            asset_creation_threads.append(thread)
         return partial_write_array_index_uri
 
     def create_arrays(
@@ -720,6 +738,7 @@ def ingest(
         vector_type: np.dtype,
         logger: logging.Logger,
         storage_version: str,
+        asset_creation_threads: Sequence[Thread],
     ) -> None:
         if index_type == "FLAT":
             if not arrays_created:
@@ -728,9 +747,11 @@ def ingest(
                     dimensions=dimensions,
                     vector_type=vector_type,
                     group_exists=True,
+                    group=group,
                     config=config,
                     storage_version=storage_version,
                     distance_metric=distance_metric,
+                    asset_creation_threads=asset_creation_threads,
                 )
         elif index_type == "IVF_FLAT":
             if not arrays_created:
@@ -739,9 +760,11 @@ def ingest(
                     dimensions=dimensions,
                     vector_type=vector_type,
                     group_exists=True,
+                    group=group,
                     config=config,
                     storage_version=storage_version,
                     distance_metric=distance_metric,
+                    asset_creation_threads=asset_creation_threads,
                 )
             create_partial_write_array_group(
                 temp_data_group=temp_data_group,
@@ -749,6 +772,7 @@ def ingest(
                 dimensions=dimensions,
                 filters=DEFAULT_ATTR_FILTERS,
                 create_index_array=True,
+                asset_creation_threads=asset_creation_threads,
             )
 
         # Note that we don't create type-erased indexes (i.e. Vamana) here. Instead we create them
@@ -1539,13 +1563,17 @@ def ingest(
 
             temp_data_group_uri = f"{index_group_uri}/{PARTIAL_WRITE_ARRAY_DIR}"
             temp_data_group = tiledb.Group(temp_data_group_uri, "w")
+            asset_creation_threads = []
             create_partial_write_array_group(
                 temp_data_group=temp_data_group,
                 vector_type=vector_type,
                 dimensions=dimensions,
                 filters=storage_formats[storage_version]["DEFAULT_ATTR_FILTERS"],
                 create_index_array=False,
+                asset_creation_threads=asset_creation_threads,
             )
+            for thread in asset_creation_threads:
+                thread.join()
             temp_data_group.close()
             temp_data_group = tiledb.Group(temp_data_group_uri)
             ids_array_uri = temp_data_group[IDS_ARRAY_NAME].uri
@@ -2942,6 +2970,7 @@ def ingest(
 
         logger.debug("Creating arrays")
         group = tiledb.Group(index_group_uri, "w")
+        asset_creation_threads = []
         temp_data_group = create_temp_data_group(group=group)
         create_arrays(
             group=group,
@@ -2953,6 +2982,7 @@ def ingest(
             vector_type=vector_type,
             logger=logger,
             storage_version=storage_version,
+            asset_creation_threads=asset_creation_threads,
         )
 
         if (
@@ -2996,6 +3026,9 @@ def ingest(
         else:
             if external_ids_type is None:
                 external_ids_type = "U64BIN"
+
+        for thread in asset_creation_threads:
+            thread.join()
         temp_data_group.close()
         group.meta["temp_size"] = size
         group.close()

--- a/apis/python/src/tiledb/vector_search/ivf_flat_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_flat_index.py
@@ -25,7 +25,8 @@ Queries can be run in multiple modes:
 """
 import json
 import multiprocessing
-from typing import Any, Mapping
+from threading import Thread
+from typing import Any, Mapping, Sequence
 
 import numpy as np
 
@@ -38,7 +39,7 @@ from tiledb.vector_search.storage_formats import validate_storage_version
 from tiledb.vector_search.utils import MAX_FLOAT32
 from tiledb.vector_search.utils import MAX_INT32
 from tiledb.vector_search.utils import MAX_UINT64
-from tiledb.vector_search.utils import add_to_group
+from tiledb.vector_search.utils import create_array_and_add_to_group
 from tiledb.vector_search.utils import normalize_vector
 from tiledb.vector_search.utils import normalize_vectors
 
@@ -538,6 +539,8 @@ def create(
     config: Optional[Mapping[str, Any]] = None,
     storage_version: str = STORAGE_VERSION,
     distance_metric: vspy.DistanceMetric = vspy.DistanceMetric.SUM_OF_SQUARES,
+    group: tiledb.Group = None,
+    asset_creation_threads: Sequence[Thread] = None,
     **kwargs,
 ) -> IVFFlatIndex:
     """
@@ -560,6 +563,15 @@ def create(
     storage_version: str
         The TileDB vector search storage version to use.
         If not provided, use the latest stable storage version.
+    group: tiledb.Group
+        TileDB group open in write mode.
+        Internal, this is used to avoid opening the group multiple times during
+        ingestion.
+    asset_creation_threads: Sequence[Thread]
+        List of asset creation threads to append new threads.
+        Internal, this is used to parallelize all asset creation during
+        ingestion.
+
     """
     validate_storage_version(storage_version)
     if (
@@ -571,20 +583,38 @@ def create(
             f"Distance metric {distance_metric} is not supported in IVF_FLAT"
         )
 
-    index.create_metadata(
-        uri=uri,
-        dimensions=dimensions,
-        vector_type=vector_type,
-        index_type=INDEX_TYPE,
-        storage_version=storage_version,
-        distance_metric=distance_metric,
-        group_exists=group_exists,
-        config=config,
-    )
+    if group is None != asset_creation_threads is not None:
+        raise ValueError(
+            "Can't pass `asset_creation_threads` without a `group` argument."
+        )
+
     with tiledb.scope_ctx(ctx_or_config=config):
-        group = tiledb.Group(uri, "w")
+        if not group_exists:
+            try:
+                tiledb.group_create(uri)
+            except tiledb.TileDBError as err:
+                raise err
+        if group is None:
+            grp = tiledb.Group(uri, "w")
+        else:
+            grp = group
+
+        if asset_creation_threads is not None:
+            threads = asset_creation_threads
+        else:
+            threads = []
+
+        index.create_metadata(
+            group=grp,
+            dimensions=dimensions,
+            vector_type=vector_type,
+            index_type=INDEX_TYPE,
+            storage_version=storage_version,
+            distance_metric=distance_metric,
+        )
+
         tile_size = int(TILE_SIZE_BYTES / np.dtype(vector_type).itemsize / dimensions)
-        group.meta["partition_history"] = json.dumps([0])
+        grp.meta["partition_history"] = json.dumps([0])
         centroids_array_name = storage_formats[storage_version]["CENTROIDS_ARRAY_NAME"]
         index_array_name = storage_formats[storage_version]["INDEX_ARRAY_NAME"]
         ids_array_name = storage_formats[storage_version]["IDS_ARRAY_NAME"]
@@ -623,8 +653,17 @@ def create(
             cell_order="col-major",
             tile_order="col-major",
         )
-        tiledb.Array.create(centroids_uri, centroids_schema)
-        add_to_group(group, centroids_uri, name=centroids_array_name)
+        thread = Thread(
+            target=create_array_and_add_to_group,
+            kwargs={
+                "array_uri": centroids_uri,
+                "array_name": centroids_array_name,
+                "group": grp,
+                "schema": centroids_schema,
+            },
+        )
+        thread.start()
+        threads.append(thread)
 
         index_array_rows_dim = tiledb.Dim(
             name="rows",
@@ -645,8 +684,17 @@ def create(
             cell_order="col-major",
             tile_order="col-major",
         )
-        tiledb.Array.create(index_array_uri, index_schema)
-        add_to_group(group, index_array_uri, name=index_array_name)
+        thread = Thread(
+            target=create_array_and_add_to_group,
+            kwargs={
+                "array_uri": index_array_uri,
+                "array_name": index_array_name,
+                "group": grp,
+                "schema": index_schema,
+            },
+        )
+        thread.start()
+        threads.append(thread)
 
         ids_array_rows_dim = tiledb.Dim(
             name="rows",
@@ -667,8 +715,17 @@ def create(
             cell_order="col-major",
             tile_order="col-major",
         )
-        tiledb.Array.create(ids_uri, ids_schema)
-        add_to_group(group, ids_uri, name=ids_array_name)
+        thread = Thread(
+            target=create_array_and_add_to_group,
+            kwargs={
+                "array_uri": ids_uri,
+                "array_name": ids_array_name,
+                "group": grp,
+                "schema": ids_schema,
+            },
+        )
+        thread.start()
+        threads.append(thread)
 
         parts_array_rows_dim = tiledb.Dim(
             name="rows",
@@ -695,8 +752,17 @@ def create(
             cell_order="col-major",
             tile_order="col-major",
         )
-        tiledb.Array.create(parts_uri, parts_schema)
-        add_to_group(group, parts_uri, name=parts_array_name)
+        thread = Thread(
+            target=create_array_and_add_to_group,
+            kwargs={
+                "array_uri": parts_uri,
+                "array_name": parts_array_name,
+                "group": grp,
+                "schema": parts_schema,
+            },
+        )
+        thread.start()
+        threads.append(thread)
 
         external_id_dim = tiledb.Dim(
             name="external_id",
@@ -711,8 +777,23 @@ def create(
             attrs=[vector_attr],
             allows_duplicates=False,
         )
-        tiledb.Array.create(updates_array_uri, updates_schema)
-        add_to_group(group, updates_array_uri, name=updates_array_name)
+        thread = Thread(
+            target=create_array_and_add_to_group,
+            kwargs={
+                "array_uri": updates_array_uri,
+                "array_name": updates_array_name,
+                "group": grp,
+                "schema": updates_schema,
+            },
+        )
+        thread.start()
+        threads.append(thread)
 
-        group.close()
-        return IVFFlatIndex(uri=uri, config=config, memory_budget=1000000)
+        if asset_creation_threads is None:
+            for thread in threads:
+                thread.join()
+        if group is None:
+            grp.close()
+            return IVFFlatIndex(uri=uri, config=config, memory_budget=1000000)
+        else:
+            return None

--- a/apis/python/src/tiledb/vector_search/utils.py
+++ b/apis/python/src/tiledb/vector_search/utils.py
@@ -16,6 +16,11 @@ def is_type_erased_index(index_type: str) -> bool:
     return index_type == "VAMANA" or index_type == "IVF_PQ"
 
 
+def create_array_and_add_to_group(array_uri, array_name, schema, group):
+    tiledb.Array.create(array_uri, schema)
+    add_to_group(group, array_uri, name=array_name)
+
+
 def add_to_group(group, uri, name):
     """
     Adds an object to a group. Automatically infers whether to use a relative path or absolute path.

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -8,14 +8,12 @@ from common import *
 from common import load_metadata
 
 from tiledb.vector_search import Index
-from tiledb.vector_search import _tiledbvspy as vspy
 from tiledb.vector_search import flat_index
 from tiledb.vector_search import ivf_flat_index
 from tiledb.vector_search import ivf_pq_index
 from tiledb.vector_search import open
 from tiledb.vector_search import vamana_index
 from tiledb.vector_search.index import DATASET_TYPE
-from tiledb.vector_search.index import create_metadata
 from tiledb.vector_search.ingestion import ingest
 from tiledb.vector_search.utils import MAX_FLOAT32
 from tiledb.vector_search.utils import MAX_UINT64

--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -551,26 +551,3 @@ def test_index_with_incorrect_num_of_query_columns_in_single_vector_query(tmp_pa
         # TODO:  This also throws a TypeError for incorrect dimension
         with pytest.raises(TypeError):
             index.query(np.array([1, 1, 1], dtype=np.float32), k=3)
-
-
-def test_create_metadata(tmp_path):
-    uri = os.path.join(tmp_path, "array")
-
-    # Create the metadata at the specified URI.
-    dimensions = 3
-    vector_type: np.dtype = np.dtype(np.uint8)
-    index_type: str = "IVF_FLAT"
-    storage_version: str = STORAGE_VERSION
-    group_exists: bool = False
-    create_metadata(
-        uri,
-        dimensions,
-        vector_type,
-        index_type,
-        storage_version,
-        vspy.DistanceMetric.SUM_OF_SQUARES,
-        group_exists,
-    )
-
-    # Check it contains the default metadata.
-    check_default_metadata(uri, vector_type, storage_version, index_type)


### PR DESCRIPTION
Parallelize asset creation and registration. This uses threads to run asset creation in an asynchronous manner. We also pass some extra arguments to the `create` methods to make sure that we open groups once and parallelise all asset creation during ingestion.

 