### PR TITLE
Add explicit markdown parser for DirectoryTextReader

### DIFF
--- a/apis/python/src/tiledb/vector_search/object_readers/directory_reader.py
+++ b/apis/python/src/tiledb/vector_search/object_readers/directory_reader.py
@@ -367,6 +367,7 @@ class TileDBLoader:
             handlers={
                 "application/pdf": PyMuPDFParser(),
                 "text/plain": TextParser(),
+                "text/markdown": TextParser(),
                 "text/html": BS4HTMLParser(),
                 "application/msword": MsWordParser(),
                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document": (
@@ -397,7 +398,7 @@ class TileDBLoader:
             mime_type = mimetypes.guess_type(self.uri)[0]
             f = vfs.open(self.uri)
 
-        if mime_type is None:
+        if mime_type is None or mime_type.startswith("text"):
             mime_type = "text/plain"
 
         if mime_type.startswith("image/"):


### PR DESCRIPTION
This change from [PR-532](https://github.com/TileDB-Inc/TileDB-Vector-Search/pull/532/files) was accidentally reverted in [PR-543](https://github.com/TileDB-Inc/TileDB-Vector-Search/pull/543/files#diff-d9366bd7a2301814cea82dd439f77e8ca991439f4cb702721ce61e95888fcb26)