### PR TITLE
Update tdbMatrixMultiRange to support both slices and individual indices

### DIFF
--- a/src/include/detail/linalg/tdb_matrix_multi_range.h
+++ b/src/include/detail/linalg/tdb_matrix_multi_range.h
@@ -104,7 +104,13 @@ class tdbBlockedMatrixMultiRange : public Matrix<T, LayoutPolicy, I> {
    * @param uri URI of the TileDB array to read.
    * @param indices The indices of the columns to read.
    * @param dimensions The number of dimensions in each vector.
-   * @param upper_bound The maximum number of vectors to read.
+   * @param query_type The type of query to perform.
+   * @param column_indices The indices of the columns to read. Should only be
+   * passed with QueryType::ColumnIndices.
+   * @param column_slices The slices of the columns to read. Should only be
+   * passed with QueryType::ColumnSlices.
+   * @param total_num_columns The total number of columns in the array.
+   * @param upper_bound The maximum number of vectors to read in at once.
    * @param temporal_policy The TemporalPolicy to use for reading the array
    * data.
    */
@@ -172,9 +178,9 @@ class tdbBlockedMatrixMultiRange : public Matrix<T, LayoutPolicy, I> {
    *
    * @param ctx The TileDB context to use.
    * @param uri URI of the TileDB array to read.
-   * @param column_indices The indices of the columns to read.
    * @param dimensions The number of dimensions in each vector.
-   * @param upper_bound The maximum number of vectors to read.
+   * @param column_indices The indices of the columns to read.
+   * @param upper_bound The maximum number of vectors to read in at once.
    * @param temporal_policy The TemporalPolicy to use for reading the array
    * data.
    */
@@ -205,9 +211,10 @@ class tdbBlockedMatrixMultiRange : public Matrix<T, LayoutPolicy, I> {
    *
    * @param ctx The TileDB context to use.
    * @param uri URI of the TileDB array to read.
-   * @param column_slices The slices of the columns to read.
    * @param dimensions The number of dimensions in each vector.
-   * @param upper_bound The maximum number of vectors to read.
+   * @param column_slices The slices of the columns to read.
+   * @param total_slices_size The total number of columns in the slices.
+   * @param upper_bound The maximum number of vectors to read in at once.
    * @param temporal_policy The TemporalPolicy to use for reading the array
    * data.
    */

--- a/src/include/index/ivf_pq_index.h
+++ b/src/include/index/ivf_pq_index.h
@@ -1273,8 +1273,8 @@ class ivf_pq_index {
           tdbColMajorMatrixMultiRange<feature_type, uint64_t>(
               group_->cached_ctx(),
               group_->feature_vectors_uri(),
-              vector_indices,
               dimensions_,
+              vector_indices,
               0,
               temporal_policy_);
       feature_vectors.load();

--- a/src/include/test/unit_tdb_matrix_multi_range.cc
+++ b/src/include/test/unit_tdb_matrix_multi_range.cc
@@ -68,7 +68,7 @@ TEMPLATE_TEST_CASE(
   std::iota(column_indices.begin(), column_indices.end(), 0);
 
   auto Y = tdbColMajorMatrixMultiRange<TestType>(
-      ctx, tmp_matrix_uri, column_indices, dimensions, num_vectors);
+      ctx, tmp_matrix_uri, dimensions, column_indices, num_vectors);
   CHECK(Y.load() == true);
   for (int i = 0; i < 5; ++i) {
     CHECK(Y.load() == false);
@@ -115,7 +115,7 @@ TEMPLATE_TEST_CASE(
     std::vector<size_t> column_indices(num_vectors);
     std::iota(column_indices.begin(), column_indices.end(), 0);
     auto Y = tdbColMajorMatrixMultiRange<TestType>(
-        ctx, tmp_matrix_uri, column_indices, dimensions, num_vectors);
+        ctx, tmp_matrix_uri, dimensions, column_indices, num_vectors);
     Y.load();
     B = std::move(Y);
   }
@@ -125,13 +125,13 @@ TEMPLATE_TEST_CASE(
     std::iota(column_indices.begin(), column_indices.end(), 0);
     auto Y = tdbColMajorMatrixMultiRange<TestType>(
         tdbColMajorMatrixMultiRange<TestType>(
-            ctx, tmp_matrix_uri, column_indices, dimensions, num_vectors));
+            ctx, tmp_matrix_uri, dimensions, column_indices, num_vectors));
   }
 
   std::vector<size_t> column_indices(num_vectors);
   std::iota(column_indices.begin(), column_indices.end(), 0);
   auto Y = tdbColMajorMatrixMultiRange<TestType>(
-      ctx, tmp_matrix_uri, column_indices, dimensions, num_vectors);
+      ctx, tmp_matrix_uri, dimensions, column_indices, num_vectors);
   Y.load();
 
   CHECK(::num_vectors(Y) == ::num_vectors(X));
@@ -206,7 +206,7 @@ TEST_CASE("limit column_indices", "[tdb_matrix_multi_range]") {
   std::vector<size_t> column_indices = {
       0, 1, 2, 3, 10, 100, 15, 299, 309, 4, 100};
   auto Y = tdbBlockedMatrixMultiRange<T, LayoutPolicy, I>(
-      ctx, tmp_matrix_uri, column_indices, dimensions, 0);
+      ctx, tmp_matrix_uri, dimensions, column_indices, 0);
   Y.load();
   CHECK(::num_vectors(Y) == column_indices.size());
   CHECK(::dimensions(Y) == ::dimensions(X));
@@ -242,7 +242,12 @@ TEST_CASE("empty matrix", "[tdb_matrix_multi_range]") {
   {
     // No dimensions and no num_vectors.
     auto X = tdbColMajorMatrixMultiRange<float>(
-        ctx, tmp_matrix_uri, {}, 0, 0, TemporalPolicy{TimeTravel, 50});
+        ctx,
+        tmp_matrix_uri,
+        0,
+        std::vector<size_t>{},
+        0,
+        TemporalPolicy{TimeTravel, 50});
     X.load();
     CHECK(X.num_cols() == 0);
     CHECK(::num_vectors(X) == 0);
@@ -253,7 +258,12 @@ TEST_CASE("empty matrix", "[tdb_matrix_multi_range]") {
   {
     // All dimensions and no num_vectors.
     auto X = tdbColMajorMatrixMultiRange<float>(
-        ctx, tmp_matrix_uri, {}, 0, 0, TemporalPolicy{TimeTravel, 50});
+        ctx,
+        tmp_matrix_uri,
+        0,
+        std::vector<size_t>{},
+        0,
+        TemporalPolicy{TimeTravel, 50});
     X.load();
     CHECK(X.num_cols() == 0);
     CHECK(::num_vectors(X) == 0);
@@ -264,7 +274,12 @@ TEST_CASE("empty matrix", "[tdb_matrix_multi_range]") {
   {
     // No dimensions and all num_vectors.
     auto X = tdbColMajorMatrixMultiRange<float>(
-        ctx, tmp_matrix_uri, {}, 0, 0, TemporalPolicy{TimeTravel, 50});
+        ctx,
+        tmp_matrix_uri,
+        0,
+        std::vector<size_t>{},
+        0,
+        TemporalPolicy{TimeTravel, 50});
     X.load();
     CHECK(X.num_cols() == 0);
     CHECK(::num_vectors(X) == 0);
@@ -275,7 +290,12 @@ TEST_CASE("empty matrix", "[tdb_matrix_multi_range]") {
   {
     // No constraints.
     auto X = tdbColMajorMatrixMultiRange<float>(
-        ctx, tmp_matrix_uri, {}, 0, 0, TemporalPolicy{TimeTravel, 50});
+        ctx,
+        tmp_matrix_uri,
+        0,
+        std::vector<size_t>{},
+        0,
+        TemporalPolicy{TimeTravel, 50});
     X.load();
     CHECK(X.num_cols() == 0);
     CHECK(::num_vectors(X) == 0);
@@ -304,12 +324,11 @@ TEST_CASE("time travel", "[tdb_matrix_multi_range]") {
 
   std::vector<size_t> column_indices(num_vectors);
   std::iota(column_indices.begin(), column_indices.end(), 0);
-  debug_matrix(column_indices, "column_indices", 100);
 
   {
     // We can load the matrix at the creation timestamp.
     auto Y = tdbColMajorMatrixMultiRange<int>(
-        ctx, tmp_matrix_uri, column_indices, dimensions, 0);
+        ctx, tmp_matrix_uri, dimensions, column_indices, 0);
     CHECK(Y.load());
     CHECK(::num_vectors(Y) == ::num_vectors(X));
     CHECK(::dimensions(Y) == ::dimensions(X));
@@ -327,8 +346,8 @@ TEST_CASE("time travel", "[tdb_matrix_multi_range]") {
     auto Y = tdbColMajorMatrixMultiRange<int>(
         ctx,
         tmp_matrix_uri,
-        column_indices,
         dimensions,
+        column_indices,
         num_vectors,
         TemporalPolicy{TimeTravel, 100});
     CHECK(Y.load());
@@ -348,8 +367,8 @@ TEST_CASE("time travel", "[tdb_matrix_multi_range]") {
     auto Y = tdbColMajorMatrixMultiRange<int>(
         ctx,
         tmp_matrix_uri,
-        column_indices,
         dimensions,
+        column_indices,
         num_vectors,
         TemporalPolicy{TimeTravel, 5});
     CHECK(Y.load());


### PR DESCRIPTION
### What
In the out-of-core IVF_PQ code we'll need to be able to read slices from a matrix. Here we update `tdbMatrixMultiRange` to support both reads with both slices and individual indices.

### Testing
Tests pass.