### PR TITLE
fix(ingestion): Pad sparse matrices to correct dimensions

### DIFF
--- a/apis/python/src/tiledb/vector_search/ingestion.py
+++ b/apis/python/src/tiledb/vector_search/ingestion.py
@@ -941,7 +941,8 @@ def ingest(
             ) as src_array:
                 src_array_schema = src_array.schema
                 data = src_array[start_pos:end_pos, 0:dimensions]
-                return coo_matrix(
+                
+                matrix = coo_matrix(
                     (
                         data[src_array_schema.attr(0).name],
                         (
@@ -950,6 +951,15 @@ def ingest(
                         ),
                     )
                 ).toarray()
+
+                if matrix.shape[1] < dimensions:
+                    matrix = np.concatenate([
+                        matrix,
+                        np.zeros(shape=(matrix.shape[0], dimensions - matrix.shape[1]))
+                    ], axis=1)
+
+                return matrix
+
         elif source_type == "TILEDB_PARTITIONED_ARRAY":
             with tiledb.open(
                 source_uri, "r", timestamp=index_timestamp, config=config


### PR DESCRIPTION
This commit fixes a bug in `ingestion.py` where sparse matrices with null entries at the end were being read with incorrect dimensions.

Previously, the `read_input_vectors` function would convert a sparse matrix to a dense matrix without accounting for trailing null columns. This could lead to a mismatch in dimensions later in the code.

For example, a sparse array whose schema specified a shape of`10x100` might be read as a `10x90` dense matrix if its last 10 columns were empty.

The fix adds a check to ensure the matrix is padded with zeros to the expected dimensions, preventing the dimension mismatch.