### PR TITLE
Rename nlist to partitions

### DIFF
--- a/apis/python/src/tiledb/vector_search/ivf_pq_index.py
+++ b/apis/python/src/tiledb/vector_search/ivf_pq_index.py
@@ -226,7 +226,7 @@ def create(
         id_type=np.dtype(np.uint64).name,
         partitioning_index_type=np.dtype(np.uint64).name,
         dimensions=dimensions,
-        n_list=partitions if (partitions is not None and partitions != -1) else 0,
+        partitions=partitions if (partitions is not None and partitions != -1) else 0,
         num_subspaces=num_subspaces,
         distance_metric=int(distance_metric),
     )

--- a/apis/python/src/tiledb/vector_search/type_erased_module.cc
+++ b/apis/python/src/tiledb/vector_search/type_erased_module.cc
@@ -491,9 +491,11 @@ void init_type_erased_module(py::module_& m) {
           "train",
           [](IndexIVFPQ& index,
              const FeatureVectorArray& vectors,
-             std::optional<size_t> nlist) { index.train(vectors, nlist); },
+             std::optional<size_t> partitions) {
+            index.train(vectors, partitions);
+          },
           py::arg("vectors"),
-          py::arg("nlist") = std::nullopt)
+          py::arg("partitions") = std::nullopt)
       .def(
           "add",
           [](IndexIVFPQ& index, const FeatureVectorArray& vectors) {

--- a/src/include/api/ivf_flat_index.h
+++ b/src/include/api/ivf_flat_index.h
@@ -100,8 +100,8 @@ class IndexIVFFlat {
       for (auto&& c : *config) {
         auto key = c.first;
         auto value = c.second;
-        if (key == "nlist") {
-          nlist_ = std::stol(value);
+        if (key == "partitions") {
+          partitions_ = std::stol(value);
         } else if (key == "dimensions") {
           dimensions_ = std::stol(value);
         } else if (key == "max_iter") {
@@ -255,12 +255,12 @@ class IndexIVFFlat {
           " != " + std::to_string(index_->dimensions()));
     }
     dimensions_ = index_->dimensions();
-    if (nlist_ != 0 && nlist_ != index_->num_partitions()) {
+    if (partitions_ != 0 && partitions_ != index_->num_partitions()) {
       throw std::runtime_error(
-          "nlist mismatch: " + std::to_string(nlist_) +
+          "partitions mismatch: " + std::to_string(partitions_) +
           " != " + std::to_string(index_->num_partitions()));
     }
-    nlist_ = index_->num_partitions();
+    partitions_ = index_->num_partitions();
   }
 
   /**
@@ -292,49 +292,49 @@ class IndexIVFFlat {
         px_datatype_ == TILEDB_UINT32) {
       index_ = std::make_unique<
           index_impl<ivf_flat_index<uint8_t, uint32_t, uint32_t>>>(
-          nlist_, max_iterations_, tolerance_, num_threads_);
+          partitions_, max_iterations_, tolerance_, num_threads_);
     } else if (
         feature_datatype_ == TILEDB_FLOAT32 && id_datatype_ == TILEDB_UINT32 &&
         px_datatype_ == TILEDB_UINT32) {
       index_ = std::make_unique<
           index_impl<ivf_flat_index<float, uint32_t, uint32_t>>>(
-          nlist_, max_iterations_, tolerance_, num_threads_);
+          partitions_, max_iterations_, tolerance_, num_threads_);
     } else if (
         feature_datatype_ == TILEDB_UINT8 && id_datatype_ == TILEDB_UINT32 &&
         px_datatype_ == TILEDB_UINT64) {
       index_ = std::make_unique<
           index_impl<ivf_flat_index<uint8_t, uint32_t, uint64_t>>>(
-          nlist_, max_iterations_, tolerance_, num_threads_);
+          partitions_, max_iterations_, tolerance_, num_threads_);
     } else if (
         feature_datatype_ == TILEDB_FLOAT32 && id_datatype_ == TILEDB_UINT32 &&
         px_datatype_ == TILEDB_UINT64) {
       index_ = std::make_unique<
           index_impl<ivf_flat_index<float, uint32_t, uint64_t>>>(
-          nlist_, max_iterations_, tolerance_, num_threads_);
+          partitions_, max_iterations_, tolerance_, num_threads_);
     } else if (
         feature_datatype_ == TILEDB_UINT8 && id_datatype_ == TILEDB_UINT64 &&
         px_datatype_ == TILEDB_UINT32) {
       index_ = std::make_unique<
           index_impl<ivf_flat_index<uint8_t, uint64_t, uint32_t>>>(
-          nlist_, max_iterations_, tolerance_, num_threads_);
+          partitions_, max_iterations_, tolerance_, num_threads_);
     } else if (
         feature_datatype_ == TILEDB_FLOAT32 && id_datatype_ == TILEDB_UINT64 &&
         px_datatype_ == TILEDB_UINT32) {
       index_ = std::make_unique<
           index_impl<ivf_flat_index<float, uint64_t, uint32_t>>>(
-          nlist_, max_iterations_, tolerance_, num_threads_);
+          partitions_, max_iterations_, tolerance_, num_threads_);
     } else if (
         feature_datatype_ == TILEDB_UINT8 && id_datatype_ == TILEDB_UINT64 &&
         px_datatype_ == TILEDB_UINT64) {
       index_ = std::make_unique<
           index_impl<ivf_flat_index<uint8_t, uint64_t, uint64_t>>>(
-          nlist_, max_iterations_, tolerance_, num_threads_);
+          partitions_, max_iterations_, tolerance_, num_threads_);
     } else if (
         feature_datatype_ == TILEDB_FLOAT32 && id_datatype_ == TILEDB_UINT64 &&
         px_datatype_ == TILEDB_UINT64) {
       index_ = std::make_unique<
           index_impl<ivf_flat_index<float, uint64_t, uint64_t>>>(
-          nlist_, max_iterations_, tolerance_, num_threads_);
+          partitions_, max_iterations_, tolerance_, num_threads_);
     }
 
     index_->train(training_set, init);
@@ -346,12 +346,12 @@ class IndexIVFFlat {
     }
     dimensions_ = index_->dimensions();
 
-    if (nlist_ != 0 && nlist_ != index_->num_partitions()) {
+    if (partitions_ != 0 && partitions_ != index_->num_partitions()) {
       throw std::runtime_error(
-          "nlist mismatch: " + std::to_string(nlist_) +
+          "partitions mismatch: " + std::to_string(partitions_) +
           " != " + std::to_string(index_->num_partitions()));
     }
-    nlist_ = index_->num_partitions();
+    partitions_ = index_->num_partitions();
   }
 
   /**
@@ -440,7 +440,7 @@ class IndexIVFFlat {
   }
 
   constexpr auto num_partitions() const {
-    return nlist_;
+    return partitions_;
   }
 
   constexpr tiledb_datatype_t feature_type() const {
@@ -523,11 +523,11 @@ class IndexIVFFlat {
     }
 
     index_impl(
-        size_t nlist,
+        size_t partitions,
         size_t max_iter,
         float tolerance,
         std::optional<size_t> num_threads)
-        : impl_index_(nlist, max_iter, tolerance) {
+        : impl_index_(partitions, max_iter, tolerance) {
     }
 
     index_impl(
@@ -717,7 +717,7 @@ class IndexIVFFlat {
   };
 
   uint64_t dimensions_ = 0;
-  size_t nlist_ = 0;
+  size_t partitions_ = 0;
   uint32_t max_iterations_ = 2;
   float tolerance_ = 1e-4;
   std::optional<size_t> num_threads_ = std::nullopt;

--- a/src/include/index/ivf_flat_index.h
+++ b/src/include/index/ivf_flat_index.h
@@ -156,7 +156,7 @@ class ivf_flat_index {
    *
    * @param dimensions Dimensions of the vectors comprising the training set and
    * the data set.
-   * @param nlist Number of centroids / partitions to compute.
+   * @param partitions Number of centroids / partitions to compute.
    * @param max_iter Maximum number of iterations for kmans algorithm.
    * @param tol Convergence tolerance for kmeans algorithm.
    * @param timestamp Timestamp for the index.
@@ -169,7 +169,7 @@ class ivf_flat_index {
    */
   ivf_flat_index(
       // size_t dim,
-      size_t nlist = 0,
+      size_t partitions = 0,
       uint32_t max_iterations = 2,
       float tol = 0.000025,
       TemporalPolicy temporal_policy = TemporalPolicy{TimeTravel, 0})
@@ -183,7 +183,7 @@ class ivf_flat_index {
                       std::chrono::duration_cast<std::chrono::milliseconds>(
                           std::chrono::system_clock::now().time_since_epoch())
                           .count())}}
-      , num_partitions_(nlist)
+      , num_partitions_(partitions)
       , max_iterations_(max_iterations)
       , tol_(tol) {
   }

--- a/src/include/index/ivf_pq_index.h
+++ b/src/include/index/ivf_pq_index.h
@@ -283,7 +283,7 @@ class ivf_pq_index {
    * parameters to be used subsequently in training. To fully create an index
    * we will need to call `train()` and `add()`.
    *
-   * @param nlist Number of centroids / partitions to compute.
+   * @param partitions Number of centroids / partitions to compute.
    * @param num_subspaces Number of subspaces to use for pq compression. This is
    * the number of sections to divide the vector into.
    * @param max_iterations Maximum number of iterations for kmeans algorithm.
@@ -304,7 +304,7 @@ class ivf_pq_index {
    * @todo -- May also want start/stop?  Use a variant?  TemporalPolicy?
    */
   ivf_pq_index(
-      size_t nlist = 0,
+      size_t partitions = 0,
       uint32_t num_subspaces = 16,
       uint32_t max_iterations = 2,
       float convergence_tolerance = 0.000025f,
@@ -316,7 +316,7 @@ class ivf_pq_index {
       : temporal_policy_{
         temporal_policy.has_value() ? *temporal_policy :
         TemporalPolicy{TimeTravel, static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count())}}
-      , num_partitions_(nlist)
+      , num_partitions_(partitions)
       , num_subspaces_{num_subspaces}
       , max_iterations_(max_iterations)
       , convergence_tolerance_(convergence_tolerance)

--- a/src/include/test/unit_api_ivf_pq_index.cc
+++ b/src/include/test/unit_api_ivf_pq_index.cc
@@ -382,7 +382,7 @@ TEST_CASE(
     "[api_ivf_pq_index]") {
   auto ctx = tiledb::Context{};
   size_t k_nn = 10;
-  size_t n_list = 100;
+  size_t partitions = 100;
   auto feature_type = "float32";
   auto id_type = "uint32";
   auto partitioning_index_type = "uint32";
@@ -399,7 +399,7 @@ TEST_CASE(
         {{"feature_type", feature_type},
          {"id_type", id_type},
          {"partitioning_index_type", partitioning_index_type},
-         {"n_list", std::to_string(n_list)},
+         {"partitions", std::to_string(partitions)},
          {"num_subspaces", std::to_string(siftsmall_dimensions / 4)}}));
 
     size_t num_vectors = 0;
@@ -674,7 +674,7 @@ TEST_CASE("clear history with an open index", "[api_ivf_pq_index]") {
   auto id_type = "uint32";
   auto partitioning_index_type = "uint32";
   uint64_t dimensions = 3;
-  size_t n_list = 1;
+  size_t partitions = 1;
   uint32_t num_subspaces = 1;
   float convergence_tolerance = 0.00003f;
   uint32_t max_iterations = 3;
@@ -690,7 +690,7 @@ TEST_CASE("clear history with an open index", "[api_ivf_pq_index]") {
       {{"feature_type", feature_type},
        {"id_type", id_type},
        {"partitioning_index_type", partitioning_index_type},
-       {"n_list", std::to_string(n_list)},
+       {"partitions", std::to_string(partitions)},
        {"num_subspaces", std::to_string(num_subspaces)},
        {"convergence_tolerance", std::to_string(convergence_tolerance)},
        {"max_iterations", std::to_string(max_iterations)}}));
@@ -724,7 +724,7 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
   auto id_type = "uint32";
   auto partitioning_index_type = "uint32";
   uint64_t dimensions = 3;
-  size_t n_list = 1;
+  size_t partitions = 1;
   uint32_t num_subspaces = 1;
   uint32_t max_iterations = 3;
   float convergence_tolerance = 0.00003f;
@@ -744,7 +744,7 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
         {"feature_type", feature_type},
         {"id_type", id_type},
         {"partitioning_index_type", partitioning_index_type},
-        {"n_list", std::to_string(n_list)},
+        {"partitions", std::to_string(partitions)},
         {"num_subspaces", std::to_string(num_subspaces)},
         {"max_iterations", std::to_string(max_iterations)},
         {"convergence_tolerance", std::to_string(convergence_tolerance)},
@@ -760,7 +760,7 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
 
     CHECK(index.temporal_policy().timestamp_end() == 0);
     CHECK(index.dimensions() == dimensions);
-    CHECK(index.n_list() == n_list);
+    CHECK(index.partitions() == partitions);
     CHECK(index.num_subspaces() == num_subspaces);
     CHECK(index.max_iterations() == max_iterations);
     CHECK(index.convergence_tolerance() == convergence_tolerance);
@@ -784,7 +784,7 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
     CHECK(typed_index.group().get_all_base_sizes().size() == 1);
     CHECK(typed_index.group().get_all_ingestion_timestamps().size() == 1);
 
-    CHECK(typed_index.group().get_all_num_partitions()[0] == n_list);
+    CHECK(typed_index.group().get_all_num_partitions()[0] == partitions);
     CHECK(typed_index.group().get_all_base_sizes()[0] == 0);
     CHECK(typed_index.group().get_all_ingestion_timestamps()[0] == 0);
   }
@@ -800,7 +800,7 @@ TEST_CASE("write and load index with timestamps", "[api_ivf_pq_index]") {
         index.temporal_policy().timestamp_end() ==
         std::numeric_limits<uint64_t>::max());
     CHECK(index.dimensions() == dimensions);
-    CHECK(index.n_list() == n_list);
+    CHECK(index.partitions() == partitions);
     CHECK(index.num_subspaces() == num_subspaces);
     CHECK(index.max_iterations() == max_iterations);
     CHECK(index.convergence_tolerance() == convergence_tolerance);

--- a/src/include/test/utils/query_common.h
+++ b/src/include/test/utils/query_common.h
@@ -153,7 +153,7 @@ struct siftsmall_test_init : public siftsmall_test_init_defaults {
   using px_type = Base::px_type;
 
   tiledb::Context ctx_;
-  size_t nlist;
+  size_t partitions;
   size_t nprobe;
 
   siftsmall_test_init(
@@ -162,8 +162,8 @@ struct siftsmall_test_init : public siftsmall_test_init_defaults {
       uint32_t num_subspaces = 0,
       size_t num_vectors = 0)
       : ctx_{ctx}
-      , nlist(nl)
-      , nprobe(std::min<size_t>(10, nlist))
+      , partitions(nl)
+      , nprobe(std::min<size_t>(10, partitions))
       , training_set(tdbColMajorMatrix<feature_type>(
             ctx_, siftsmall_inputs_uri, num_vectors))
       , query_set(tdbColMajorMatrix<feature_type>(ctx_, siftsmall_query_uri))
@@ -172,12 +172,12 @@ struct siftsmall_test_init : public siftsmall_test_init_defaults {
     if constexpr (std::is_same_v<
                       IndexType,
                       ivf_flat_index<feature_type, id_type, px_type>>) {
-      idx = IndexType(nlist, max_iterations, convergence_tolerance);
+      idx = IndexType(partitions, max_iterations, convergence_tolerance);
     } else if constexpr (std::is_same_v<
                              IndexType,
                              ivf_pq_index<feature_type, id_type, px_type>>) {
       idx = IndexType(
-          nlist, num_subspaces, max_iterations, convergence_tolerance);
+          partitions, num_subspaces, max_iterations, convergence_tolerance);
     } else {
       std::cout << "Unsupported index type" << std::endl;
     }
@@ -236,7 +236,7 @@ struct siftsmall_test_init : public siftsmall_test_init_defaults {
 
     size_t intersectionsm1 = count_intersections(top_k, groundtruth_set, k_nn);
     double recallm1 = intersectionsm1 / ((double)top_k.num_cols() * k_nn);
-    if (nlist == 1) {
+    if (partitions == 1) {
       CHECK(
           intersectionsm1 == (size_t)(num_vectors(top_k) * dimensions(top_k)));
       CHECK(recallm1 == 1.0);
@@ -246,7 +246,7 @@ struct siftsmall_test_init : public siftsmall_test_init_defaults {
     // @todo There is randomness in initialization of kmeans, use a fixed seed
     size_t intersections0 = count_intersections(top_k_ivf, top_k, k_nn);
     double recall0 = intersections0 / ((double)top_k.num_cols() * k_nn);
-    if (nlist == 1) {
+    if (partitions == 1) {
       CHECK(intersections0 == (size_t)(num_vectors(top_k) * dimensions(top_k)));
       CHECK(recall0 == 1.0);
     }
@@ -254,7 +254,7 @@ struct siftsmall_test_init : public siftsmall_test_init_defaults {
     size_t intersections1 =
         (long)count_intersections(top_k_ivf, groundtruth_set, k_nn);
     double recall1 = intersections1 / ((double)top_k_ivf.num_cols() * k_nn);
-    if (nlist == 1) {
+    if (partitions == 1) {
       CHECK(intersections1 == (size_t)(num_vectors(top_k) * dimensions(top_k)));
       CHECK(recall1 == 1.0);
     }


### PR DESCRIPTION
### What
Rename `nlist` to `partitions` because we call it `partitions` in Python.

### Testing
Tests pass.