### PR TITLE
Add IVF_PQ backwards compatibility data generation and testing

### DIFF
--- a/apis/python/test/test_backwards_compatibility.py
+++ b/apis/python/test/test_backwards_compatibility.py
@@ -4,6 +4,7 @@ from tiledb.vector_search.flat_index import FlatIndex
 from tiledb.vector_search.ivf_flat_index import IVFFlatIndex
 from tiledb.vector_search.utils import load_fvecs
 from tiledb.vector_search.vamana_index import VamanaIndex
+from tiledb.vector_search.ivf_pq_index import IVFPQIndex
 
 MINIMUM_ACCURACY = 0.85
 
@@ -63,6 +64,8 @@ def test_query_old_indices():
                 index = FlatIndex(uri=index_uri)
             elif "vamana" in index_name:
                 index = VamanaIndex(uri=index_uri)
+            elif "ivf_pq" in index_name:
+                index = IVFPQIndex(uri=index_uri)
             else:
                 assert False, f"Unknown index name: {index_name}"
 

--- a/apis/python/test/test_backwards_compatibility.py
+++ b/apis/python/test/test_backwards_compatibility.py
@@ -2,9 +2,9 @@ from common import *
 
 from tiledb.vector_search.flat_index import FlatIndex
 from tiledb.vector_search.ivf_flat_index import IVFFlatIndex
+from tiledb.vector_search.ivf_pq_index import IVFPQIndex
 from tiledb.vector_search.utils import load_fvecs
 from tiledb.vector_search.vamana_index import VamanaIndex
-from tiledb.vector_search.ivf_pq_index import IVFPQIndex
 
 MINIMUM_ACCURACY = 0.85
 

--- a/backwards-compatibility-data/generate_data.py
+++ b/backwards-compatibility-data/generate_data.py
@@ -66,7 +66,7 @@ def generate_indexes(version):
     queries = base[indices]
 
     # Generate each index and query to make sure it works before we write it.
-    index_types = ["FLAT", "IVF_FLAT", "VAMANA"]
+    index_types = ["FLAT", "IVF_FLAT", "VAMANA", "IVF_PQ"]
     data_types = ["float32", "uint8"]
     for index_type in index_types:
         for data_type in data_types:
@@ -75,6 +75,7 @@ def generate_indexes(version):
                 index_type=index_type,
                 index_uri=index_uri,
                 input_vectors=base.astype(data_type),
+                num_subspaces=len(base[0])
             )
 
             result_d, result_i = index.query(queries, k=1)

--- a/backwards-compatibility-data/generate_data.py
+++ b/backwards-compatibility-data/generate_data.py
@@ -75,7 +75,7 @@ def generate_indexes(version):
                 index_type=index_type,
                 index_uri=index_uri,
                 input_vectors=base.astype(data_type),
-                num_subspaces=len(base[0])
+                num_subspaces=len(base[0]),
             )
 
             result_d, result_i = index.query(queries, k=1)

--- a/src/include/test/unit_backwards_compatibility.cc
+++ b/src/include/test/unit_backwards_compatibility.cc
@@ -35,12 +35,12 @@
 #include <iostream>
 #include "api/feature_vector_array.h"
 #include "api/ivf_flat_index.h"
-#include "api/vamana_index.h"
 #include "api/ivf_pq_index.h"
+#include "api/vamana_index.h"
 #include "detail/linalg/matrix.h"
 #include "index/ivf_flat_index.h"
-#include "index/vamana_index.h"
 #include "index/ivf_pq_index.h"
+#include "index/vamana_index.h"
 #include "mdspan/mdspan.hpp"
 #include "test/utils/array_defs.h"
 


### PR DESCRIPTION
### What
Add IVF_PQ backwards compatibility data generation and testing.

### Testing
Can generate:
```
(TileDB-Vector-Search-3) ~/repo/TileDB-Vector-Search-3 python backwards-compatibility-data/generate_data.py 0.20.0
/opt/homebrew/anaconda3/envs/TileDB-Vector-Search-3/lib/python3.9/site-packages/tiledb/vector_search/ivf_pq_index.py:198: UserWarning: The IVF PQ index is not yet supported, please use with caution.
  warnings.warn("The IVF PQ index is not yet supported, please use with caution.")
/opt/homebrew/anaconda3/envs/TileDB-Vector-Search-3/lib/python3.9/site-packages/tiledb/vector_search/ivf_pq_index.py:149: UserWarning: The IVF PQ index is not yet supported, please use with caution.
  warnings.warn("The IVF PQ index is not yet supported, please use with caution.")
false
```
And python tests pass:
```
(TileDB-Vector-Search-3) ~/repo/TileDB-Vector-Search-3 pytest apis/python/test/test_backwards_compatibility.py -s                  

============================================= test session starts =============================================
platform darwin -- Python 3.9.18, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/parismorgan/repo/TileDB-Vector-Search-3
collected 1 item                                                                                              

apis/python/test/test_backwards_compatibility.py .

============================================== warnings summary ===============================================
apis/python/test/test_backwards_compatibility.py::test_query_old_indices
  /opt/homebrew/anaconda3/envs/TileDB-Vector-Search-3/lib/python3.9/site-packages/tiledb/vector_search/ivf_pq_index.py:149: UserWarning: The IVF PQ index is not yet supported, please use with caution.
    warnings.warn("The IVF PQ index is not yet supported, please use with caution.")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================== 1 passed, 1 warning in 1.65s =========================================
```
And C++ tests pass.