### PR TITLE
Add start, stop, and temporal_policy to FeatureVector and FeatureVectorArray

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -1664,8 +1664,8 @@ def ingest(
             ctx,
             parts_array_uri,
             ids_array_uri,
-            0,
-            0,
+            0,  # first_col
+            0,  # last_col
             to_temporal_policy(index_timestamp),
         )
         if index_type == "VAMANA":

--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -1661,7 +1661,12 @@ def ingest(
 
         ctx = vspy.Ctx(config)
         data = vspy.FeatureVectorArray(
-            ctx, parts_array_uri, ids_array_uri, 0, to_temporal_policy(index_timestamp)
+            ctx,
+            parts_array_uri,
+            ids_array_uri,
+            0,
+            0,
+            to_temporal_policy(index_timestamp),
         )
         if index_type == "VAMANA":
             index = vspy.IndexVamana(ctx, index_group_uri)

--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -196,7 +196,7 @@ void init_type_erased_module(py::module_& m) {
           py::arg("ctx"),
           py::arg("uri"),
           py::arg("first_col") = 0,
-          py::arg("first_col") = 0,
+          py::arg("last_col") = 0,
           py::arg("temporal_policy") = std::nullopt)
       .def(py::init<size_t, const std::string&>())
       .def(py::init<size_t, void*, const std::string&>())
@@ -268,7 +268,7 @@ void init_type_erased_module(py::module_& m) {
           py::arg("uri"),
           py::arg("ids_uri") = "",
           py::arg("first_col") = 0,
-          py::arg("first_col") = 0,
+          py::arg("last_col") = 0,
           py::arg("temporal_policy") = std::nullopt)
       .def(py::init<size_t, size_t, const std::string&, const std::string&>())
       .def("dimensions", &FeatureVectorArray::dimensions)

--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -182,9 +182,22 @@ void init_type_erased_module(py::module_& m) {
 
   py::class_<FeatureVector>(m, "FeatureVector", py::buffer_protocol())
       .def(
-          py::init<const tiledb::Context&, const std::string&>(),
-          py::keep_alive<1, 2>()  // IndexIVFFlat should keep ctx alive.
-          )
+          "__init__",
+          [](FeatureVector& instance,
+             const tiledb::Context& ctx,
+             const std::string& uri,
+             size_t first_col,
+             size_t last_col,
+             std::optional<TemporalPolicy> temporal_policy) {
+            new (&instance)
+                FeatureVector(ctx, uri, first_col, last_col, temporal_policy);
+          },
+          py::keep_alive<1, 2>(),
+          py::arg("ctx"),
+          py::arg("uri"),
+          py::arg("first_col") = 0,
+          py::arg("first_col") = 0,
+          py::arg("temporal_policy") = std::nullopt)
       .def(py::init<size_t, const std::string&>())
       .def(py::init<size_t, void*, const std::string&>())
       .def("dimensions", &FeatureVector::dimensions)
@@ -244,16 +257,18 @@ void init_type_erased_module(py::module_& m) {
              const tiledb::Context& ctx,
              const std::string& uri,
              const std::string& ids_uri,
-             size_t num_vectors,
+             size_t first_col,
+             size_t last_col,
              std::optional<TemporalPolicy> temporal_policy) {
             new (&instance) FeatureVectorArray(
-                ctx, uri, ids_uri, num_vectors, temporal_policy);
+                ctx, uri, ids_uri, first_col, last_col, temporal_policy);
           },
           py::keep_alive<1, 2>(),  // FeatureVectorArray should keep ctx alive.
           py::arg("ctx"),
           py::arg("uri"),
           py::arg("ids_uri") = "",
-          py::arg("num_vectors") = 0,
+          py::arg("first_col") = 0,
+          py::arg("first_col") = 0,
           py::arg("temporal_policy") = std::nullopt)
       .def(py::init<size_t, size_t, const std::string&, const std::string&>())
       .def("dimensions", &FeatureVectorArray::dimensions)

--- a/src/include/api/feature_vector.h
+++ b/src/include/api/feature_vector.h
@@ -86,13 +86,20 @@ class FeatureVector {
    * @param ctx
    * @param uri
    */
-  FeatureVector(const tiledb::Context& ctx, const std::string& uri) {
-    auto array = tiledb_helpers::open_array(tdb_func__, ctx, uri, TILEDB_READ);
+  FeatureVector(
+      const tiledb::Context& ctx,
+      const std::string& uri,
+      size_t start = 0,
+      size_t end = 0,
+      std::optional<TemporalPolicy> temporal_policy_input = std::nullopt) {
+    auto temporal_policy = temporal_policy_input.value_or(TemporalPolicy{});
+    auto array = tiledb_helpers::open_array(
+        tdb_func__, ctx, uri, TILEDB_READ, temporal_policy);
 
     feature_type_ = get_array_datatype(*array);
     array->close();
 
-    tdb_vector_from_datatype(ctx, uri);
+    tdb_vector_from_datatype(ctx, uri, start, end, temporal_policy);
   }
 
   /*
@@ -126,25 +133,35 @@ class FeatureVector {
    * Dispatch to the appropriate concrete class based on the datatype.
    */
   void tdb_vector_from_datatype(
-      const tiledb::Context& ctx, const std::string& uri) {
+      const tiledb::Context& ctx,
+      const std::string& uri,
+      size_t start,
+      size_t end,
+      TemporalPolicy temporal_policy) {
     switch (feature_type_) {
       case TILEDB_FLOAT32:
-        vector_ = std::make_unique<vector_impl<tdbVector<float>>>(ctx, uri);
+        vector_ = std::make_unique<vector_impl<tdbVector<float>>>(
+            ctx, uri, start, end, temporal_policy);
         break;
       case TILEDB_INT8:
-        vector_ = std::make_unique<vector_impl<tdbVector<int8_t>>>(ctx, uri);
+        vector_ = std::make_unique<vector_impl<tdbVector<int8_t>>>(
+            ctx, uri, start, end, temporal_policy);
         break;
       case TILEDB_UINT8:
-        vector_ = std::make_unique<vector_impl<tdbVector<uint8_t>>>(ctx, uri);
+        vector_ = std::make_unique<vector_impl<tdbVector<uint8_t>>>(
+            ctx, uri, start, end, temporal_policy);
         break;
       case TILEDB_INT32:
-        vector_ = std::make_unique<vector_impl<tdbVector<int32_t>>>(ctx, uri);
+        vector_ = std::make_unique<vector_impl<tdbVector<int32_t>>>(
+            ctx, uri, start, end, temporal_policy);
         break;
       case TILEDB_UINT32:
-        vector_ = std::make_unique<vector_impl<tdbVector<uint32_t>>>(ctx, uri);
+        vector_ = std::make_unique<vector_impl<tdbVector<uint32_t>>>(
+            ctx, uri, start, end, temporal_policy);
         break;
       case TILEDB_UINT64:
-        vector_ = std::make_unique<vector_impl<tdbVector<uint64_t>>>(ctx, uri);
+        vector_ = std::make_unique<vector_impl<tdbVector<uint64_t>>>(
+            ctx, uri, start, end, temporal_policy);
         break;
       default:
         throw std::runtime_error("Unsupported attribute type");
@@ -202,8 +219,13 @@ class FeatureVector {
     explicit vector_impl(size_t size)
         : vector_(size) {
     }
-    vector_impl(const tiledb::Context& ctx, const std::string& uri)
-        : vector_(ctx, uri) {
+    vector_impl(
+        const tiledb::Context& ctx,
+        const std::string& uri,
+        size_t start,
+        size_t end,
+        TemporalPolicy temporal_policy)
+        : vector_(ctx, uri, start, end, temporal_policy) {
     }
     //[[nodiscard]] void* data() override {
     //  return _cpo::data(vector_);

--- a/src/include/detail/linalg/tdb_vector.h
+++ b/src/include/detail/linalg/tdb_vector.h
@@ -47,8 +47,16 @@ class tdbVector : public Vector<T> {
   using Base::Base;
 
  public:
-  tdbVector(const tiledb::Context& ctx, const std::string& uri)
-      : Base(read_vector<T>(ctx, uri)) {
+  tdbVector(
+      const tiledb::Context& ctx,
+      const std::string& uri,
+      size_t start,
+      size_t end,
+      TemporalPolicy temporal_policy)
+      : Base(
+            (start == 0 && end == 0) ?
+                read_vector<T>(ctx, uri, temporal_policy) :
+                read_vector<T>(ctx, uri, start, end, temporal_policy)) {
   }
 };
 

--- a/src/include/detail/linalg/vector.h
+++ b/src/include/detail/linalg/vector.h
@@ -44,11 +44,11 @@
 #if 0
 template <class T>
 std::vector<T> read_vector(
-    const tiledb::Context& ctx,
-    const std::string&,
-    size_t start_pos,
-    size_t end_pos,
-    uint64_t timestamp);
+   const tiledb::Context& ctx,
+   const std::string&,
+   size_t start_pos,
+   size_t end_pos,
+   uint64_t timestamp);
 #endif
 
 template <class M>
@@ -165,7 +165,7 @@ void debug_vector(
     const V& v, const std::string& msg = "", size_t max_size = 10) {
   size_t end = std::min(max_size, dimensions(v));
   if (!msg.empty()) {
-    std::cout << msg << ": ";
+    std::cout << msg << " (" << dimensions(v) << "): ";
   }
   std::cout << "[";
   for (size_t i = 0; i < end; ++i) {
@@ -185,7 +185,7 @@ void debug_vector(
     const V& v, const std::string& msg = "", size_t max_size = 10) {
   size_t end = std::min(max_size, dimensions(v));
   if (!msg.empty()) {
-    std::cout << msg << ": ";
+    std::cout << msg << " (" << dimensions(v) << "): ";
   }
   std::cout << "[";
   size_t idx = 0;

--- a/src/include/test/unit_api_feature_vector.cc
+++ b/src/include/test/unit_api_feature_vector.cc
@@ -141,6 +141,16 @@ TEMPLATE_LIST_TEST_CASE("api: FeatureVector read", "[api]", TestTypes) {
   auto bz = (TestType*)y.data();
   auto ez = by + dimensions(y);
   CHECK(std::equal(bz, ez, begin(x)));
+
+  if (N > 10) {
+    auto vector = FeatureVector{ctx, vname, 0, 10};
+    CHECK(dimensions(vector) == 10);
+  }
+
+  if (N > 10) {
+    auto vector = FeatureVector{ctx, vname, 5, 10};
+    CHECK(dimensions(vector) == 5);
+  }
 }
 
 TEMPLATE_TEST_CASE(

--- a/src/include/test/unit_api_feature_vector_array.cc
+++ b/src/include/test/unit_api_feature_vector_array.cc
@@ -69,6 +69,16 @@ TEST_CASE("feature vector array open", "[api]") {
   CHECK(d.feature_type() == TILEDB_FLOAT32);
   CHECK(dimensions(d) == 128);
   CHECK(num_vectors(d) == num_sift_vectors);
+
+  auto e = FeatureVectorArray(ctx, sift_inputs_uri, "", 0, 100);
+  CHECK(e.feature_type() == TILEDB_FLOAT32);
+  CHECK(dimensions(e) == 128);
+  CHECK(num_vectors(e) == 100);
+
+  auto f = FeatureVectorArray(ctx, sift_inputs_uri, "", 50, 100);
+  CHECK(f.feature_type() == TILEDB_FLOAT32);
+  CHECK(dimensions(f) == 128);
+  CHECK(num_vectors(f) == 50);
 }
 
 template <query_vector_array M>
@@ -668,7 +678,12 @@ TEST_CASE("temporal_policy", "[api]") {
   // Read the data at timestamp 99.
   {
     auto feature_vector_array = FeatureVectorArray(
-        ctx, feature_vectors_uri, ids_uri, 0, TemporalPolicy(TimeTravel, 99));
+        ctx,
+        feature_vectors_uri,
+        ids_uri,
+        0,
+        0,
+        TemporalPolicy(TimeTravel, 99));
     auto data = MatrixView<FeatureType, stdx::layout_left>{
         (FeatureType*)feature_vector_array.data(),
         extents(feature_vector_array)[0],
@@ -689,7 +704,12 @@ TEST_CASE("temporal_policy", "[api]") {
   // Read the data at timestamp 50.
   {
     auto feature_vector_array = FeatureVectorArray(
-        ctx, feature_vectors_uri, ids_uri, 0, TemporalPolicy(TimeTravel, 50));
+        ctx,
+        feature_vectors_uri,
+        ids_uri,
+        0,
+        0,
+        TemporalPolicy(TimeTravel, 50));
     CHECK(extents(feature_vector_array)[0] == 0);
     CHECK(extents(feature_vector_array)[1] == 0);
     CHECK(feature_vector_array.num_vectors() == 0);

--- a/src/include/test/unit_api_flat_l2_index.cc
+++ b/src/include/test/unit_api_flat_l2_index.cc
@@ -149,7 +149,7 @@ TEST_CASE("api: queries", "[api][flat_l2_index]") {
       CHECK(dimensions(a) == dim);
       CHECK(num_vectors(a) == numv);
 
-      auto aq = QueryVectorArray(ctx, q_uri, "", num_queries);
+      auto aq = QueryVectorArray(ctx, q_uri, "", 0, num_queries);
       load(aq);
 
       auto [aq_scores, aq_top_k] = a.query(aq, k_nn);

--- a/src/include/test/utils/set_seed_from_catch.h
+++ b/src/include/test/utils/set_seed_from_catch.h
@@ -56,4 +56,4 @@ class SetSeedFromCatch : public Catch::EventListenerBase {
 
 CATCH_REGISTER_LISTENER(SetSeedFromCatch)
 
-#endif  //  TILEDB_TEST_SUPPORT_PRNG_H
+#endif  //  SET_SEED_FROM_CATCH_H


### PR DESCRIPTION
### What
Add `start`, `stop`, and `temporal_policy` to `FeatureVector` and `FeatureVectorArray`. This will let us call `ingest_parts()` on batches of vectors from Python for the new IVF_PQ out-of-core work.

### Testing
* New tests pass.
* Existing tests pass.