### PR TITLE
Use `is_dir` instead of `dir_size` for non-existent folders after index deletion

### DIFF
--- a/apis/python/test/test_index.py
+++ b/apis/python/test/test_index.py
@@ -111,7 +111,7 @@ def test_flat_index(tmp_path):
     vfs = tiledb.VFS()
     assert vfs.dir_size(uri) > 0
     Index.delete_index(uri=uri, config={})
-    assert vfs.dir_size(uri) == 0
+    assert not vfs.is_dir(uri)
 
 
 def test_ivf_flat_index(tmp_path):
@@ -196,7 +196,7 @@ def test_ivf_flat_index(tmp_path):
     vfs = tiledb.VFS()
     assert vfs.dir_size(uri) > 0
     Index.delete_index(uri=uri, config={})
-    assert vfs.dir_size(uri) == 0
+    assert not vfs.is_dir(uri)
 
 
 def test_vamana_index_simple(tmp_path):
@@ -217,7 +217,7 @@ def test_vamana_index_simple(tmp_path):
     vfs = tiledb.VFS()
     assert vfs.dir_size(uri) > 0
     Index.delete_index(uri=uri, config={})
-    assert vfs.dir_size(uri) == 0
+    assert not vfs.is_dir(uri)
 
 
 def test_vamana_index(tmp_path):
@@ -298,7 +298,7 @@ def test_vamana_index(tmp_path):
     vfs = tiledb.VFS()
     assert vfs.dir_size(uri) > 0
     Index.delete_index(uri=uri, config={})
-    assert vfs.dir_size(uri) == 0
+    assert not vfs.is_dir(uri)
 
 
 def test_ivf_pq_index(tmp_path):
@@ -407,7 +407,7 @@ def test_ivf_pq_index(tmp_path):
     vfs = tiledb.VFS()
     assert vfs.dir_size(uri) > 0
     Index.delete_index(uri=uri, config={})
-    assert vfs.dir_size(uri) == 0
+    assert not vfs.is_dir(uri)
 
 
 def test_delete_invalid_index(tmp_path):
@@ -429,7 +429,7 @@ def test_delete_index(tmp_path):
             num_subspaces=1,
         )
         Index.delete_index(uri=index_uri, config={})
-        assert vfs.dir_size(index_uri) == 0
+        assert not vfs.is_dir(index_uri)
         with pytest.raises(tiledb.TileDBError) as error:
             open(uri=index_uri)
         assert "does not exist" in str(error.value)
@@ -459,7 +459,7 @@ def test_index_with_incorrect_dimensions(tmp_path):
 
         assert vfs.dir_size(uri) > 0
         Index.delete_index(uri=uri, config={})
-        assert vfs.dir_size(uri) == 0
+        assert not vfs.is_dir(uri)
 
 
 def test_index_with_incorrect_num_of_query_columns_simple(tmp_path):
@@ -524,7 +524,7 @@ def test_index_with_incorrect_num_of_query_columns_complex(tmp_path):
 
             assert vfs.dir_size(index_uri) > 0
             Index.delete_index(uri=index_uri, config={})
-            assert vfs.dir_size(index_uri) == 0
+            assert not vfs.is_dir(index_uri)
 
 
 def test_index_with_incorrect_num_of_query_columns_in_single_vector_query(tmp_path):

--- a/apis/python/test/test_ingestion.py
+++ b/apis/python/test/test_ingestion.py
@@ -79,7 +79,7 @@ def test_vamana_ingestion_u8(tmp_path):
 
     assert vfs.dir_size(index_uri) > 0
     Index.delete_index(uri=index_uri, config={})
-    assert vfs.dir_size(index_uri) == 0
+    assert not vfs.is_dir(index_uri)
 
 
 def test_flat_ingestion_u8(tmp_path):
@@ -376,7 +376,7 @@ def test_ingestion_fvec(tmp_path):
 
         assert vfs.dir_size(index_uri) > 0
         Index.delete_index(uri=index_uri, config={})
-        assert vfs.dir_size(index_uri) == 0
+        assert not vfs.is_dir(index_uri)
 
 
 def test_ingestion_numpy(tmp_path):
@@ -430,7 +430,7 @@ def test_ingestion_numpy(tmp_path):
 
         assert vfs.dir_size(index_uri) > 0
         Index.delete_index(uri=index_uri, config={})
-        assert vfs.dir_size(index_uri) == 0
+        assert not vfs.is_dir(index_uri)
 
 
 def test_ingestion_numpy_i8(tmp_path):
@@ -486,7 +486,7 @@ def test_ingestion_numpy_i8(tmp_path):
 
         assert vfs.dir_size(index_uri) > 0
         Index.delete_index(uri=index_uri, config={})
-        assert vfs.dir_size(index_uri) == 0
+        assert not vfs.is_dir(index_uri)
 
 
 def test_ingestion_multiple_workers(tmp_path):
@@ -541,7 +541,7 @@ def test_ingestion_multiple_workers(tmp_path):
 
         assert vfs.dir_size(index_uri) > 0
         Index.delete_index(uri=index_uri, config={})
-        assert vfs.dir_size(index_uri) == 0
+        assert not vfs.is_dir(index_uri)
 
 
 def test_ingestion_external_ids_numpy(tmp_path):
@@ -590,7 +590,7 @@ def test_ingestion_external_ids_numpy(tmp_path):
 
         assert vfs.dir_size(index_uri) > 0
         Index.delete_index(uri=index_uri, config={})
-        assert vfs.dir_size(index_uri) == 0
+        assert not vfs.is_dir(index_uri)
 
 
 def test_ingestion_timetravel(tmp_path):
@@ -935,7 +935,7 @@ def test_ingestion_with_updates(tmp_path):
 
         assert vfs.dir_size(index_uri) > 0
         Index.delete_index(uri=index_uri, config={})
-        assert vfs.dir_size(index_uri) == 0
+        assert not vfs.is_dir(index_uri)
 
 
 def test_ingestion_with_batch_updates(tmp_path):
@@ -1003,7 +1003,7 @@ def test_ingestion_with_batch_updates(tmp_path):
 
         assert vfs.dir_size(index_uri) > 0
         Index.delete_index(uri=index_uri, config={})
-        assert vfs.dir_size(index_uri) == 0
+        assert not vfs.is_dir(index_uri)
 
 
 def test_ingestion_with_updates_and_timetravel(tmp_path):
@@ -1277,7 +1277,7 @@ def test_ingestion_with_updates_and_timetravel(tmp_path):
 
         assert vfs.dir_size(index_uri) > 0
         Index.delete_index(uri=index_uri, config={})
-        assert vfs.dir_size(index_uri) == 0
+        assert not vfs.is_dir(index_uri)
 
 
 def test_ingestion_with_additions_and_timetravel(tmp_path):
@@ -1335,7 +1335,7 @@ def test_ingestion_with_additions_and_timetravel(tmp_path):
 
         assert vfs.dir_size(index_uri) > 0
         Index.delete_index(uri=index_uri, config={})
-        assert vfs.dir_size(index_uri) == 0
+        assert not vfs.is_dir(index_uri)
 
 
 def test_ivf_flat_ingestion_tdb_random_sampling_policy(tmp_path):


### PR DESCRIPTION
Calling `dir_size` on non-existent paths causes `VFSException`s to be thrown according to: https://github.com/TileDB-Inc/TileDB/blob/c36bce6517a46ce75f9a7c9090bd833ad40521b8/tiledb/sm/filesystem/vfs.cc#L209-L212.
`is_dir` is more suitable to call after index deletions in tests.

This PR resolves the errors we're currently encountering in CI.

---

[sc-65377]