### PR TITLE
Fix backwards compatibility tests on Windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 .git_archival.txt  export-subst
 *.qmd linguist-language=RMarkdown
-backwards-compatibility-data/data/* binary
+backwards-compatibility-data/data/**/* binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 .git_archival.txt  export-subst
 *.qmd linguist-language=RMarkdown
 backwards-compatibility-data/data/**/* binary
+external/test-data/**/* binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 .git_archival.txt  export-subst
 *.qmd linguist-language=RMarkdown
+backwards-compatibility-data/data/* binary

--- a/backwards-compatibility-data/data/README.md
+++ b/backwards-compatibility-data/data/README.md
@@ -1,3 +1,0 @@
-### What
-
-Holds test indices built using different versions of TileDB-Vector-Search.

--- a/src/include/test/unit_backwards_compatibility.cc
+++ b/src/include/test/unit_backwards_compatibility.cc
@@ -89,16 +89,6 @@ TEST_CASE("test_query_old_indices", "[backwards_compatibility]") {
         continue;
       }
 
-      // Skip pre-0.16.0 versions on Windows due to blosc1/blosc2
-      // incompatibility. TileDB 2.30.0+ uses blosc2, but older test data was
-      // compressed with blosc1. blosc2 has a Windows-specific bug when
-      // decompressing blosc1 data.
-#ifdef _WIN32
-      if (index_uri.find("0.16.0") == std::string::npos) {
-        continue;
-      }
-#endif
-
       auto read_group = tiledb::Group(ctx, index_uri, TILEDB_READ, cfg);
       std::vector<float> expected_distances(query_indices.size(), 0.0);
       if (index_uri.find("ivf_flat") != std::string::npos) {


### PR DESCRIPTION
On Windows, Git checks out text files with CRLF line endings. This can cause problems when reading the  backwards compatibility arrays, because TileDB supports only LF line endings at the moment in its line-delimited files.[^1]

This PR fixes the test failures, by instructing Git to treat all test data as `binary`, causing it to not modify line endings.

[^1]: In this case, the failures were caused by TileDB-Inc/TileDB#5662, but CRLF support has been broken in other places before that.