### PR TITLE
Enable wheel production for python 3.13

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -95,7 +95,7 @@ jobs:
           - [macos-13, macosx_x86_64]
           - [macos-13, macosx_arm64]
           - [windows-2022, win_amd64]
-        python: ["cp39", "cp310", "cp311", "cp312", "pp39"]
+        python: ["cp39", "cp310", "cp311", "cp312", "cp313", "pp39"]
         exclude:
           - buildplat: [macos-13, macosx_arm64]
             python: "pp39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,16 @@ description = "TileDB Vector Search Python client"
 license = { text = "MIT" }
 readme = "README.md"
 authors = []
-requires-python = "~=3.7"
+requires-python = "~=3.9"
 classifiers = [
   "Development Status :: 4 - Beta",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 
 # These are the runtime depdendencies.


### PR DESCRIPTION
Enable Python 3.13 wheels for TileDB Vector Search.